### PR TITLE
SKETCH-2512. Only apply stylesheet to WASM build

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -126,18 +126,18 @@ void apply_stylesheet(QApplication& app)
 int main(int argc, char** argv)
 {
     QApplication application(argc, argv);
-    apply_stylesheet(application);
     Q_INIT_RESOURCE(sketcher);
 
 #ifdef __EMSCRIPTEN__
+    // Only apply this stylesheet for the WASM build
+    apply_stylesheet(application);
     auto& sk = get_sketcher_instance();
-#else
-    SketcherWidget sk;
-#endif
-
     QObject::connect(&sk, &SketcherWidget::moleculeChanged, &sketcher_changed);
     QObject::connect(&sk, &SketcherWidget::representationChanged,
                      &sketcher_changed);
+#else
+    SketcherWidget sk;
+#endif
 
     sk.show();
     return application.exec();


### PR DESCRIPTION
* Linked Case: SKETCH-2512
* Branch: 2025-4
* Primary Reviewer: @KevKeating 
 
### Description
Gah, you were right. If I apply this to all builds the styling gets stupid. Fix is to only apply to WASM builds

### Testing Done
CI and local testing