### PR TITLE
Minor fixes to buildinger premake

### DIFF
--- a/premake
+++ b/premake
@@ -50,14 +50,15 @@ cmake -B $BUILD_DIR \
 
 # allow CMake to be invoked using make
 echo "
+.PHONY: all test memtest
 all:
 	cmake --build $BUILD_DIR --config $BUILD_TYPE
 
 test:
-	ctest --build-config $BUILD_TYPE --test-dir $SCHRODINGER/sketcher -LE memtest --output-on-failure
+	$SCHRODINGER/run ctest --build-config $BUILD_TYPE --test-dir $SCHRODINGER/sketcher -LE memtest --output-on-failure
 
 memtest:
-	ctest --build-config $BUILD_TYPE --test-dir $SCHRODINGER/sketcher -L memtest --output-on-failure
+	$SCHRODINGER/run ctest --build-config $BUILD_TYPE --test-dir $SCHRODINGER/sketcher -L memtest --output-on-failure
 " > $BUILD_DIR/Makefile
 
 # buildinger expects stdout to define variables


### PR DESCRIPTION
* Linked Case: SKETCH-2187
* Branch: main
 
### Description
When the tests are launched through buildinger, they inadvertently depended on `build_env` having been sourced in the terminal used to launch buildinger.  I've now tweaked the Makefile so that it launches the tests using `$SCHRODINGER/run`, so the tests now run correctly regardless.

I've also marked all of the Makefile targets as phony.  Without that, Make would decide whether or not to run the tests based on the timestamp of the `test` directory (since it has the same name as the `test` target.

### Testing Done
Launched the tests via buildinger on Windows.
