### PR TITLE
LDID8-1005: publish @schrodinger/sketcher npm package during nightly build

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -1,0 +1,35 @@
+name: publish-npm-package
+description: Publishes the @schrodinger/sketcher npm package with the WASM artifacts
+
+outputs:
+  version:
+    description: The package version that was published the npm registry
+    value: ${{ steps.publish.outputs.published-version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install node
+      uses: actions/setup-node@v5
+      with:
+        node-version: latest
+
+    - id: prepare-package
+      run: |
+        mv sketcher-wasm/* wasm/package/dist
+
+        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9+]")
+        sed -i -e "s/<SKETCHER_VERSION>/$SKETCHER_VERSION/" wasm/package/package.json
+
+        TAG_NAME=$(echo $SKETCHER_VERSION | awk -F . '{print "v"$1"-"$2}')
+        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+    
+    - id: publish
+      uses: schrodinger/action-npm-publish@v2
+      with:
+        path: wasm/package
+        pre-release: true
+        tag: ${{ steps.prepare-package.outputs.TAG_NAME }}
+        version-conflict-strategy: skip
+

--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         mv sketcher-wasm/* wasm/package/dist
 
-        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9+]")
+        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
         sed -i -e "s/<SKETCHER_VERSION>/$SKETCHER_VERSION/" wasm/package/package.json
 
         TAG_NAME=$(echo $SKETCHER_VERSION | awk -F . '{print "v"$1"-"$2}')

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -254,3 +254,7 @@ jobs:
         with:
           name: sketcher-${{ inputs.ref }}-${{ matrix.build-output }}
           path: sketcher-wasm.tar.gz
+
+      - name: Publish sketcher npm package
+        if: matrix.build-output == 'wasm' && github.event_name == 'workflow_call'
+        uses: ./.github/actions/publish-npm-package

--- a/wasm/package/package.json
+++ b/wasm/package/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@schrodinger/sketcher",
+  "version": "<SKETCHER_VERSION>",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/schrodinger/sketcher"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "files": [
+    "dist"
+  ]
+}


### PR DESCRIPTION
* Linked Case: LDID8-1005
* Branch: main
 
### Description
Publishes an npm package with the WASM artifacts with a pre-release version (so it doesn't need a version bump, the npm-publish action can generate unique pre-release version names from the same base package version as long as the commits are different). For now, will only publish packages when run as a `workflow_call` (which currently only happens from the nightly build workflow).

Merging it into `main` because it's practically not going to have any effect on the `2025-4` branch (since the workflow file from that branch will never be read in any of the cases where this action will run).