### PR TITLE
SKETCH-2496. Introduce minimum nightly build

### DIFF
--- a/.github/actions/build-external/action.yml
+++ b/.github/actions/build-external/action.yml
@@ -10,7 +10,6 @@ inputs:
     required: true
   host-build:
     description: "Whether to build a host library for use in cross-compiling (e.g. a Linux build of Qt that gets used during the WASM build process)"
-    required: false
     default: false
 
 outputs:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,23 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-branch:
+        description: 'Release branch to bump and merge (leave empty to skip)'
+        default: 2025-4
+        type: string
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  # Create Nightly Builds
+  build-release-branch:
+    if: inputs.release-branch != ''
+    uses: ./.github/workflows/sketcher-builder.yml
+    with:
+      ref: ${{ inputs.release-branch }}
+  build-main-branch:
+    uses: ./.github/workflows/sketcher-builder.yml
+    with:
+      ref: main

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -2,10 +2,14 @@ name: Sketcher Build and Test
 
 on:
   workflow_dispatch: ~
-  push: ~
   pull_request: ~
-  schedule:
-    - cron: "0 4 * * *"
+  merge_group: ~
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        default: ${{ github.ref }}
 
 jobs:
   build:
@@ -25,6 +29,8 @@ jobs:
         #     build-output: memtest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Create and activate virtualenv
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
* Linked Case: SKETCH-2496
* Branch: 2025-4
 
### Description
Updated nightly-build.yml to contain the bare minimum -- nightly builds of release branch and main on a sketcher repo cron schedule. I'll figure out how to handle version bumps, auto-merge, and triggering from core-infra's end over in https://github.com/schrodinger/sketcher/pull/72. The goal here is to have artifacts published in a way that unblocks Juzer from re-establishing the NB sketcher auto bump pipeline for LD.
