### PR TITLE
LDID8-1005: change npm publish condition to workflow input

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -1,0 +1,35 @@
+name: publish-npm-package
+description: Publishes the @schrodinger/sketcher npm package with the WASM artifacts
+
+outputs:
+  version:
+    description: The package version that was published the npm registry
+    value: ${{ steps.publish.outputs.published-version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install node
+      uses: actions/setup-node@v5
+      with:
+        node-version: latest
+
+    - id: prepare-package
+      run: |
+        mv sketcher-wasm/* wasm/package/dist
+
+        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9+]")
+        sed -i -e "s/<SKETCHER_VERSION>/$SKETCHER_VERSION/" wasm/package/package.json
+
+        TAG_NAME=$(echo $SKETCHER_VERSION | awk -F . '{print "v"$1"-"$2}')
+        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+    
+    - id: publish
+      uses: schrodinger/action-npm-publish@v2
+      with:
+        path: wasm/package
+        pre-release: true
+        tag: ${{ steps.prepare-package.outputs.TAG_NAME }}
+        version-conflict-strategy: skip
+

--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         mv sketcher-wasm/* wasm/package/dist
 
-        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9+]")
+        SKETCHER_VERSION=$(grep "VERSION " CMakeLists.txt | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
         sed -i -e "s/<SKETCHER_VERSION>/$SKETCHER_VERSION/" wasm/package/package.json
 
         TAG_NAME=$(echo $SKETCHER_VERSION | awk -F . '{print "v"$1"-"$2}')

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,7 +17,9 @@ jobs:
     uses: ./.github/workflows/sketcher-builder.yml
     with:
       ref: ${{ inputs.release-branch }}
+      publish-npm-package: true
   build-main-branch:
     uses: ./.github/workflows/sketcher-builder.yml
     with:
       ref: main
+      publish-npm-package: true

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -254,3 +254,7 @@ jobs:
         with:
           name: sketcher-${{ inputs.ref }}-${{ matrix.build-output }}
           path: sketcher-wasm.tar.gz
+
+      - name: Publish sketcher npm package
+        if: matrix.build-output == 'wasm' && github.event_name == 'workflow_call'
+        uses: ./.github/actions/publish-npm-package

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -10,6 +10,10 @@ on:
         description: 'Git ref to checkout'
         type: string
         default: ${{ github.ref }}
+      publish-npm-package:
+        description: Whether an npm package should be published with the WASM build artifacts
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -256,5 +260,5 @@ jobs:
           path: sketcher-wasm.tar.gz
 
       - name: Publish sketcher npm package
-        if: matrix.build-output == 'wasm' && github.event_name == 'workflow_call'
+        if: matrix.build-output == 'wasm' && inputs.publish-npm-package
         uses: ./.github/actions/publish-npm-package

--- a/wasm/package/package.json
+++ b/wasm/package/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@schrodinger/sketcher",
+  "version": "<SKETCHER_VERSION>",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/schrodinger/sketcher"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "files": [
+    "dist"
+  ]
+}


### PR DESCRIPTION
* Linked Case: LDID8-1005
* Branch: 2025-4
 
### Description
Two things:
- Merges the changes from [2f9f1d6](https://github.com/schrodinger/sketcher/commit/2f9f1d67e44c2c7375b9e684a5e034c4c11e2572) into `2025-4` so the release branch has the necessary source code changes to build the package
- Changes the conditional for running the npm publish step from `github.event_name == 'workflow_run'` to `inputs.publish-npm-package`. Turns out `workflow_call` is not an `event_name` because called workflows are run within the context of their caller workflow so the `github.event_name` context has the value for the event name for the caller workflow (for e.g. `workflow_dispatch` for a manually triggered nightly build workflow). So switching it over to an explicit input that the nightly build workflow provides to the sketcher-builder workflow.