### PR TITLE
SKETCH-2593: fix export macro clash

### DIFF
--- a/include/schrodinger/rdkit_extensions/definitions.h
+++ b/include/schrodinger/rdkit_extensions/definitions.h
@@ -2,12 +2,20 @@
 
 #pragma once
 
+#ifndef API_HELPER_IMPORT
 #ifdef _WIN32
 #define API_HELPER_IMPORT __declspec(dllimport)
-#define API_HELPER_EXPORT __declspec(dllexport)
 #else
 #define API_HELPER_IMPORT __attribute__((visibility("default")))
+#endif
+#endif
+
+#ifndef API_HELPER_EXPORT
+#ifdef _WIN32
+#define API_HELPER_EXPORT __declspec(dllexport)
+#else
 #define API_HELPER_EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 #ifdef RDKIT_EXTENSIONS_STATIC_DEFINE

--- a/include/schrodinger/sketcher/definitions.h
+++ b/include/schrodinger/sketcher/definitions.h
@@ -2,12 +2,20 @@
 
 #pragma once
 
+#ifndef API_HELPER_IMPORT
 #ifdef _WIN32
 #define API_HELPER_IMPORT __declspec(dllimport)
-#define API_HELPER_EXPORT __declspec(dllexport)
 #else
 #define API_HELPER_IMPORT __attribute__((visibility("default")))
+#endif
+#endif
+
+#ifndef API_HELPER_EXPORT
+#ifdef _WIN32
+#define API_HELPER_EXPORT __declspec(dllexport)
+#else
 #define API_HELPER_EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 #ifdef SKETCHER_STATIC_DEFINE


### PR DESCRIPTION
Part of SKETCH-2593. When the rdkit_extensions or sketcher headers are included in other Core Suite files, the export macros clash with the ones already defined in the suite. This checks for the existence of the macros before attempting to define them. It also allows overriding them, in case anyone needs to do thath.