### PR TITLE
SKETCH-2222. Fix selection context menu to account for no atoms

### DIFF
--- a/src/schrodinger/sketcher/menu/selection_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/selection_context_menu.cpp
@@ -106,7 +106,7 @@ void SelectionContextMenu::updateActions()
             return m_atoms.count(bond->getBeginAtom()) !=
                    m_atoms.count(bond->getEndAtom());
         });
-    bool one_fragment = in_same_fragment(m_atoms);
+    bool one_fragment = !m_atoms.empty() && in_same_fragment(m_atoms);
     m_flip_action->setEnabled(true);
     m_flip_action->setVisible(crossing_bonds_count == 1 && one_fragment);
     m_flip_molecule_menu->menuAction()->setVisible(crossing_bonds_count == 0 &&


### PR DESCRIPTION
* Linked Case: SKETCH-2222
* Branch: 2026-1
* Primary Reviewer: @KevKeating 
 
### Description
Fix the test that was segfaulting by making sure there are atoms present. I'm gonna push this to get the tests passing again. Also going to talk to Lenna about getting a merge queue set up to avoid stuff like this in the future.

### Testing Done
CI
