### PR TITLE
Make connections in MonomerMols directional when necessary

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/cg_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/cg_coordgen.cpp
@@ -121,7 +121,8 @@ static void compute_full_ring_info(const RDKit::ROMol& polymer)
     if (polymer.getRingInfo()->isInitialized()) {
         polymer.getRingInfo()->reset();
     }
-    RDKit::MolOps::findSSSR(polymer);
+    bool include_dative_bonds = true;
+    RDKit::MolOps::findSSSR(polymer, /*res=*/ nullptr, include_dative_bonds);
 
     for (auto bond_idx : zob_idxs) {
         const_cast<RDKit::Bond*>(polymer.getBondWithIdx(bond_idx))
@@ -136,7 +137,8 @@ static void compute_full_ring_info(const RDKit::ROMol& polymer)
 static std::vector<int> find_largest_ring(const RDKit::ROMol& polymer)
 {
     if (!polymer.getRingInfo()->isInitialized()) {
-        RDKit::MolOps::findSSSR(polymer);
+        bool include_dative_bonds = true;
+        RDKit::MolOps::findSSSR(polymer, /*res=*/ nullptr, include_dative_bonds);
     }
 
     std::vector<int> largest_ring{};
@@ -409,7 +411,8 @@ static void lay_out_linear_polymer(RDKit::ROMol& polymer,
 static void lay_out_polymer(RDKit::ROMol& polymer, const bool rotate = false)
 {
     if (!polymer.getRingInfo()->isInitialized()) {
-        RDKit::MolOps::findSSSR(polymer);
+        bool include_dative_bonds = true;
+        RDKit::MolOps::findSSSR(polymer, /*res=*/ nullptr, include_dative_bonds);
     }
     if (polymer.getRingInfo()->numRings() > 0) {
         lay_out_cyclic_polymer(polymer);

--- a/src/schrodinger/rdkit_extensions/monomer_mol.cpp
+++ b/src/schrodinger/rdkit_extensions/monomer_mol.cpp
@@ -12,6 +12,24 @@
 
 #include "schrodinger/rdkit_extensions/helm.h"
 
+
+namespace
+{
+
+std::pair<unsigned int, unsigned int> getAttchpts(const std::string& linkage)
+{
+    // in form RX-RY, returns {X, Y}
+    auto dash = linkage.find('-');
+    if (dash == std::string::npos) {
+        throw std::runtime_error(
+            fmt::format("Invalid linkage format: {}", linkage));
+    }
+    return {std::stoi(linkage.substr(1, dash - 1)),
+            std::stoi(linkage.substr(dash + 2))};
+}
+
+} // unnamed namespace
+
 namespace schrodinger::rdkit_extensions
 {
 
@@ -90,15 +108,37 @@ void addConnection(RDKit::RWMol& monomer_mol, size_t monomer1, size_t monomer2,
         // Update the linkage property
         bond->setProp(CUSTOM_BOND, linkage);
     } else {
-        auto bond_type = (linkage.front() == 'p' ? ::RDKit::Bond::ZERO
-                                                 : ::RDKit::Bond::SINGLE);
-        const auto new_total =
-            monomer_mol.addBond(monomer1, monomer2, bond_type);
-        bond = monomer_mol.getBondWithIdx(new_total - 1);
-        bond->setProp(LINKAGE, linkage);
+        auto create_bond = [&](unsigned int first_monomer, unsigned int second_monomer, ::RDKit::Bond::BondType bond_type, const std::string& linkage_prop) {
+            const auto new_total =
+                monomer_mol.addBond(first_monomer, second_monomer, bond_type);
+            auto bond = monomer_mol.getBondWithIdx(new_total - 1);
+            bond->setProp(LINKAGE, linkage_prop);
+            if (is_custom_bond) {
+                bond->setProp(CUSTOM_BOND, linkage_prop);
+            }
+        };
 
-        if (is_custom_bond) {
-            bond->setProp(CUSTOM_BOND, linkage);
+        // Connections that use specific and different attachment points (such as R2-R1 or R3-R1)
+        // should be set as directional (dative) bonds so that substructure matching and canonicalization
+        // can take sequence direction into account. To ensure consistent bond directionality, we always
+        // set the direction from the higher attachment point to the lower attachment point.
+        bool set_directional_bond = false;
+        if (linkage.front() != 'p' && linkage.find('?') == std::string::npos) {
+            auto [begin_attchpt, end_attchpt] = getAttchpts(linkage);
+            if (begin_attchpt > end_attchpt) {
+                create_bond(monomer1, monomer2, ::RDKit::Bond::DATIVE, linkage);
+                set_directional_bond = true;
+            } else if (begin_attchpt < end_attchpt) {
+                auto new_linkage = fmt::format("R{}-R{}", end_attchpt, begin_attchpt);
+                create_bond(monomer2, monomer1, ::RDKit::Bond::DATIVE, new_linkage);
+                set_directional_bond = true;
+            }
+        }
+
+        if (!set_directional_bond) {
+            auto bond_type = (linkage.front() == 'p' ? ::RDKit::Bond::ZERO
+                                                    : ::RDKit::Bond::SINGLE);
+            create_bond(monomer1, monomer2, bond_type, linkage);
         }
     }
 

--- a/src/schrodinger/rdkit_extensions/to_atomistic.cpp
+++ b/src/schrodinger/rdkit_extensions/to_atomistic.cpp
@@ -282,8 +282,14 @@ AttachmentMap addPolymer(RDKit::RWMol& atomistic_mol,
         auto [core_aid2, attachment_point2] =
             attachment_point_map.at({to_res, to_rgroup});
 
+        auto bond_type = bond->getBondType();
+        if (bond_type == RDKit::Bond::DATIVE) {
+            // Only relevant at the monomer mol level, this is just
+            // a single bond at the atomistic level
+            bond_type = RDKit::Bond::SINGLE;
+        }
         auto atomistic_bond_idx =
-            atomistic_mol.addBond(core_aid1, core_aid2, bond->getBondType()) -
+            atomistic_mol.addBond(core_aid1, core_aid2, bond_type) -
             1;
         remove_atoms.push_back(attachment_point1);
         remove_atoms.push_back(attachment_point2);
@@ -357,7 +363,13 @@ boost::shared_ptr<RDKit::RWMol> toAtomistic(const RDKit::ROMol& monomer_mol)
             begin_attachment_points.at({begin_res, from_rgroup});
         auto [core_atom2, attachment_point2] =
             end_attachment_points.at({end_res, to_rgroup});
-        atomistic_mol->addBond(core_atom1, core_atom2, bnd->getBondType());
+        auto bond_type = bnd->getBondType();
+        if (bond_type == RDKit::Bond::DATIVE) {
+            // Only relevant at the monomer mol level, this is just
+            // a single bond at the atomistic level
+            bond_type = RDKit::Bond::SINGLE;
+        }
+        atomistic_mol->addBond(core_atom1, core_atom2, bond_type);
         remove_atoms.push_back(attachment_point1);
         remove_atoms.push_back(attachment_point2);
     }

--- a/test/schrodinger/rdkit_extensions/test_coarse_grain.cpp
+++ b/test/schrodinger/rdkit_extensions/test_coarse_grain.cpp
@@ -37,11 +37,14 @@ BOOST_AUTO_TEST_CASE(TestBasicCoarseGrainMol)
                       "PEPTIDE1{A.G.C}$$$$V2.0");
     BOOST_CHECK_EQUAL(to_string(monomer_mol, Format::FASTA), ">\nAGC\n");
 
+    std::cout << ::RDKit::MolToSmiles(monomer_mol) << std::endl;
+
     // making it a cyclic peptide
     addConnection(monomer_mol, 2, 0);
     assignChains(monomer_mol);
     BOOST_CHECK_EQUAL(to_string(monomer_mol, Format::HELM),
                       "PEPTIDE1{A.G.C}$PEPTIDE1,PEPTIDE1,3:R2-1:R1$$$V2.0");
+    std::cout << ::RDKit::MolToSmiles(monomer_mol) << std::endl;
     // This is a cyclic peptide, should FASTA throw?
     // BOOST_CHECK_THROW(to_string(monomer_mol, Format::FASTA),
     // std::invalid_argument);


### PR DESCRIPTION
* Branch: main
* Primary Reviewer: @whosayn 
 
### Description
Connections that use specific and different attachment points (such as R2-R1 or R3-R1) should be set as directional (dative) bonds so that substructure matching and canonicalization can take sequence direction into account. To ensure consistent bond directionality, we always set the direction from the higher attachment point to the lower attachment point.

### Testing Done
Tests do not currently pass, it looks like the HELM writer isn't understanding the dative bonds when writing out the connection section 