### PR TITLE
SKETCH-2532: Fixing mmshare Linux build errors

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_atom_or_bond_display_settings.h
+++ b/src/schrodinger/sketcher/molviewer/abstract_atom_or_bond_display_settings.h
@@ -21,6 +21,7 @@ class SKETCHER_API AbstractAtomOrBondDisplaySettings
     AbstractAtomOrBondDisplaySettings() = default;
     explicit AbstractAtomOrBondDisplaySettings(
         const AbstractAtomOrBondDisplaySettings&) = default;
+    virtual ~AbstractAtomOrBondDisplaySettings() = default;
 
     /**
      * Set a pre-defined RDKit color scheme

--- a/src/schrodinger/sketcher/molviewer/atom_display_settings.h
+++ b/src/schrodinger/sketcher/molviewer/atom_display_settings.h
@@ -26,6 +26,8 @@ class SKETCHER_API AtomDisplaySettings
     // a single AtomDisplaySettings object with all AtomItems.
     explicit AtomDisplaySettings(const AtomDisplaySettings&) = default;
 
+    virtual ~AtomDisplaySettings() = default;
+
     /**
      * Set a pre-defined RDKit color scheme
      * @param scheme color scheme to apply to atom items

--- a/src/schrodinger/sketcher/molviewer/bond_display_settings.h
+++ b/src/schrodinger/sketcher/molviewer/bond_display_settings.h
@@ -24,6 +24,7 @@ class SKETCHER_API BondDisplaySettings
     // Prevent implicit copies, since that could cause bugs, as the Scene shares
     // a single BondDisplaySettings object with all BondItems.
     explicit BondDisplaySettings(const BondDisplaySettings&) = default;
+    virtual ~BondDisplaySettings() = default;
     /// The width of the pen to use for drawing bond lines
     qreal m_bond_width = BOND_DEFAULT_PEN_WIDTH;
     /// How far apart to draw the lines of a double (or triple) bond


### PR DESCRIPTION
* Linked Case: SKETCH-2532
* Branch: main
 
### Description
Linux builds of mmshare were complaining about the non-virtual destructor, so this commit fixes the problem.  I've already pushed this to mmshare to stop breaking the build, but wanted to sync the change over to this repo.

### Testing Done
Linux builds succeeded on my DevBox as well as the per-commit builder.