### PR TITLE
Restore builds; pin cmake; skip rdkit_cstdint.patch

### DIFF
--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -34,7 +34,7 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
 
       - name: Install Python packages
-        run: python3 -m pip install ninja clang-format==14.0.6
+        run: python3 -m pip install clang-format==14.0.6 cmake==3.24 ninja==1.13.0
 
       - name: Install valgrind
         if: matrix.build-output == 'memtest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,11 @@ project(
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_policy(SET CMP0167 NEW)
+# cmake_policy(SET CMP0167 NEW)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 option(ENABLE_TESTING "Build and enable tests" ON)
-option(ENFORCE_DEPENDENCY_VERSIONS
-       "Require that the dependencies match the versions listed in \
-    external/versions.json" ON)
+option(ENFORCE_DEPENDENCY_VERSIONS "Require versions.json enforcement" ON)
 
 # Load dependency versions
 if(${ENFORCE_DEPENDENCY_VERSIONS})
@@ -30,9 +28,7 @@ if(${ENFORCE_DEPENDENCY_VERSIONS})
   foreach(dep ${DEPENDENCIES})
     string(TOUPPER ${dep} dep_upper)
     string(JSON ${dep_upper}_VERSION GET ${VERSIONS} ${dep})
-    set(${dep_upper}_VERSION
-        ${${dep_upper}_VERSION}
-        PARENT_SCOPE)
+    set(${dep_upper}_VERSION ${${dep_upper}_VERSION})
   endforeach()
 endif()
 
@@ -112,12 +108,9 @@ function(setup_target TARGET)
     # We optimize for space in WASM builds because otherwise binaryen (run
     # because of ASYNCIFY) runs out of memory
     target_link_options(${TARGET} PRIVATE -sGL_ENABLE_GET_PROC_ADDRESS
-                                          -fexceptions
-                                          -sDISABLE_EXCEPTION_CATCHING=0
-                                          -Os)
+                        -fexceptions -sDISABLE_EXCEPTION_CATCHING=0 -Os)
     target_compile_options(${TARGET} PRIVATE -fexceptions
-                                             -sDISABLE_EXCEPTION_CATCHING=0
-                                             -Os)
+                                             -sDISABLE_EXCEPTION_CATCHING=0 -Os)
   endif()
 endfunction()
 
@@ -204,9 +197,9 @@ if(EMSCRIPTEN)
       -fexceptions
       -sDISABLE_EXCEPTION_CATCHING=0)
 endif()
-target_link_libraries(${APP_TARGET} PRIVATE Boost::boost Qt6::Widgets
-                                            ${SKETCHER_TARGET}
-                                            ${EXTRA_SKETCHER_APP_LINK_FLAGS})
+target_link_libraries(
+  ${APP_TARGET} PRIVATE Boost::boost Qt6::Widgets ${SKETCHER_TARGET}
+                        ${EXTRA_SKETCHER_APP_LINK_FLAGS})
 
 # Tests
 if(ENABLE_TESTING)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,7 +28,8 @@ endfunction()
 
 if(EMSCRIPTEN)
   set(EXTRA_BOOST_CMAKE_ARGS
-      -DCMAKE_CXX_FLAGS=-fdeclspec\ -pthread\ -fexceptions\ -sDISABLE_EXCEPTION_CATCHING=0)
+      -DCMAKE_CXX_FLAGS=-fdeclspec\ -pthread\ -fexceptions\ -sDISABLE_EXCEPTION_CATCHING=0
+  )
   set(EXTRA_QT_CMAKE_ARGS
       -DQT_HOST_PATH=${CMAKE_CURRENT_BINARY_DIR}/host/qt-${QT_VERSION})
   set(EXTRA_RDKIT_CMAKE_ARGS
@@ -78,8 +79,7 @@ ExternalProject_Add(
   CMAKE_ARGS
     ${COMMON_EXTERNAL_PROJECT_CMAKE_ARGS}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/zlib-${ZLIB_VERSION}
-    -DBUILD_SHARED_LIBS=OFF
-    -DZLIB_BUILD_EXAMPLES=OFF)
+    -DBUILD_SHARED_LIBS=OFF -DZLIB_BUILD_EXAMPLES=OFF)
 
 # Build zstd library
 ExternalProject_Add(
@@ -126,6 +126,7 @@ set_cmake_arg(
   geometry
   iostreams
   json
+  locale
   multi_array
   multiprecision
   program_options
@@ -196,11 +197,9 @@ if(EMSCRIPTEN)
 endif()
 # Prevent RDKit from trying to build shared libs
 list(APPEND RDKIT_PATCH_COMMAND && git apply
-      ${CMAKE_CURRENT_SOURCE_DIR}/rdkit_static_build.patch)
+     ${CMAKE_CURRENT_SOURCE_DIR}/rdkit_static_build.patch)
 list(APPEND RDKIT_PATCH_COMMAND && git apply
-      ${CMAKE_CURRENT_SOURCE_DIR}/rdkit_cstdint.patch)
-list(APPEND RDKIT_PATCH_COMMAND && git apply
-      ${CMAKE_CURRENT_SOURCE_DIR}/rdkit_extern_patch.patch)
+     ${CMAKE_CURRENT_SOURCE_DIR}/rdkit_cstdint.patch)
 if(WIN32)
   set(RDKIT_INSTALL_STATIC_LIBS_VAL ON)
 else()


### PR DESCRIPTION
* Branch: 2025-4
* Primary Reviewer: @ricrogz 
 
### Description
I cleared the dep caches, and the mac and ubuntu build fail. The mac build fails because it looks like the cmake version on macos-latest was *too* new that the zstd build was failing. And @ricrogz 's patch for extern created weird errors on ubuntu. This change does the following:
- pin cmake (3.24) and ninja (1.13.0) versions
- comment out CMP0167 policy (it only exists in 3.30!)
- skip rdkit_extern_patch.patch (for now)
I'm working on fixing the extern thing (Brian left comments on https://github.com/rdkit/rdkit/pull/8765) but these changes allow the builds to complete and the non-wasm tests to pass. Second review to come.

Also a couple of other things:
- added boost::locale in anticipation of updating RDKit
- Remove PARENT_SCOPE -- it was creating warnings in the configure stage
- Ran cmake-format on CMakeLists.txt files

### Testing Done
CI
