### PR TITLE
SKETCH-2449 fix error in click detection for move-rotate actions

### DIFF
--- a/src/schrodinger/sketcher/tool/move_rotate_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/move_rotate_scene_tool.cpp
@@ -96,7 +96,7 @@ void MoveRotateSceneTool::onLeftButtonDragStart(
         emit newCursorHintRequested(m_translate_cursor_hint);
         m_action = Action::TRANSLATE;
         description = "Translate";
-        if (m_move_selection_item.rect().contains(event->scenePos())) {
+        if (m_move_selection_item.rect().contains(m_mouse_press_scene_pos)) {
             setObjectsToMove(selected_atoms, selected_non_mol_objs);
         }
     }


### PR DESCRIPTION
* Linked Case: SKETCH-2449
* Primary Reviewer: @ethan-schrodinger 
 
### Description
we were using the point where the drag starts rather than the click down point

### Testing Done
tested in molviewer