### PR TITLE
SHARED-11709: test_file_stream fails on Windows

### DIFF
--- a/test/schrodinger/rdkit_extensions/test_file_stream.cpp
+++ b/test/schrodinger/rdkit_extensions/test_file_stream.cpp
@@ -159,11 +159,8 @@ BOOST_DATA_TEST_CASE(TestGetDecompressedString,
                              CompressionType::GZIP}),
                      testfile, compression_type)
 {
-#ifdef _WIN32
-    return; // Skip on Windows due to gzip error
-#endif
     auto fname = testfile_path(testfile);
-    std::ifstream is(fname);
+    std::ifstream is(fname, std::ios::binary);
     std::string buffer(std::istreambuf_iterator<char>(is), {});
 
     // MAESTRO formatted file should have a title


### PR DESCRIPTION
* Linked Case: SHARED-11709
* Branch: 2025-4
* Primary Reviewer: @rachelnwalker 
 
### Description
<!--Provide a detailed description what these changes are and why they are necessary -->
The problem came from us not opening the file in binary mode, which is a known cross-platform issue for file reading/writing. 

### Testing Done
<!--Describe the testing that was done to ensure the changes are working as expected -->
made sure the affected test was re-enabled and is now passing.