### PR TITLE
when unable to trim a bond line, keep it as is

### DIFF
--- a/src/schrodinger/sketcher/molviewer/coord_utils.cpp
+++ b/src/schrodinger/sketcher/molviewer/coord_utils.cpp
@@ -298,13 +298,13 @@ void trim_line_to_rect(QLineF& line, const QRectF& rect)
 
     QPointF inter_point; // the intersection point
 
-    // if the line is completely inside the rect, make it an invalid line
+    // if the line is completely inside the rect, skip the trimming
     if (enlarged_rect.contains(line.p1()) &&
         enlarged_rect.contains(line.p2())) {
-        line.setP1(line.p2());
-    } else if (enlarged_rect.contains(line.p1()) &&
-               intersection_of_line_and_rect(line, enlarged_rect,
-                                             inter_point)) {
+        return;
+    }
+    if (enlarged_rect.contains(line.p1()) &&
+        intersection_of_line_and_rect(line, enlarged_rect, inter_point)) {
         line.setP1(inter_point);
     } else if (enlarged_rect.contains(line.p2()) &&
                intersection_of_line_and_rect(line, enlarged_rect,


### PR DESCRIPTION
* Linked Case: SKETCH-2501
* Branch: <branch>
* Primary Reviewer: @ethan-schrodinger 
 
### Description
this prevents the maestro crash.


### Testing Done
maestro no longer crashes,
here's the resulting overlay picture:

<img width="252" height="206" alt="Screenshot 2025-09-10 at 10 45 57" src="https://github.com/user-attachments/assets/c284eda5-aa15-4d61-8c87-c188fb2cd42a" />
