### PR TITLE
SKETCH-2462: Now always drawing "explicit" hydrogens

### DIFF
--- a/src/schrodinger/sketcher/molviewer/atom_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/atom_item.cpp
@@ -644,6 +644,14 @@ bool AtomItem::determineLabelIsVisible() const
     if (m_atom->getFormalCharge() != 0) {
         return true;
     }
+    if (m_atom->getNumExplicitHs()) {
+        // "explicit" hydrogens (at least according to RDKit) are hydrogens that
+        // are involved in determining a stereocenter. We always want to draw
+        // these since RDKit won't automatically remove them if we add another
+        // bond to this atom. This can lead to valence errors, so we don't want
+        // them to be a surprise to the user.
+        return true;
+    }
     int num_bonds = m_atom->getDegree();
     if (num_bonds == 0) {
         return true;


### PR DESCRIPTION
* Linked Case: SKETCH-2462
* Branch: main
* Primary Reviewer: @ethan-schrodinger 
 
### Description
So this isn't exactly a bug, _per se_.  (Although it is confusing, which I think we can fix.  See below.)  Nic's comment on the Jira case is correct: the issue here comes down to how RDKit treats implicit versus explicit hydrogens, which is complicated by the fact that RDKit uses "explicit" to mean something that has absolutely nothing to do with whether the hydrogen is stored as a separate (explicit) `RDKit::Atom` object.  My understanding (which I think is probably hopefully at least mostly right) is that RDKit has three categories of hydrogens:

- "neighbor" hydrogens, where the hydrogen has its own `Atom` object
- "explicit" hydrogens, where the hydrogen doesn't have its own `Atom` object but is involved in determining a stereocenter
- "implicit" hydrogens, where the hydrogen doesn't have its own `Atom` object and is not involved in determining a stereocenter

When the user adds a new bond to a carbon, then RDKit will automatically remove an implicit hydrogen from that carbon (assuming one exists) to avoid creating a pentavalent carbon.  However, RDKit will *not* remove any "explicit" hydrogens in that scenario.  As a result, adding a new bond to a carbon with three bonds and an explicit carbon results in a pentavalent carbon.  In the Jira case, it _looks_ like the hydrogen mysteriously appears when the the fourth bond is added.  What's actually happening, though, is that adding the third bond (i.e. the wedge bond) to the carbon results in one of the implicit hydrogens becoming explicit.  We don't immediately draw the explicit hydrogen, though, because there's no valence error.  Then, when the fourth bond is added, the carbon winds up with a valence error, which causes the hydrogen to be drawn since we always draw hydrogens on atoms with valence errors.

I think the fix here is to always draw "explicit" hydrogens.  That way, it's much clearer whats happening and it doesn't look like the hydrogen randomly appeared just for the sake of creating a valence error.  The hydrogen would instead get drawn as soon as the extracyclic bond switches from a normal single bond to a wedge bond (and would similarly disappear if the bond were switched back to a normal single bond).  That would look something like this (as rendered in lazy ASCII art):
```
   C-C
  /   \
 C     C
  \   /
   C-C

     C
     |
   C-C
  /   \
 C     C
  \   /
   C-C

      C
      ▼
   C-CH
  /   \
 C     C
  \   /
   C-C

      C
      ▼
   C-CH-C
  /   \
 C     C
  \   /
   C-C
```
(There'd be a valence error on the pentavalent carbon in the last picture.)

### Testing Done
Confirmed that the existing unit tests pass, and confirmed that the Sketcher behavior matches the ASCII art above.
