### PR TITLE
SKETCH-2577: Fix wiggly bond preservation

### DIFF
--- a/src/schrodinger/rdkit_extensions/stereochemistry.cpp
+++ b/src/schrodinger/rdkit_extensions/stereochemistry.cpp
@@ -75,6 +75,30 @@ void wedgeMolBonds(RDKit::ROMol& mol, const RDKit::Conformer* conf)
     RDKit::ClearSingleBondDirFlags(mol);
     RDKit::Chirality::clearMolBlockWedgingInfo(mol);
 
+    // SKETCH-2577 workaround: hide wiggly bonds from WedgeMolBonds by
+    // temporarily changing them to Bond::OTHER. WedgeMolBonds only considers
+    // Bond::SINGLE bonds, so this prevents pickBondToWedge from stealing a
+    // wiggly bond to express a neighboring chiral atom's stereo — which the
+    // restore step below would then overwrite with UNKNOWN, losing that
+    // atom's wedge representation entirely.
+    //
+    // The upstream fix lives in RDKit (pickBondToWedge skips bonds with
+    // BondDir::UNKNOWN or _UnknownStereo=1). Once that lands in the RDKit
+    // version sketcher uses, this OTHER-type swap can go away — only the
+    // _UnknownStereo → BondDir::UNKNOWN restore below is still needed
+    // (clearSingleBondDirFlags clears UNKNOWN to NONE; we put it back so
+    // MolToCXSmiles emits |w:|).
+    std::vector<RDKit::Bond*> wiggly_bonds;
+    for (auto bond : mol.bonds()) {
+        int unknown_stereo{0};
+        if (bond->getPropIfPresent(RDKit::common_properties::_UnknownStereo,
+                                   unknown_stereo) &&
+            unknown_stereo && bond->getBondType() == RDKit::Bond::SINGLE) {
+            wiggly_bonds.push_back(bond);
+            bond->setBondType(RDKit::Bond::OTHER);
+        }
+    }
+
     try {
         // Temporarily silence RDKit's loggers
         RDLog::LogStateSetter silence_rdkit_logging;
@@ -87,6 +111,14 @@ void wedgeMolBonds(RDKit::ROMol& mol, const RDKit::Conformer* conf)
     // Restore the dummies
     for (auto bond : attachment_dummy_bonds) {
         bond->setBondType(RDKit::Bond::SINGLE);
+    }
+
+    // Restore wiggly bonds: SINGLE type + BondDir::UNKNOWN. The OTHER-type
+    // swap above is part of the SKETCH-2577 workaround; the BondDir::UNKNOWN
+    // restore is permanently needed regardless of the upstream RDKit fix.
+    for (auto bond : wiggly_bonds) {
+        bond->setBondType(RDKit::Bond::SINGLE);
+        bond->setBondDir(RDKit::Bond::BondDir::UNKNOWN);
     }
 }
 

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -2952,6 +2952,26 @@ void MolModel::addMolCommandFunc(RDKit::ROMol mol)
          ++bond_index) {
         RDKit::Bond* bond = m_mol.getBondWithIdx(bond_index);
         setTagForBond(bond, m_next_bond_tag++);
+
+        // SKETCH-2577 workaround: bridge wiggly state from the input mol
+        // (where prepare_mol set BondDir::UNKNOWN) into a property that
+        // survives downstream re-wedging passes. clearMolBlockWedgingInfo
+        // wipes the CXSMILES wiggly annotation; setting _MolFileBondCfg=2
+        // (MDL V3000 wiggly marker) lets the next wedgeMolBonds save block
+        // re-detect this bond as wiggly.
+        //
+        // TODO(SKETCH-2577): Once the upstream RDKit fix lands
+        // (pickBondToWedge skipping bonds with _UnknownStereo=1 set by
+        // clearSingleBondDirFlags), re-evaluate whether this bridge is still
+        // needed — clearSingleBondDirFlags already saves _UnknownStereo=1,
+        // which the upstream fix would respect.
+        auto* src_bond = mol.getBondWithIdx(bond_index - old_num_bonds);
+        bond->setBondDir(src_bond->getBondDir());
+        if (src_bond->getBondDir() == RDKit::Bond::BondDir::UNKNOWN &&
+            !src_bond->hasProp(RDKit::common_properties::_MolFileBondCfg)) {
+            bond->setProp(RDKit::common_properties::_MolFileBondCfg, 2);
+        }
+
         if (contains_two_monomer_linkages(bond)) {
             setSecondaryConnectionTagForBond(bond, m_next_bond_tag++);
         }

--- a/test/schrodinger/rdkit_extensions/test_convert.cpp
+++ b/test/schrodinger/rdkit_extensions/test_convert.cpp
@@ -1255,3 +1255,70 @@ $$$$)MDL";
         BOOST_TEST(cxsmiles == "CC[C@H](C)[C@H](C)C[C@H](C)N |a:4,7,o1:2|");
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_wiggly_bond_cxsmiles_roundtrip)
+{
+    // Test that wiggly bonds are preserved when round-tripping through
+    // to_rdkit and to_string with EXTENDED_SMILES format
+    const std::string input_smiles = "CCC(C)N |w:2.3|";
+    auto mol = to_rdkit(input_smiles, Format::EXTENDED_SMILES);
+    BOOST_REQUIRE(mol != nullptr);
+
+    std::string output_smiles = to_string(*mol, Format::EXTENDED_SMILES);
+    BOOST_TEST(output_smiles == input_smiles);
+}
+
+/**
+ * Document where wigglyness lives on the bond after to_rdkit() for both MDL
+ * and CXSMILES inputs. This is the contract the sketcher's wedgeMolBonds()
+ * relies on for restoring BondDir::UNKNOWN.
+ *
+ * MDL: preserve_wiggly_bonds() converts the _MolFileBond{Stereo,Cfg} property
+ * into BondDir::UNKNOWN before mol_model sees the bond.
+ *
+ * CXSMILES: RDKit stores wigglyness via the chiral atom's UNSPECIFIED tag —
+ * no bond-level property or BondDir is set. MolToCXSmiles infers |w:| on
+ * output from the atom state, which is why no sketcher-side intervention is
+ * needed for the CXSMILES roundtrip case.
+ */
+BOOST_AUTO_TEST_CASE(test_to_rdkit_wiggly_bond_state)
+{
+    // MDL V3000 wiggly bond (CFG=2)
+    const std::string mdl_v3000 = R"(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.078434 0.000000 0.000000 0
+M  V30 2 C -0.779413 -0.750012 0.000000 0
+M  V30 3 C 0.519609 0.000000 0.000000 0
+M  V30 4 C 1.818630 -0.750012 0.000000 0
+M  V30 5 N 0.519609 1.500025 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 3 5 CFG=2
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+$$$$
+)";
+    auto mdl_mol = to_rdkit(mdl_v3000);
+    BOOST_REQUIRE(mdl_mol != nullptr);
+    auto* mdl_bond = mdl_mol->getBondBetweenAtoms(2, 4);
+    BOOST_REQUIRE(mdl_bond != nullptr);
+    BOOST_TEST(mdl_bond->getBondDir() == RDKit::Bond::BondDir::UNKNOWN);
+
+    // CXSMILES |w:2.3| does NOT set BondDir::UNKNOWN — wigglyness is kept on
+    // the chiral atom state. MolToCXSmiles re-derives |w:| on output.
+    const std::string cxsmiles = "CCC(C)N |w:2.3|";
+    auto cx_mol = to_rdkit(cxsmiles, Format::EXTENDED_SMILES);
+    BOOST_REQUIRE(cx_mol != nullptr);
+    auto* cx_bond = cx_mol->getBondBetweenAtoms(2, 3);
+    BOOST_REQUIRE(cx_bond != nullptr);
+    BOOST_TEST(cx_bond->getBondDir() == RDKit::Bond::BondDir::NONE);
+}

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4906,5 +4906,59 @@ BOOST_AUTO_TEST_CASE(test_helm_string_chain_renaming)
                        "dR](A)P}|RNA6{[dR](C)P}|PEPTIDE1{W}$$$$V2.0");
 }
 
+/**
+ * Test that wiggly bonds (unknown stereochemistry) are preserved when
+ * round-tripping through add_text_to_mol_model and EXTENDED_SMILES export.
+ */
+BOOST_AUTO_TEST_CASE(test_wiggly_bond_preservation)
+{
+    // Test MDL V3000 format roundtrip
+    QUndoStack undo_stack_mdl;
+    TestMolModel model_mdl(&undo_stack_mdl);
+
+    const std::string mdl_wiggly_bond = R"(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.078434 0.000000 0.000000 0
+M  V30 2 C -0.779413 -0.750012 0.000000 0
+M  V30 3 C 0.519609 0.000000 0.000000 0
+M  V30 4 C 1.818630 -0.750012 0.000000 0
+M  V30 5 N 0.519609 1.500025 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 3 5 CFG=2
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+$$$$
+)";
+
+    add_text_to_mol_model(model_mdl, mdl_wiggly_bond);
+
+    // Verify EXTENDED_SMILES export shows wiggly bond from MDL input
+    std::string exported_smiles_from_mdl =
+        get_mol_text(&model_mdl, Format::EXTENDED_SMILES);
+    BOOST_TEST(exported_smiles_from_mdl == "CCC(C)N |w:2.3|");
+
+    // Test EXTENDED_SMILES format roundtrip
+    QUndoStack undo_stack_smiles;
+    TestMolModel model_smiles(&undo_stack_smiles);
+
+    // Add a molecule with a wiggly bond using add_text_to_mol_model
+    add_text_to_mol_model(model_smiles, "CCC(C)N |w:2.3|");
+
+    // Extract it as EXTENDED_SMILES and verify the wiggly bond is preserved
+    std::string exported_smiles =
+        get_mol_text(&model_smiles, Format::EXTENDED_SMILES);
+    BOOST_TEST(exported_smiles == "CCC(C)N |w:2.3|");
+}
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/test/schrodinger/sketcher/rdkit/test_stereochemistry.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_stereochemistry.cpp
@@ -101,5 +101,88 @@ BOOST_AUTO_TEST_CASE(test_wedgeMolBonds)
                       false);
 }
 
+/**
+ * Verify that wedgeMolBonds preserves wiggly bonds (unknown stereochemistry).
+ * Without this preservation, wiggly bonds would be lost when recalculating
+ * wedging, since ClearSingleBondDirFlags clears BondDir::UNKNOWN.
+ */
+BOOST_AUTO_TEST_CASE(test_wedgeMolBonds_preserves_wiggly_bonds)
+{
+    // Create a molecule with a wiggly bond using CXSMILES
+    const std::string cxsmiles = "CCC(C)N |w:2.3|";
+    auto mol = rdkit_extensions::to_rdkit(
+        cxsmiles, rdkit_extensions::Format::EXTENDED_SMILES);
+    BOOST_REQUIRE(mol != nullptr);
+
+    // Generate 2D coordinates
+    rdkit_extensions::compute2DCoords(*mol);
+
+    // Set BondDir to UNKNOWN to simulate a wiggly bond
+    auto* bond = mol->getBondWithIdx(2);
+    BOOST_REQUIRE(bond != nullptr);
+    bond->setBondDir(RDKit::Bond::BondDir::UNKNOWN);
+    BOOST_TEST(bond->getBondDir() == RDKit::Bond::BondDir::UNKNOWN);
+
+    // Call wedgeMolBonds - it should preserve the wiggly bond
+    rdkit_extensions::wedgeMolBonds(*mol, &mol->getConformer());
+
+    // Verify that BondDir::UNKNOWN was preserved
+    BOOST_TEST(bond->getBondDir() == RDKit::Bond::BondDir::UNKNOWN);
+}
+
+/**
+ * Verify that wedgeMolBonds does not steal a wiggly bond to express the stereo
+ * of an adjacent chiral atom.
+ *
+ * WedgeMolBonds prefers terminal-neighbor bonds for wedging. If the wiggly bond
+ * connects to a terminal atom (N in this case), WedgeMolBonds would naively
+ * steal it to express the adjacent chiral atom's stereo. When we then restore
+ * it to UNKNOWN, the chiral atom loses its wedge — the stereo is no longer
+ * represented.
+ *
+ * The fix: before calling WedgeMolBonds, temporarily change wiggly bonds to
+ * Bond::OTHER type so WedgeMolBonds skips them entirely (it only considers
+ * Bond::SINGLE bonds), then restore them to SINGLE + UNKNOWN afterward.
+ */
+BOOST_AUTO_TEST_CASE(
+    test_wedgeMolBonds_does_not_steal_wiggly_bond_from_adjacent_chiral_atom)
+{
+    // CC[C@@H](CC)N: atom 2 (C@@H) has defined stereo;
+    // the bond to N (atom 5, degree-1 terminal) is the wiggly bond.
+    // WedgeMolBonds prefers terminal-neighbor bonds, so without the fix it
+    // picks this bond for atom 2's stereo — which we then overwrite with
+    // UNKNOWN.
+    auto mol = rdkit_extensions::to_rdkit("CC[C@@H](CC)N",
+                                          rdkit_extensions::Format::SMILES);
+    BOOST_REQUIRE(mol != nullptr);
+    rdkit_extensions::compute2DCoords(*mol);
+
+    // Simulate wiggly bond state (as mol_model.cpp does when adding a molecule)
+    auto* wiggly_bond = mol->getBondBetweenAtoms(2, 5);
+    BOOST_REQUIRE(wiggly_bond != nullptr);
+    wiggly_bond->setBondDir(RDKit::Bond::BondDir::UNKNOWN);
+
+    rdkit_extensions::wedgeMolBonds(*mol, &mol->getConformer());
+
+    // The wiggly bond must remain UNKNOWN
+    BOOST_TEST(wiggly_bond->getBondDir() == RDKit::Bond::BondDir::UNKNOWN);
+
+    // The chiral atom (C@@H, atom 2) must still have its stereo represented
+    // by at least one other bond with a wedge/dash direction.
+    auto* stereo_atom = mol->getAtomWithIdx(2);
+    bool has_stereo_bond = false;
+    for (auto* b : mol->atomBonds(stereo_atom)) {
+        if (b != wiggly_bond &&
+            (b->getBondDir() == RDKit::Bond::BondDir::BEGINWEDGE ||
+             b->getBondDir() == RDKit::Bond::BondDir::BEGINDASH)) {
+            has_stereo_bond = true;
+            break;
+        }
+    }
+    BOOST_TEST(has_stereo_bond,
+               "The chiral atom adjacent to the wiggly bond should still have "
+               "its stereo expressed by a wedge or dash on another bond");
+}
+
 } // namespace sketcher
 } // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-2577
* Branch: 2026-1
 
### Description
Wiggly bonds were being lost during normal molecule operations for several reasons. The wedgeMolBonds() function calls ClearSingleBondDirFlags() which clears the BondDir::UNKNOWN flag that indicates wiggly bonds. Additionally, RDKit's insertMol() doesn't preserve the _MolFileBondCfg property that the sketcher's prepare_mol function checks to detect wiggly bonds. Finally, CXSMILES input sets BondDir::UNKNOWN but doesn't set the _MolFileBondCfg property, creating an inconsistency with MDL format handling.

The fix involves capturing wiggly bond state before it gets cleared and restoring it afterward. In stereochemistry.cpp, the code now saves which bonds are wiggly by checking _MolFileBondStereo (MDL V2000), _MolFileBondCfg (MDL V3000), and BondDir::UNKNOWN (CXSMILES) before calling ClearSingleBondDirFlags(). After the wedging calculation completes, it restores the wiggly bond directions.

In mol_model.cpp, when adding molecules, the code now explicitly copies the BondDir from the source molecule and sets _MolFileBondCfg=2 for CXSMILES-sourced wiggly bonds so that prepare_mol can properly detect them.

### Testing Done
Added test to demonstrate what currently works, as well as what is fixed.
Also added a test to demonstrate the issue with insertMol
