### PR TITLE
SKETCH-2540: Adding SketcherWidget::activateSelectionTool

### DIFF
--- a/include/schrodinger/sketcher/public_constants.h
+++ b/include/schrodinger/sketcher/public_constants.h
@@ -12,5 +12,15 @@ enum class SelectMode {
     SELECT_ONLY, // normal click (no Shift or Ctrl)
 };
 
+/**
+ * Possible selection tools to equip
+ */
+enum class SelectionTool {
+    RECTANGLE,
+    ELLIPSE,
+    LASSO,
+    FRAGMENT,
+};
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -110,13 +110,21 @@ class SKETCHER_API SketcherWidget : public QWidget
      * Enable or disable select-only mode, which removes the toolbars and limits
      * user interaction to selecting items.
      */
-    void setSelectOnlyMode(bool select_only_mode_enabled);
+    void setSelectOnlyMode(const bool select_only_mode_enabled);
 
     /**
      * Set the color scheme, which controls the atom and bond colors as well as
      * the background color.
      */
-    void setColorScheme(ColorScheme color_scheme);
+    void setColorScheme(const ColorScheme color_scheme);
+
+    /**
+     * Switch to the specified selection tool. Note that this call will have no
+     * effect if select-only mode is disabled and the workspace is empty, as the
+     * select tool isn't allowed in that scenario (since there's nothing to
+     * select).
+     */
+    void activateSelectionTool(const SelectionTool tool);
 
     /**
      * Undoably select or deselect the specified atoms and bonds.

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -10,6 +10,7 @@
 #include <boost/functional/hash.hpp>
 
 #include "schrodinger/sketcher/image_constants.h"
+#include "schrodinger/sketcher/public_constants.h"
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/molviewer/atom_display_settings.h"
 #include "schrodinger/sketcher/molviewer/bond_display_settings.h"
@@ -32,16 +33,6 @@ struct RenderOptions;
  * Whether to the entire scene or a selection subset should be used
  */
 enum class SceneSubset { ALL, SELECTION, HOVERED, SELECTED_OR_HOVERED };
-
-/**
- * Possible selection tools to equip
- */
-enum class SelectionTool {
-    RECTANGLE,
-    ELLIPSE,
-    LASSO,
-    FRAGMENT,
-};
 
 /**
  * All supported elements.

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -325,13 +325,15 @@ bool SketcherWidget::isEmpty() const
     return m_mol_model->isEmpty();
 }
 
-void SketcherWidget::setSelectOnlyMode(bool select_only_mode_enabled)
+void SketcherWidget::setSelectOnlyMode(const bool select_only_mode_enabled)
 {
     m_select_only_mode_active = select_only_mode_enabled;
     setToolbarsVisible(!select_only_mode_enabled);
     m_sketcher_model->setSelectToolAllowedWhenSceneEmpty(
         select_only_mode_enabled);
-    if (select_only_mode_enabled) {
+    // make sure that a select tool is active if we're enabling select-only mode
+    if (select_only_mode_enabled &&
+        m_sketcher_model->getDrawTool() != DrawTool::SELECT) {
         m_sketcher_model->setValues(
             {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::SELECT)},
              {ModelKey::SELECTION_TOOL,
@@ -339,9 +341,16 @@ void SketcherWidget::setSelectOnlyMode(bool select_only_mode_enabled)
     }
 }
 
-void SketcherWidget::setColorScheme(ColorScheme color_scheme)
+void SketcherWidget::setColorScheme(const ColorScheme color_scheme)
 {
     m_sketcher_model->setColorScheme(color_scheme);
+}
+
+void SketcherWidget::activateSelectionTool(const SelectionTool tool)
+{
+    m_sketcher_model->setValues(
+        {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::SELECT)},
+         {ModelKey::SELECTION_TOOL, QVariant::fromValue(tool)}});
 }
 
 static std::unordered_set<const RDKit::Atom*>


### PR DESCRIPTION
* Linked Case: SKETCH-2540
* Branch: main
 
### Description
This adds a SketcherWidget method for activating any of the selection tools.  The only minor caveat here is that doing something like
```py
sk = sketcher.SketcherWidget()
sk.activateSelectionTool(sketcher.SelectionTool.ELLIPSE)
sk.setSelectOnlyMode(True)
```
won't actually activate the ellipse selection tool, since "normal" Sketcher (i.e. not select only Sketcher) doesn't allow selection tools to be activated when the workspace is empty, meaning that the `activateSelectionTool()` will be a no-op.  The workaround is to make sure that select-only mode is enabled first, i.e.,
```py
sk = sketcher.SketcherWidget()
sk.setSelectOnlyMode(True)
sk.activateSelectionTool(sketcher.SelectionTool.ELLIPSE)
```
will work as expected.  This seems like a relatively minor inconvenience, especially since it's not an issue when using the (Python-only) `SelectOnlySketcherWidget` class, as that will be in select-only mode as soon as its instantiated.

I've also added SIP wrappings for the new method, but that part is mmshare-only so it's not in this diff (since we don't have the SIP wrappings in this repo yet).  It's just the new line from sketcher_widget.h copied over to _sketcher.sip.

@matvey83, GitHub still won't let me add you as a reviewer on this repo, so I'm trying a ping instead.

### Testing Done
Tested with an mmshare build using the Maestro Python terminal.
