### PR TITLE
SKETCH-2424. Prep CMakeLists.txt for move of all sketcher source into the repo

### DIFF
--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -68,6 +68,13 @@ jobs:
             echo "${{ github.workspace }}/build/external/emsdk-${{ env.VERSION }}/emsdk/" >> $GITHUB_PATH && \
             echo "${{ github.workspace }}/build/external/emsdk-${{ env.VERSION }}/emsdk/upstream/emscripten" >> $GITHUB_PATH
 
+      - name: Configure Node.js for WASM tests
+        if: matrix.build-output == 'wasm'
+        # CMake uses Node.js to run the tests on emscripten builds
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+
       - name: Configure Dependency CMake
         run: |
             ${{ matrix.build-output == 'wasm' && 'emcmake ' || '' }}\
@@ -197,25 +204,25 @@ jobs:
       - name: Build
         run: cmake --build build --config ${{ env.BUILD_TYPE }}
 
-      - name: Configure Node.js
-        if: matrix.build-output == 'wasm'
-        # CMake uses Node.js to run the tests on emscripten builds
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.14.0
-
       - name: Run tests
         working-directory: build
+        if: matrix.build-output != 'debug'
         # Launching `xvfb-run -a` required for Ubuntu non-wasm builds
         run: |
           ${{ matrix.os == 'ubuntu-latest' && matrix.build-output != 'wasm' && 'xvfb-run -a' || ''}} \
-          ctest --build-config ${{ env.BUILD_TYPE }} -LE memtest --output-on-failure
+          ctest --build-config ${{ env.BUILD_TYPE }} -LE memtest --output-on-failure --output-junit junit-report.xml
 
       - name: Run memtests
         working-directory: build
         if: matrix.build-output == 'debug'
         run: |
-          xvfb-run -a ctest --build-config Debug -L memtest --output-on-failure
+          xvfb-run -a ctest --build-config ${{ env.BUILD_TYPE }} -L memtest --output-on-failure --output-junit junit-report.xml
+
+      - name: Publish Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "build/junit-report.xml"
+        if: always()
 
       - name: Download sketcher executable
         if: matrix.build-output != 'wasm'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 find_package(
   Boost ${BOOST_VERSION} REQUIRED COMPONENTS filesystem iostreams json
                                              serialization unit_test_framework)
-find_package(Qt6 ${QT_VERSION} REQUIRED COMPONENTS Widgets Svg SvgWidgets)
+find_package(Qt6 ${QT_VERSION} REQUIRED COMPONENTS Widgets Svg SvgWidgets Test)
 find_package(Eigen3 ${EIGEN_VERSION} REQUIRED)
 find_package(RDKit ${RDKIT_VERSION} REQUIRED)
 find_package(fmt ${FMT_VERSION} REQUIRED)
@@ -73,14 +73,22 @@ find_package(zstd ${ZSTD_VERSION} REQUIRED)
 
 # Common library/executable configuration
 function(setup_target TARGET)
+  # Visibility settings for dynamic vs static builds
+  if(${BUILD_SHARED_LIBS})
+    set(VISIBILITY "default")
+  else()
+    set(VISIBILITY "hidden")
+  endif()
+  # Compilation optimization, warnings, and error handling
   if(MSVC)
     target_compile_options(${TARGET} PRIVATE -WX)
   elseif(WIN32)
-    target_compile_options(${TARGET} PRIVATE -Wall -Werror -Wswitch -O2
-                                             -fvisibility=hidden -Wno-restrict)
+    target_compile_options(
+      ${TARGET} PRIVATE -Wall -Werror -Wswitch -O2 -fvisibility=${VISIBILITY}
+                        -Wno-restrict)
   else()
     target_compile_options(${TARGET} PRIVATE -Wall -Werror -Wswitch -O2
-                                             -fvisibility=hidden)
+                                             -fvisibility=${VISIBILITY})
   endif()
   # Allow RDKit includes to be prefixed, and add all relevant and necessary
   # sketcher-specific include directories
@@ -108,15 +116,27 @@ endfunction()
 function(build_schrodinger_library TARGET)
   set(INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/schrodinger/${TARGET})
   set(SRC_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/${TARGET})
-  # Collect public headers so that Qt can build .moc files
+  # Collect all headers, source, and resources; note we collect public headers
+  # so that Qt can build .moc files
   file(GLOB_RECURSE SOURCE_LIST CONFIGURE_DEPENDS ${INCLUDE_DIR}/*.h
-       ${SRC_DIR}/*.h ${SRC_DIR}/*.cpp)
+       ${SRC_DIR}/*.h ${SRC_DIR}/*.cpp ${SRC_DIR}/*.qrc)
   add_library(${TARGET} ${SOURCE_LIST})
   add_library(schrodinger::${TARGET} ALIAS ${TARGET})
   setup_target(${TARGET})
   # Auto-generate compile definitions
   string(TOUPPER ${TARGET} TARGET_UPPER)
   target_compile_definitions(${TARGET} PRIVATE IN_${TARGET_UPPER}_DLL)
+endfunction()
+
+# Enable Qt's MOC and UIC features
+function(enable_qt_moc TARGET)
+  set(UI_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/sketcher/ui)
+  set_target_properties(
+    ${TARGET}
+    PROPERTIES AUTOMOC ON
+               AUTOUIC ON
+               AUTOUIC_SEARCH_PATHS ${UI_DIR}
+               AUTORCC ON)
 endfunction()
 
 # schrodinger::rdkit_extensions library
@@ -154,19 +174,13 @@ target_link_libraries(
 # Configure and include version information for the sketcher
 configure_file(${PROJECT_SOURCE_DIR}/include/schrodinger/sketcher/version.h.in
                ${PROJECT_BINARY_DIR}/include/schrodinger/sketcher/version.h)
-# Enable Qt MOC and UIC
-set(UI_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/sketcher/ui)
-set_target_properties(
-  ${SKETCHER_TARGET}
-  PROPERTIES AUTOMOC ON
-             AUTOUIC ON
-             AUTOUIC_SEARCH_PATHS ${UI_DIR})
+enable_qt_moc(${SKETCHER_TARGET})
 
 # Standalone executable
 set(APP_TARGET sketcher_app)
 add_executable(${APP_TARGET} src/app/main.cpp)
 setup_target(${APP_TARGET})
-target_link_libraries(${APP_TARGET} PRIVATE Qt6::Widgets ${SKETCHER_TARGET})
+target_link_libraries(${APP_TARGET} PRIVATE Boost::boost Qt6::Widgets ${SKETCHER_TARGET})
 
 # Tests
 enable_testing()
@@ -178,7 +192,9 @@ set(TEST_DEPENDENCIES
     Boost::unit_test_framework
     Eigen3::Eigen
     fmt::fmt
+    Qt6::Test
     Qt6::Widgets
+    RDKit::ChemReactions
     RDKit::FileParsers
     ${RDKIT_EXTENSIONS_TARGET}
     ${SKETCHER_TARGET})
@@ -192,11 +208,18 @@ set(MEMTEST_COMMAND
 separate_arguments(MEMTEST_COMMAND)
 
 foreach(TEST_SOURCE ${TEST_SOURCE_LIST})
-  cmake_path(GET TEST_SOURCE STEM TEST_TARGET)
+  cmake_path(GET TEST_SOURCE STEM TEST_STEM)
+  # Mirror the source directory for test collection and make unique target names
+  cmake_path(RELATIVE_PATH TEST_SOURCE OUTPUT_VARIABLE TEST_PATH)
+  cmake_path(GET TEST_PATH PARENT_PATH PREFIX_PATH)
+  # Create unique target name by replacing path separators with underscores
+  string(REPLACE "/" "_" TEST_TARGET_SUFFIX "${PREFIX_PATH}")
+  set(TEST_TARGET "${TEST_STEM}_${TEST_TARGET_SUFFIX}")
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   setup_target(${TEST_TARGET})
   target_include_directories(${TEST_TARGET} PRIVATE ${PROJECT_SOURCE_DIR}/test)
   target_link_libraries(${TEST_TARGET} PRIVATE ${TEST_DEPENDENCIES})
+  enable_qt_moc(${TEST_TARGET})
   if(EMSCRIPTEN)
     set(TEST_COMMAND node $<TARGET_FILE:${TEST_TARGET}>)
   else()
@@ -206,12 +229,8 @@ foreach(TEST_SOURCE ${TEST_SOURCE_LIST})
   set_tests_properties(
     ${TEST_TARGET} PROPERTIES ENVIRONMENT
                               "SKETCHER_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
-  # Mirror the source directory for test collection
-  cmake_path(RELATIVE_PATH TEST_SOURCE OUTPUT_VARIABLE TEST_PATH)
-  cmake_path(GET TEST_PATH PARENT_PATH PREFIX_PATH)
   set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                   ${PREFIX_PATH})
-
   if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     # create the valgrind test
     set(CURRENT_MEMTEST_COMMAND ${MEMTEST_COMMAND})

--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -10,7 +10,7 @@
 
 namespace Ui
 {
-class ExampleWidgetForm;
+class SketcherWidgetForm;
 }
 
 namespace schrodinger
@@ -18,15 +18,15 @@ namespace schrodinger
 namespace sketcher
 {
 
-class SKETCHER_API ExampleWidget : public QWidget
+class SKETCHER_API SketcherWidget : public QWidget
 {
     Q_OBJECT
   public:
-    ExampleWidget(QWidget* parent = nullptr);
-    ~ExampleWidget();
+    SketcherWidget(QWidget* parent = nullptr);
+    ~SketcherWidget();
 
   protected:
-    std::unique_ptr<Ui::ExampleWidgetForm> m_ui;
+    std::unique_ptr<Ui::SketcherWidgetForm> m_ui;
 };
 
 } // namespace sketcher

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -2,12 +2,12 @@
 
 #include <QApplication>
 
-#include "schrodinger/sketcher/example_widget.h"
+#include "schrodinger/sketcher/sketcher_widget.h"
 
 int main(int argc, char** argv)
 {
     QApplication application(argc, argv);
-    schrodinger::sketcher::ExampleWidget widget;
-    widget.show();
+    schrodinger::sketcher::SketcherWidget sketcher_widget;
+    sketcher_widget.show();
     return application.exec();
 }

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -1,29 +1,29 @@
 // @copyright Schrodinger, LLC - All Rights Reserved
 
-#include "schrodinger/sketcher/example_widget.h"
+#include "schrodinger/sketcher/sketcher_widget.h"
 
 #include <QWidget>
 
 #include "schrodinger/rdkit_extensions/example.h"
-#include "schrodinger/sketcher/ui/ui_example_widget.h"
+#include "schrodinger/sketcher/ui/ui_sketcher_widget.h"
 
 namespace schrodinger
 {
 namespace sketcher
 {
 
-ExampleWidget::ExampleWidget(QWidget* parent) : QWidget(parent)
+SketcherWidget::SketcherWidget(QWidget* parent) : QWidget(parent)
 {
-    m_ui.reset(new Ui::ExampleWidgetForm());
+    m_ui.reset(new Ui::SketcherWidgetForm());
     m_ui->setupUi(this);
     if (rdkit_extensions::dependency_test("c1ccccc1")) {
         m_ui->label->setText(QString::fromStdString("Dependencies work!"));
     }
 }
 
-ExampleWidget::~ExampleWidget() = default;
+SketcherWidget::~SketcherWidget() = default;
 
 } // namespace sketcher
 } // namespace schrodinger
 
-#include "schrodinger/sketcher/example_widget.moc"
+#include "schrodinger/sketcher/sketcher_widget.moc"

--- a/src/schrodinger/sketcher/ui/sketcher_widget.ui
+++ b/src/schrodinger/sketcher/ui/sketcher_widget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ExampleWidgetForm</class>
- <widget class="QWidget" name="ExampleWidgetForm">
+ <class>SketcherWidgetForm</class>
+ <widget class="QWidget" name="SketcherWidgetForm">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -1,23 +1,23 @@
 // @copyright Schrodinger, LLC - All Rights Reserved
 
-#define BOOST_TEST_MODULE example_widget_test
+#define BOOST_TEST_MODULE sketcher_widget_test
 
 #include <boost/test/unit_test.hpp>
 
-#include "schrodinger/sketcher/example_widget.h"
+#include "schrodinger/sketcher/sketcher_widget.h"
 #include "qapplication_required_fixture.h"
 
 using namespace schrodinger::sketcher;
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
 
-class TestExampleWidget : public ExampleWidget
+class TestSketcherWidget : public SketcherWidget
 {
   public:
-    TestExampleWidget() : ExampleWidget(){};
+    TestSketcherWidget() : SketcherWidget(){};
 };
 
 BOOST_AUTO_TEST_CASE(test_widget)
 {
-    TestExampleWidget widget;
+    TestSketcherWidget widget;
 }


### PR DESCRIPTION
* Linked Case: SKETCH-2424
* Branch: 2025-4
* Primary Reviewer: @KevKeating 
 
### Description
- add Qt::Test dependency
- fix visibility settings for static libs (currently only worked for dynamic)
- include resource files in compilation grep
- added AUTOMOC function to be reused for both library and tests
- update test files to account for duplicate test names in rdkit_extensions and sketcher subdirs
- update SketcherWidget naming so move of the real widget doesn't have naming conflicts
- added test-summary/action@v2 to the repo 🙌 

### Testing Done
CI with full copy of rdkit_extensions/sketcher moved into the repo
