### PR TITLE
Fixing MSVC warnings about lex.yy.cpp

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/generated/lex.yy.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/generated/lex.yy.cpp
@@ -1,3 +1,4 @@
+#include <stdint.h>
 
 #define YY_INT_ALIGNED short int
 

--- a/src/schrodinger/rdkit_extensions/helm/helm_lexer.l
+++ b/src/schrodinger/rdkit_extensions/helm/helm_lexer.l
@@ -8,6 +8,14 @@
  *          flex helm_lexer.l
  */
 
+/* We must include stdint.h before the generated file tries to define its own
+ * integral limits.  Otherwise, MSVC will complain about the macros being
+ * redefined when it gets transitively included later
+ */
+%top{
+#include <stdint.h>
+}
+
 %{
 
 #include <string>


### PR DESCRIPTION
* Linked Case: BLDMGR-10073
* Branch: main
 
### Description
This fixes some of the warnings that @saptarshi-sdgr was running into on https://github.com/schrodinger/sketcher/pull/73 (which I've copied and pasted below).  Based on a quick Google, this seems to be a common issue with Lex/Flex and MSVC that happens when something imports stdint.h after Flex has already defined its own versions of the macros.  By importing stdint.h at the top of the file, Flex will skip it's own macros and use the stdint.h ones instead.
```
.yy.cpp.obj /FdCMakeFiles\rdkit_extensions.dir\ /FS -c C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(49): error C2220: the following warning is treated as an error
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(49): warning C4005: 'INT8_MIN': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(81): note: see previous definition of 'INT8_MIN'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(50): warning C4005: 'INT16_MIN': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(84): note: see previous definition of 'INT16_MIN'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(51): warning C4005: 'INT32_MIN': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(87): note: see previous definition of 'INT32_MIN'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(53): warning C4005: 'INT8_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(90): note: see previous definition of 'INT8_MAX'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(54): warning C4005: 'INT16_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(93): note: see previous definition of 'INT16_MAX'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(55): warning C4005: 'INT32_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(96): note: see previous definition of 'INT32_MAX'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(57): warning C4005: 'UINT8_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(99): note: see previous definition of 'UINT8_MAX'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(58): warning C4005: 'UINT16_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(102): note: see previous definition of 'UINT16_MAX'
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\build_env\vs-2019\compiler-16.11.11\VC\Tools\MSVC\14.29.30133\include\stdint.h(59): warning C4005: 'UINT32_MAX': macro redefinition
C:\Users\saptarshi.mondal\package_factory\pf-local-channels\bldmgr-10073-2\bld\rattler-build_sketcher_1759751124\work\src\schrodinger\rdkit_extensions\helm\generated\lex.yy.cpp(105): note: see previous definition of 'UINT32_MAX'
```

### Testing Done
Local build using package factory gets further with this change.