### PR TITLE
rework selection tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ TAGS
 .pytest_cache
 # compilation database
 compile_commands.json
+.vscode/

--- a/src/schrodinger/sketcher/ui/select_options_widget.ui
+++ b/src/schrodinger/sketcher/ui/select_options_widget.ui
@@ -60,7 +60,7 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QToolButton" name="select_square_btn">
+      <widget class="schrodinger::sketcher::ModularToolButton" name="select_tool_btn_1">
        <property name="maximumSize">
         <size>
          <width>32</width>
@@ -68,12 +68,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Select structure (with square marqee)</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../sketcher.qrc">
-         <normaloff>:/icons/select_square.svg</normaloff>
-         <disabledoff>:/icons/select_square_dis.svg</disabledoff>:/icons/select_square.svg</iconset>
+        <string/>
        </property>
        <property name="iconSize">
         <size>
@@ -90,7 +85,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="select_lasso_btn">
+      <widget class="schrodinger::sketcher::ModularToolButton" name="select_tool_btn_2">
        <property name="maximumSize">
         <size>
          <width>32</width>
@@ -98,12 +93,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Select structure (with lasso)</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../sketcher.qrc">
-         <normaloff>:/icons/select_lasso.svg</normaloff>
-         <disabledoff>:/icons/select_lasso_dis.svg</disabledoff>:/icons/select_lasso.svg</iconset>
+        <string/>
        </property>
        <property name="iconSize">
         <size>
@@ -284,13 +274,20 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>schrodinger::sketcher::ModularToolButton</class>
+   <extends>QToolButton</extends>
+   <header>schrodinger/sketcher/widget/modular_tool_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../sketcher.qrc"/>
  </resources>
  <connections/>
  <buttongroups>
+  <buttongroup name="erase_tool_group"/>
   <buttongroup name="select_tool_group"/>
   <buttongroup name="move_tool_group"/>
-  <buttongroup name="erase_tool_group"/>
  </buttongroups>
 </ui>

--- a/src/schrodinger/sketcher/ui/selection_tool_popup.ui
+++ b/src/schrodinger/sketcher/ui/selection_tool_popup.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SelectionToolPopup</class>
+ <widget class="QWidget" name="SelectionToolPopup">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>96</width>
+    <height>32</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item row="0" column="1">
+    <widget class="QToolButton" name="lasso_btn">
+     <property name="maximumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Select structure (with lasso)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../sketcher.qrc">
+       <normaloff>:/icons/select_lasso.svg</normaloff>:/icons/select_lasso.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>30</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <attribute name="buttonGroup">
+      <string notr="true">group</string>
+     </attribute>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QToolButton" name="rect_btn">
+     <property name="maximumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Select structure (with square marquee)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../sketcher.qrc">
+       <normaloff>:/icons/select_square.svg</normaloff>:/icons/select_square.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>30</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <attribute name="buttonGroup">
+      <string notr="true">group</string>
+     </attribute>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="ellipse_btn">
+     <property name="maximumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Select structure (with ellipse marquee)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../sketcher.qrc">
+       <normaloff>:/icons/select_square.svg</normaloff>:/icons/select_square.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>30</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <attribute name="buttonGroup">
+      <string notr="true">group</string>
+     </attribute>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../sketcher.qrc"/>
+ </resources>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="group"/>
+ </buttongroups>
+</ui>

--- a/src/schrodinger/sketcher/widget/select_options_widget.h
+++ b/src/schrodinger/sketcher/widget/select_options_widget.h
@@ -7,6 +7,7 @@
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/model/sketcher_model.h"
 #include "schrodinger/sketcher/widget/sketcher_view.h"
+#include <QAbstractButton>
 
 namespace Ui
 {
@@ -28,6 +29,8 @@ class SKETCHER_API SelectOptionsWidget : public SketcherView
     SelectOptionsWidget(QWidget* parent = nullptr);
     ~SelectOptionsWidget();
 
+    void setModel(SketcherModel* model) override;
+
   signals:
     void selectAllRequested();
     void clearSelectionRequested();
@@ -35,11 +38,13 @@ class SKETCHER_API SelectOptionsWidget : public SketcherView
 
   protected:
     std::unique_ptr<Ui::SelectOptionsWidget> ui;
+    SelectionToolPopup* m_selection_tool1_widget = nullptr;
+    SelectionToolPopup* m_selection_tool2_widget = nullptr;
 
   protected slots:
     void updateWidgetsEnabled() override;
 
-    void onSelectButtonClicked(int button_id);
+    void onSelectButtonClicked(QAbstractButton* button);
     void onMoveButtonClicked();
     void onEraseButtonClicked();
 

--- a/src/schrodinger/sketcher/widget/selection_tool_popup.cpp
+++ b/src/schrodinger/sketcher/widget/selection_tool_popup.cpp
@@ -1,0 +1,49 @@
+#include "schrodinger/sketcher/ui/ui_selection_tool_popup.h"
+#include "schrodinger/sketcher/widget/selection_tool_popup.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+SelectionToolPopup::SelectionToolPopup(QWidget* parent) : ModularPopup(parent)
+{
+    ui.reset(new Ui::SelectionToolPopup());
+    ui->setupUi(this);
+    setButtonGroup(ui->group);
+}
+
+SelectionToolPopup::~SelectionToolPopup()
+{
+}
+
+int SelectionToolPopup::getButtonIDToCheck()
+{
+    auto model = getModel();
+    if (model == nullptr) {
+        return -1;
+    }
+
+    int button_id = -1;
+    auto draw_tool = model->getDrawTool();
+    if (draw_tool == DrawTool::SELECT) {
+        button_id = model->getValueInt(ModelKey::SELECTION_TOOL);
+    }
+    return button_id;
+}
+
+void SelectionToolPopup::generateButtonPackets()
+{
+    m_button_packets.emplace_back(ui->rect_btn,
+                                  static_cast<int>(SelectionTool::RECTANGLE));
+    m_button_packets.emplace_back(ui->lasso_btn,
+                                  static_cast<int>(SelectionTool::LASSO));
+    m_button_packets.emplace_back(ui->ellipse_btn,
+                                  static_cast<int>(SelectionTool::ELLIPSE));
+}
+
+} // namespace sketcher
+} // namespace schrodinger
+
+#include "schrodinger/sketcher/widget/selection_tool_popup.moc"

--- a/src/schrodinger/sketcher/widget/selection_tool_popup.h
+++ b/src/schrodinger/sketcher/widget/selection_tool_popup.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <memory>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/widget/modular_popup.h"
+
+namespace Ui
+{
+class SelectionToolPopup;
+}
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Popup used to provide functionality choices for a selection tool button.
+ */
+class SKETCHER_API SelectionToolPopup : public ModularPopup
+{
+    Q_OBJECT
+
+  public:
+    SelectionToolPopup(QWidget* parent = nullptr);
+    ~SelectionToolPopup();
+
+  protected:
+    std::unique_ptr<Ui::SelectionToolPopup> ui;
+    void generateButtonPackets() override;
+    int getButtonIDToCheck() override;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/widget/test_select_options_widget.cpp
+++ b/test/schrodinger/sketcher/widget/test_select_options_widget.cpp
@@ -115,8 +115,7 @@ BOOST_AUTO_TEST_CASE(updateWidgetsEnabled)
     auto ui = wdg.getUI();
     QGraphicsTextItem text_item;
 
-    auto requires_contents_btns = {ui->select_square_btn, ui->select_lasso_btn,
-                                   ui->move_rotate_btn, ui->erase_btn};
+    auto requires_contents_btns = {ui->move_rotate_btn, ui->erase_btn};
     auto requires_selection_btns = {ui->clear_selection_btn,
                                     ui->invert_selection_btn};
 


### PR DESCRIPTION
rework selection tools and add ellipse

* Linked Case: SKETCH-2452
* Branch: <branch>
* Primary Reviewer: @ethan-schrodinger 
 
### Description
This makes the two selection tool buttons popup buttons, each allowing the selection of either square, lasso or ellipse. The default are square and lasso, like before.
I think we're missing an icon for the ellipse, but otherwise everything seems to work

### Testing Done
tested in molviewer