### PR TITLE
LDID8-1005: update md5 hash substitutions in WASM assets

### DIFF
--- a/wasm/create_wasm_tarball.sh
+++ b/wasm/create_wasm_tarball.sh
@@ -11,7 +11,7 @@ fi
 rm -fr ${INSTALL_DIR} || true
 mkdir -p ${INSTALL_DIR}
 
-echo -e "Building WASM distibution in ${INSTALL_DIR}"
+echo -e "Building WASM distribution in ${INSTALL_DIR}"
 echo -e "\tRunning in:" `pwd` 
 
 ls -al ./build
@@ -21,15 +21,14 @@ cp -v ${QT_DIR}/plugins/platforms/qtloader.js ${INSTALL_DIR}
 cp -vr ./wasm/public/. ${INSTALL_DIR}
 
 export md5Wasm=$(md5sum ./build/sketcher_app.wasm | awk '{ print $1 }')
-export md5Js=$(md5sum ./build/sketcher_app.js | awk '{ print $1 }')
-
-perl -i -pe 's/\.wasm/.wasm?cache_bust=$ENV{md5Wasm}/g' ${INSTALL_DIR}/qtloader.js
-perl -i -pe 's/"\.js"/".js?cache_bust=$ENV{md5Js}"/g' ${INSTALL_DIR}/qtloader.js
+perl -i -pe 's/sketcher_app\.wasm/sketcher_app.wasm?cache_bust=$ENV{md5Wasm}/g' ${INSTALL_DIR}/sketcher_app.js
 
 export md5Qt=$(md5sum ${INSTALL_DIR}/qtloader.js | awk '{ print $1 }')
+export md5Js=$(md5sum ./build/sketcher_app.js | awk '{ print $1 }')
 perl -i -pe 's/qtloader\.js/qtloader.js?cache_bust=$ENV{md5Qt}/g' ${INSTALL_DIR}/wasm_shell.html
+perl -i -pe 's/sketcher_app\.js/sketcher_app.js?cache_bust=$ENV{md5Js}/g' ${INSTALL_DIR}/wasm_shell.html
 
-echo -e "Built WASM distibution in ${INSTALL_DIR}\n"
+echo -e "Built WASM distribution in ${INSTALL_DIR}\n"
 
 echo -e "Creating ${INSTALL_DIR}.tar.gz"
 rm -f ${INSTALL_DIR}.tar.gz || true


### PR DESCRIPTION
* Linked Case: LDID8-1005
* Branch: 2025-4
 
### Description
Updates the application of cache busting md5 hashes in the WASM assets so the hashes are inserted in the correct files for the new Qt version