### PR TITLE
Skip substructure match section of tests on windows

### DIFF
--- a/test/schrodinger/rdkit_extensions/test_conversions.cpp
+++ b/test/schrodinger/rdkit_extensions/test_conversions.cpp
@@ -69,7 +69,8 @@ file_to_rdkit(const std::string& filename)
     return to_rdkit(content);
 }
 
-[[maybe_unused]] static std::unique_ptr<RDKit::ROMol> resolve_his(const RDKit::ROMol& mol)
+[[maybe_unused]] static std::unique_ptr<RDKit::ROMol>
+resolve_his(const RDKit::ROMol& mol)
 {
     // Some structures may contain different protonation states for histidine,
     // but we currently map all of them to the same single letter code 'H' in


### PR DESCRIPTION
The substructure match in this test seems to cause a segv on just windows. I will file an RDKit issue for that soon but want to skip that section of the test now.