### PR TITLE
SKETCH-2539: Strip /r when reading from clipboard

### DIFF
--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -390,6 +390,10 @@ void SketcherWidget::pasteAt(std::optional<QPointF> position)
     if (text.empty()) {
         return;
     }
+    // On WASM builds, RDKit doesn't like Windows newline characters, so we
+    // explicitly remove the /r's, which converts Windows-style newlines to
+    // Unix-style
+    std::erase_if(text, [](char c) { return c == '\r'; });
     std::optional<RDGeom::Point3D> mol_position = std::nullopt;
     if (position.has_value()) {
         // Convert the position from global to scene coordinates

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -222,6 +222,20 @@ BOOST_AUTO_TEST_CASE(test_cut_copy_paste)
     BOOST_TEST(!sk.m_mol_model->hasSelection());
 }
 
+/**
+ * Make sure that pasting a string containing Windows newline characters work
+ * correctly.  (RDKit parsing can't handle \r's on WASM builds, so
+ * SketcherWidget must remove those manually.)
+ */
+BOOST_AUTO_TEST_CASE(test_paste_with_windows_newline)
+{
+    TestSketcherWidget sk;
+    sk.setClipboardContents("CCC\n\r");
+    sk.paste();
+    auto mol = sk.m_mol_model->getMol();
+    BOOST_TEST(mol->getNumAtoms() == 3);
+}
+
 BOOST_AUTO_TEST_CASE(test_importText_slot)
 {
     TestSketcherWidget sk;


### PR DESCRIPTION
* Linked Case: SKETCH-2539
* Branch: main
* Primary Reviewer: @ethan-schrodinger 
 
### Description
RDKit doesn't like Windows-style newlines on WASM builds, so this PR explicitly strips any `\r` characters from the clipboard before passing the string to RDKit.

### Testing Done
Confirmed that I could paste a SMILES string containing Windows-style newlines into a WASM build.  I also added a unit test, but it passes even without this fix since the tests are currently not run on WASM builds.
