### PR TITLE
SKETCH-2491: Fixing delayed fitToScreen calls

### DIFF
--- a/src/schrodinger/sketcher/molviewer/view.cpp
+++ b/src/schrodinger/sketcher/molviewer/view.cpp
@@ -173,6 +173,16 @@ void View::zoomOutToIncludeAll()
 
 void View::fitToScreen()
 {
+    if (!m_initial_geometry_set) {
+        // If the view hasn't been shown yet then it doesn't know how large it
+        // will be, so this method would fit the molecule into the initial
+        // default widget size, which is tiny. The zoom doesn't get updated when
+        // the window is shown, so we'd wind up with a normal size window and a
+        // very tiny molecule. To avoid this, we don't do anything now and
+        // instead re-call this method as soon as the view is shown.
+        m_delayed_fit_to_screen = true;
+        return;
+    }
     Scene* cur_scene = dynamic_cast<Scene*>(scene());
     if (!cur_scene) {
         return;

--- a/test/schrodinger/sketcher/molviewer/test_view.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_view.cpp
@@ -1,0 +1,55 @@
+#define BOOST_TEST_MODULE Test_Sketcher
+
+#include <boost/test/data/test_case.hpp>
+
+#include <QUndoStack>
+#include <QShowEvent>
+
+#include "../test_common.h"
+#include "schrodinger/sketcher/molviewer/view.h"
+// #include "schrodinger/sketcher/molviewer/scene.h"
+// #include "schrodinger/sketcher/model/mol_model.h"
+// #include "schrodinger/sketcher/model/sketcher_model.h"
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+class TestView : public View
+{
+  public:
+    TestView(QGraphicsScene* scene, QWidget* parent = nullptr) :
+        View(scene, parent)
+    {
+    }
+    using View::m_delayed_fit_to_screen;
+    using View::m_initial_geometry_set;
+    using View::showEvent;
+};
+
+/**
+ * When calling fitToScreen() before the View has been shown, make sure that a
+ * delayed fitToScreen() call is scheduled for immediately after the View is
+ * shown.
+ */
+BOOST_AUTO_TEST_CASE(test_delayed_fit_to_screen)
+{
+    auto scene = TestScene::getScene();
+    TestView view(scene.get());
+    BOOST_TEST(!view.m_delayed_fit_to_screen);
+    BOOST_TEST(!view.m_initial_geometry_set);
+    view.fitToScreen();
+    BOOST_TEST(view.m_delayed_fit_to_screen);
+    BOOST_TEST(!view.m_initial_geometry_set);
+
+    QShowEvent show_event;
+    view.showEvent(&show_event);
+    BOOST_TEST(!view.m_delayed_fit_to_screen);
+    BOOST_TEST(view.m_initial_geometry_set);
+}
+
+} // namespace sketcher
+} // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-2491
* Branch: main
* Primary Reviewer: @ethan-schrodinger 
 
### Description
This issue occurs when a molecule is added before the Sketcher is shown.  The `View` doesn't have any geometry set, so `fitToScreen` calls don't work because the `View` doesn't know what to fit _to_.  My initial commit for SKETCH-2358 included a fix for this, but it looks like half of that was inadvertently removed in https://github.com/schrodinger/mmshare/pull/3064.  This PR restores the removed code and adds a quick unit test to cover the behavior.

### Testing Done
Confirmed that the new unit test passes with the view.cpp changes and fails without them.  I also launched Sketcher via an ipython shell and ran
```py
from rdkit import Chem
from schrodinger.Qt import QtWidgets
from schrodinger.ui import sketcher
app = QtWidgets.QApplication([])
mol = Chem.MolFromSmiles("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
sketcher_widget = sketcher.SketcherWidget()
sketcher_widget.addRDKitMolecule(mol)
sketcher_widget.show(); app.exec()
```
Without these changes, the carbon chain winds up super tiny.  With them, it nearly fills the window.
