### PR TITLE
SKETCH-2033. Minor updates to sketcher-builder.yml, CMakeLists, and README 

### DIFF
--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Test
         working-directory: build
-        # Launching`xvfb-run -a` required for Ubuntu non-wasm builds
+        # Launching `xvfb-run -a` required for Ubuntu non-wasm builds
         run: |
           ${{ matrix.os == 'ubuntu-latest' && matrix.build-output != 'wasm' && 'xvfb-run -a' || ''}} \
           ctest --build-config ${{ env.BUILD_TYPE }} --output-on-failure

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -191,9 +191,8 @@ jobs:
         env:
             # ".exe" on Windows, no extension everywhere else
             EXT: ${{matrix.os == 'windows-latest' && '.exe' || ''}}
-            OS_NAME: replace(${{ matrix.os }}, '-latest', '')
         with:
-          name: sketcher-${{env.OS_NAME}}-${{ matrix.build-output }}${{env.EXT}}
+          name: sketcher-${{ matrix.os }}-${{ matrix.build-output }}${{env.EXT}}
           path: build/sketcher_app${{env.EXT}}
 
       - name: Create wasm tarball

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -57,10 +57,10 @@ jobs:
       - name: Add emscripten to PATH
         if: matrix.build-output == 'wasm'
         env:
-          version: ${{ fromJson(env.VERSIONS_JSON).emscripten }}
+          VERSION: ${{ fromJson(env.VERSIONS_JSON).emscripten }}
         run: |
-            echo "${{ github.workspace }}/build/external/emsdk-${{ env.version }}/emsdk/" >> $GITHUB_PATH && \
-            echo "${{ github.workspace }}/build/external/emsdk-${{ env.version }}/emsdk/upstream/emscripten" >> $GITHUB_PATH
+            echo "${{ github.workspace }}/build/external/emsdk-${{ env.VERSION }}/emsdk/" >> $GITHUB_PATH && \
+            echo "${{ github.workspace }}/build/external/emsdk-${{ env.VERSION }}/emsdk/upstream/emscripten" >> $GITHUB_PATH
 
       - name: Configure Dependency CMake
         run: |
@@ -73,7 +73,7 @@ jobs:
         run: |
             cmake -B build/external/host/ -S external/ -G Ninja \
                 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DQT_HOST_BUILD=ON
-                
+
       - name: Fetch fmt
         id: fetch-fmt
         uses: ./.github/actions/build-external
@@ -180,8 +180,7 @@ jobs:
 
       - name: Test
         working-directory: build
-        # the first line of the command launches xvfb-run -a, but only for
-        # Ubuntu non-wasm builds
+        # Launching`xvfb-run -a` required for Ubuntu non-wasm builds
         run: |
           ${{ matrix.os == 'ubuntu-latest' && matrix.build-output != 'wasm' && 'xvfb-run -a' || ''}} \
           ctest --build-config ${{ env.BUILD_TYPE }} --output-on-failure
@@ -190,11 +189,11 @@ jobs:
         if: matrix.build-output != 'wasm'
         uses: actions/upload-artifact@v4
         env:
-            # ".exe" on Windows, empty everywhere else
-            dot_exe: ${{matrix.os == 'windows-latest' && '.exe' || ''}}
+            # ".exe" on Windows, no extension everywhere else
+            EXT: ${{matrix.os == 'windows-latest' && '.exe' || ''}}
         with:
-          name: sketcher_${{ matrix.os}}_${{ matrix.build-output }}${{env.dot_exe}}
-          path: build/sketcher_app${{env.dot_exe}}
+          name: sketcher_${{ matrix.os}}_${{ matrix.build-output }}${{env.EXT}}
+          path: build/sketcher_app${{env.EXT}}
 
       - name: Create wasm tarball
         if: matrix.build-output == 'wasm'
@@ -206,5 +205,5 @@ jobs:
         if: matrix.build-output == 'wasm'
         uses: actions/upload-artifact@v4
         with:
-          name: sketcher-wasm.tar.gz
+          name: sketcher_${{ matrix.os}}_${{ matrix.build-output }}.tar.gz
           path: sketcher-wasm.tar.gz

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -191,7 +191,7 @@ jobs:
         env:
             # ".exe" on Windows, no extension everywhere else
             EXT: ${{matrix.os == 'windows-latest' && '.exe' || ''}}
-            OS_NAME: ${{ replace(matrix.os, '-latest', '') }}
+            OS_NAME: replace(${{ matrix.os }}, '-latest', '')
         with:
           name: sketcher-${{env.OS_NAME}}-${{ matrix.build-output }}${{env.EXT}}
           path: build/sketcher_app${{env.EXT}}

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -191,8 +191,9 @@ jobs:
         env:
             # ".exe" on Windows, no extension everywhere else
             EXT: ${{matrix.os == 'windows-latest' && '.exe' || ''}}
+            OS_NAME: ${{ replace(matrix.os, '-latest', '') }}
         with:
-          name: sketcher_${{ matrix.os}}_${{ matrix.build-output }}${{env.EXT}}
+          name: sketcher-${{env.OS_NAME}}-${{ matrix.build-output }}${{env.EXT}}
           path: build/sketcher_app${{env.EXT}}
 
       - name: Create wasm tarball
@@ -205,5 +206,5 @@ jobs:
         if: matrix.build-output == 'wasm'
         uses: actions/upload-artifact@v4
         with:
-          name: sketcher_${{ matrix.os}}_${{ matrix.build-output }}.tar.gz
+          name: sketcher-${{ matrix.build-output }}.tar.gz
           path: sketcher-wasm.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,15 @@ function(setup_target TARGET)
   endif()
   # Allow RDKit includes to be prefixed
   target_include_directories(${TARGET} PRIVATE ${RDKit_INCLUDE_DIRS}/..
-                                               ${PROJECT_SOURCE_DIR}/include)
+                                               ${PROJECT_SOURCE_DIR}/include
+                                               ${PROJECT_SOURCE_DIR}/src)
   # Assume use of static libraries
   target_compile_definitions(
     ${TARGET} PRIVATE RDKIT_EXTENSIONS_STATIC_DEFINE SKETCHER_STATIC_DEFINE
                       RDK_BUILD_MAEPARSER_SUPPORT BOOST_BEAST_HEADER_ONLY)
+  if (WIN32)
+    target_link_libraries(${TARGET} PUBLIC -static)
+  endif()
   if (EMSCRIPTEN)
     target_link_options(${TARGET} PRIVATE -sGL_ENABLE_GET_PROC_ADDRESS)
   endif()
@@ -99,18 +103,12 @@ set_target_properties(${SKETCHER_LIB} PROPERTIES AUTOMOC ON)
 set_target_properties(${SKETCHER_LIB} PROPERTIES AUTOUIC ON)
 set(UI_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/${SKETCHER_LIB}/ui)
 set_target_properties(${SKETCHER_LIB} PROPERTIES AUTOUIC_SEARCH_PATHS ${UI_DIR})
-if (WIN32)
-    target_link_libraries(${SKETCHER_LIB} PUBLIC "-static")
-endif()
 
 # Standalone executable
 set(EXE_TARGET sketcher_app)
 add_executable(${EXE_TARGET} src/app/main.cpp)
 setup_target(${EXE_TARGET})
 target_link_libraries(${EXE_TARGET} PRIVATE Qt6::Widgets ${SKETCHER_LIB})
-if (WIN32)
-    target_link_libraries(${EXE_TARGET} PUBLIC "-static")
-endif()
 
 # Tests
 enable_testing()
@@ -136,6 +134,3 @@ foreach(TEST_SOURCE ${TEST_SOURCE_LIST})
   set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                   ${PREFIX_PATH})
 endforeach()
-if (WIN32)
-    target_link_libraries(${TEST_TARGET} PUBLIC "-static")
-endif()

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 * maeparser
 * fmt
 * boost
-* emsdk (to build WASM)
+* emsdk (WASM only)
 
 ## Build and Install
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,55 @@
 
 [![sketcher](https://github.com/schrodinger/sketcher/blob/main/.github/schrodinger-sketcher-screenshot.png)](https://www.schrodinger.com/2dsketcher)
 
-* Open access at [schrodinger.com/2dsketcher](https://www.schrodinger.com/2dsketcher)
-* [Training and Video Walkthrough](https://www.schrodinger.com/sites/default/files/s3/public/2D-Sketcher/2023-2/Content/Resources/Videos/2D_Sketcher.mp4)
+The Schrödinger 2D Sketcher is an open-source application for drawing and editing chemical structures in two dimensions. It provides a user-friendly interface for creating molecules, reactions, and other chemical diagrams, which can be used independently or integrated into other cheminformatics workflows.
 
-----
+This project is released by Schrödinger, Inc. and is available under an open-source license to foster collaboration and development within the scientific community.
 
-## Dependencies
+## Features
 
-* Qt
-* RDKit
-* maeparser
-* fmt
-* boost
-* emsdk (WASM only)
+* Intuitive drawing tools for atoms, bonds, rings, and functional groups.
+* Support for many chemical file formats.
+* Cleanup and layout algorithms for generating clear 2D representations.
+* Support for stereochemistry representation.
+* Integration capabilities for use in other applications, including as a web component.
 
-## Build and Install
+## Access and Training
 
-TBD.
+**[Open Access Online Version](https://www.schrodinger.com/2dsketcher)** -- Explore the sketcher directly in your web browser.
+
+**[Training and Video Walkthrough](https://www.schrodinger.com/sites/default/files/s3/public/2D-Sketcher/2023-2/Content/Resources/Videos/2D_Sketcher.mp4)** -- Learn how to use the sketcher with this guided video.
+
+## Build Prerequisites
+
+* A C++ compiler supporting C++20 or later
+* CMake (version 3.24 or later)
+* All required dependencies installed and accessible to CMake:
+    * [RDKit](https://github.com/rdkit/rdkit)
+    * [Qt](https://github.com/qt/qt5)
+    * [boost](https://github.com/boostorg/boost)
+    * [fmt](https://github.com/fmtlib/fmt)
+    * [zlib](https://github.com/madler/zlib)
+    * [zstd](https://github.com/facebook/zstd)
+    * [emscripten](https://github.com/emscripten-core/emsdk)
+
+Specific dependency versions used in development:
+
+https://github.com/schrodinger/sketcher/blob/main/external/versions.json
+
+## Support and Community
+
+For questions, support, or discussions related to the Schrödinger 2D Sketcher, please use the [GitHub issue tracker](https://github.com/schrodinger/sketcher/issues).
+
+To contribute code, please follow these steps:
+
+* **Fork the repository:** Fork the `schrodinger/sketcher` repository to your own GitHub account.
+* **Create a branch:** Create a new branch in your forked repository for your changes.
+* **Implement your changes:** Make your code changes or additions.
+* **Test your changes:** Ensure your changes build correctly and pass any existing tests. Add new tests for new features if applicable.
+* **Submit a Pull Request:** Open a pull request from your branch to the `main` branch of the `schrodinger/sketcher` repository. Please provide a clear description of your changes.
+
+All contributions are subject to the terms of the BSD license.
 
 ## License
 
-Code released under the [BSD license](https://github.com/schrodinger/sketcher/blob/master/LICENSE)
+The code is released under the [BSD 3-Clause License](https://github.com/schrodinger/sketcher/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![sketcher](https://github.com/schrodinger/sketcher/blob/main/.github/schrodinger-sketcher-screenshot.png)](https://www.schrodinger.com/2dsketcher)
 
-The Schrödinger 2D Sketcher is an open-source application for drawing and editing chemical structures in two dimensions. It provides a user-friendly interface for creating molecules, reactions, and other chemical diagrams, which can be used independently or integrated into other cheminformatics workflows.
+The Schrödinger 2D Sketcher is an open-source application for drawing and editing chemical structures. The entire sketcher is built on top of the RDKit open source toolkit, which serves as its underlying chemical model. It provides a user-friendly interface for creating molecules, reactions, and other chemical diagrams, which can be used independently or integrated into other cheminformatics workflows.
 
 This project is released by Schrödinger, Inc. and is available under an open-source license to foster collaboration and development within the scientific community.
 
@@ -25,15 +25,6 @@ This project is released by Schrödinger, Inc. and is available under an open-so
 * A C++ compiler supporting C++20 or later
 * CMake (version 3.24 or later)
 * All required dependencies installed and accessible to CMake:
-    * [RDKit](https://github.com/rdkit/rdkit)
-    * [Qt](https://github.com/qt/qt5)
-    * [boost](https://github.com/boostorg/boost)
-    * [fmt](https://github.com/fmtlib/fmt)
-    * [zlib](https://github.com/madler/zlib)
-    * [zstd](https://github.com/facebook/zstd)
-    * [emscripten](https://github.com/emscripten-core/emsdk)
-
-Specific dependency versions used in development:
 
 https://github.com/schrodinger/sketcher/blob/main/external/versions.json
 


### PR DESCRIPTION
* Linked Case: SKETCH-2033
* Branch: main
* Primary Reviewer: @KevKeating 
 
### Description
A bunch of minor changes while I was testing moving rdkit_extensions code into the public repo:
- capitalized all env vars in the workflow
- updated the wasm build artifact name
- Build now adds local src/ directory for includes (for local .h files)
- Deduped static linking in the cmake instructions
- Updated the README with real information!

### Testing Done
Runners
