### PR TITLE
SKETCH-2205. Add Boost::json as a dependency

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,7 +39,7 @@ PointerAlignment: Left
 SpaceAfterCStyleCast: false
 SpacesBeforeTrailingComments: 1
 Cpp11BracedListStyle: true
-Standard:        c++17
+Standard:        c++20
 IndentWidth:     4
 TabWidth:        8
 UseTab:          Never

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Python packages
-        run: python3 -m pip install ninja clang-format
+        run: python3 -m pip install ninja clang-format==14.0.6
 
       - name: Code formatting check
         run: find . -name *.h -o -name *.cpp | xargs clang-format -n --Werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ build_static_library(${RDKIT_EXTENSIONS_LIB})
 target_link_libraries(
   ${RDKIT_EXTENSIONS_LIB}
   PRIVATE Boost::filesystem
+          Boost::json
           Boost::serialization
           RDKit::CIPLabeler
           RDKit::ChemReactions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ string(JSON ZSTD_VERSION GET ${VERSIONS} zstd)
 set(Boost_USE_STATIC_LIBS ON) # Ensure static libs are found
 
 find_package(Boost ${BOOST_VERSION} REQUIRED
-             COMPONENTS filesystem serialization unit_test_framework)
+             COMPONENTS filesystem json serialization unit_test_framework)
 find_package(Qt6 ${QT_VERSION} REQUIRED COMPONENTS Widgets Svg)
 find_package(RDKit ${RDKIT_VERSION} REQUIRED)
 find_package(fmt ${FMT_VERSION} REQUIRED)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -47,6 +47,7 @@ set(BOOST_INCLUDE_LIBS
     flyweight
     graph
     iostreams
+    json
     multi_array
     multiprecision
     program_options

--- a/src/schrodinger/rdkit_extensions/example.cpp
+++ b/src/schrodinger/rdkit_extensions/example.cpp
@@ -12,6 +12,7 @@
 #include <boost/bimap.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/json.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/range/combine.hpp>
@@ -78,6 +79,9 @@ bool dependency_test(const std::string& smiles)
     std::string byte_array(test.size(), '\0');
     boost::beast::detail::base64::decode(byte_array.data(), test.data(),
                                          test.size());
+    boost::json::stream_parser p;
+    boost::system::error_code ec;
+    p.write(byte_array.data(), byte_array.size(), ec);
 
     // RDKit
     boost::shared_ptr<RDKit::RWMol> mol;


### PR DESCRIPTION
* Linked Case: SKETCH-2205
* Branch: 2024-3
* Primary Reviewer: @ricrogz 
 
### Description
Added Boost::json into the example runner

### Testing Done
macOS tests pass (the only runner currently enabled)
