### PR TITLE
SHARED-12177 patch: toMonomeric: improve monomer recognition

### DIFF
--- a/src/schrodinger/rdkit_extensions/monomer_database.cpp
+++ b/src/schrodinger/rdkit_extensions/monomer_database.cpp
@@ -24,6 +24,8 @@
 #include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 #include <rdkit/GraphMol/QueryOps.h>
+#include <rdkit/GraphMol/ChemReactions/Reaction.h>
+#include <rdkit/GraphMol/ChemReactions/ReactionParser.h>
 #include <rdkit/GraphMol/SmilesParse/SmilesParse.h>
 #include <rdkit/GraphMol/SmilesParse/SmilesWrite.h>
 #include <rdkit/GraphMol/Substruct/SubstructMatch.h>
@@ -33,6 +35,7 @@
 #include "schrodinger/rdkit_extensions/monomer_mol.h" // ChainType
 #include "schrodinger/rdkit_extensions/monomer_db_schema.h"
 #include "schrodinger/rdkit_extensions/monomer_db_default_monomers.h"
+#include "schrodinger/rdkit_extensions/monomer_utils.h"
 #include "schrodinger/rdkit_extensions/stereochemistry.h"
 
 using managed_db_t = std::unique_ptr<sqlite3, decltype(&sqlite3_close_v2)>;
@@ -458,21 +461,57 @@ void insert_monomers_from_json(sqlite3* db, std::string_view json)
     execute_sql_on(db, "COMMIT;");
 }
 
+/// Generate a few common tautomers from a SMILES
+std::queue<boost::shared_ptr<RDKit::RWMol>>
+enumerate_tautomers(const std::string& smiles)
+{
+    using namespace RDKit::v2::SmilesParse;
+    using namespace RDKit::v2::ReactionParser;
+    const static SmilesParserParams p{.removeHs = false, .replacements = {}};
+
+    static auto rxns = []() {
+        std::vector<std::unique_ptr<RDKit::ChemicalReaction>> rxns;
+        // Just a few patterns cover most of the observed tautomer
+        // inconsistencies in ChEMBL, and applying them this way is much
+        // faster than using the RDKit tautomer canonicalizer. But this
+        // approach is still imperfect and incomplete.
+        for (auto smarts :
+             {"[nH:1]:[c;!$(*=*):2]:[n0:3]>>[nH0:1]:[c:2]:[nH:3]",
+              "[NH:1]-[C:2]=[NH:3]>>[NH0:1]=[C:2]-[NH2:3]",
+              "[NH2:1]-[C:2]=[NH0:3]>>[NH1:1]=[C:2]-[NH1:3]",
+              "[NH1:1]-[C:2]=[CH2:3]>>[NH0:1]=[C:2]-[CH3:3]",
+              "[NH0:1]=[C:2]-[CH3:3]>>[NH1:1]-[C:2]=[CH2:3]",
+              "[NH1:1]-[C:2]=[CH1:3]>>[NH0:1]=[C:2]-[CH2:3]",
+              "[NH0:1]=[C:2]-[CH2:3]-[*:4]>>[NH1:1]/[C:2]=[CH1:3]/[*:4]",
+              "[NH0:1]=[C:2]-[CH2:3]-[*:4]>>[NH1:1]/[C:2]=[CH1:3]\\[*:4]"}) {
+            rxns.push_back(ReactionFromSmarts(smarts));
+            rxns.back()->initReactantMatchers();
+        }
+        return rxns;
+    }();
+
+    std::queue<boost::shared_ptr<RDKit::RWMol>> q;
+    q.emplace(MolFromSmiles(smiles, p));
+    schrodinger::rdkit_extensions::neutralizeAtoms(*q.front());
+    for (auto& rxn : rxns) {
+        for (auto& prods : rxn->runReactants({q.front()})) {
+            q.push(boost::make_shared<RDKit::RWMol>(*prods[0]));
+        }
+    }
+    return q;
+}
+
 // Enumerates all possible SMILES variations by replacing atom map numbers
 // with either the mapped atom or a dummy atom (element 0)
 std::vector<std::string> enumerate_smiles(const std::string& smiles)
 {
     using namespace RDKit::v2::SmilesParse;
 
-    const static SmilesParserParams p{.removeHs = false, .replacements = {}};
-
     static RDKit::Atom dummy_atom(0);
 
     std::vector<std::string> enumerated_smiles;
 
-    std::queue<std::unique_ptr<RDKit::RWMol>> q;
-
-    q.emplace(MolFromSmiles(smiles, p));
+    auto q = enumerate_tautomers(smiles);
 
     while (!q.empty()) {
         auto mol = std::move(q.front());
@@ -1009,28 +1048,51 @@ boost::shared_ptr<RDKit::RWMol> make_query(const RDKit::ROMol& mol,
     return rwmol;
 }
 
-/// Return a map from atom index to attachment point number.
-std::vector<unsigned int> make_attch_map(const RDKit::ROMol& mol)
-{
-    // TODO: this duplicates parts of
-    // to_monomeric.cpp:prepare_static_mol_query() but it's not clear where to
-    // put such a utility function so that it can be called across translation
-    // units. It seemed out of place on monomer_database.h.
-    std::vector<unsigned int> attch_map(mol.getNumAtoms(), NO_ATTACHMENT);
-    for (const auto atom : mol.atoms()) {
-        if (atom->hasProp(RDKit::common_properties::molAtomMapNumber)) {
-            attch_map[atom->getIdx()] = atom->getProp<unsigned int>(
-                RDKit::common_properties::molAtomMapNumber);
-        }
-    }
-    return attch_map;
-}
-
 [[nodiscard]] const std::vector<ResidueQuery>&
 MonomerDatabase::getComplexMonomerQueries() const
 {
     using namespace RDKit::v2::SmilesParse;
-    static auto residue_query = MolFromSmarts("NCC(=O)[O,N]");
+    static auto residue_query = MolFromSmarts("N[C;H,H2]C(=O)[O,N]");
+
+    // Return the atom indices for the R1 and R2 attachment points (either
+    // one may be missing).
+    auto find_r1r2 = [](auto& mol) {
+        std::optional<unsigned int> r1;
+        std::optional<unsigned int> r2;
+        for (auto atom : mol.atoms()) {
+            switch (atom->getAtomMapNum()) {
+                case 1:
+                    r1 = atom->getIdx();
+                    break;
+                case 2:
+                    r2 = atom->getIdx();
+                    break;
+            }
+        }
+        return std::make_pair(r1, r2);
+    };
+
+    // Roughly: a monomer is complex unless it matches the residue_query
+    // pattern once and has r1 and r2 four bonds apart, or is tiny.
+    auto is_complex = [&](auto& mol) {
+        auto matches = SubstructMatch(mol, *residue_query);
+        if (matches.size() == 1) {
+            // Look at distance between mapping numbers
+            auto [r1, r2] = find_r1r2(mol);
+            if (r1 && r2) {
+                auto* dmat = RDKit::MolOps::getDistanceMat(mol);
+                auto d = dmat[*r1 * mol.getNumAtoms() + *r2];
+                // 4 is the number of bonds between attachment points in a
+                // standard aminoacid, i.e. [H:1]-N-C-C(-[O:2])=O
+                return d != 4;
+            }
+            return false;
+        } else {
+            // This is to to prevent treating things like [am] as complex.
+            return mol.getNumAtoms() > 4;
+        }
+    };
+
     if (!m_complex_monomer_queries.has_value()) {
         auto queries = std::vector<ResidueQuery>();
         RDKit::MatchVectType res;
@@ -1040,13 +1102,21 @@ MonomerDatabase::getComplexMonomerQueries() const
             std::unique_ptr<RDKit::RWMol> mol(
                 RDKit::SmilesToMol(smiles, debug, sanitize));
             RDKit::MolOps::sanitizeMol(*mol);
-            if (SubstructMatch(*mol, *residue_query).size() > 1) {
-                auto query = ResidueQuery{};
-                query.mol = make_query(*mol, smiles);
-                query.attch_map = make_attch_map(*query.mol);
-                query.name = symbol;
-                query.use_chirality = true;
-                queries.push_back(query);
+            if (is_complex(*mol)) {
+                for (auto q = enumerate_tautomers(smiles); !q.empty();
+                     q.pop()) {
+                    auto& tautomer = *q.front();
+                    auto query = ResidueQuery{};
+                    auto can_smiles = RDKit::MolToSmiles(tautomer);
+                    std::unique_ptr<RDKit::RWMol> can_tautomer(
+                        RDKit::SmilesToMol(can_smiles, debug, sanitize));
+                    RDKit::MolOps::sanitizeMol(*can_tautomer);
+                    query.mol = make_query(*can_tautomer, can_smiles);
+                    query.attch_map = make_attch_map(*query.mol);
+                    query.name = symbol;
+                    query.use_chirality = true;
+                    queries.push_back(query);
+                }
             }
         }
         m_complex_monomer_queries = std::move(queries);

--- a/src/schrodinger/rdkit_extensions/monomer_database.h
+++ b/src/schrodinger/rdkit_extensions/monomer_database.h
@@ -44,9 +44,6 @@ struct RDKIT_EXTENSIONS_API MonomerInfo {
     bool areRequiredFieldsPopulated() const;
 };
 
-inline constexpr unsigned int NO_ATTACHMENT =
-    std::numeric_limits<unsigned int>::max();
-
 struct RDKIT_EXTENSIONS_API ResidueQuery {
     /// Query molecule
     boost::shared_ptr<RDKit::RWMol> mol;

--- a/src/schrodinger/rdkit_extensions/monomer_utils.cpp
+++ b/src/schrodinger/rdkit_extensions/monomer_utils.cpp
@@ -1,0 +1,65 @@
+#include "schrodinger/rdkit_extensions/monomer_utils.h"
+
+#include <rdkit/GraphMol/RDKitBase.h>
+#include <rdkit/GraphMol/ROMol.h>
+#include <rdkit/GraphMol/RWMol.h>
+#include <rdkit/GraphMol/SmilesParse/SmilesParse.h>
+#include <rdkit/GraphMol/Substruct/SubstructMatch.h>
+
+#include <memory>
+
+namespace schrodinger
+{
+namespace rdkit_extensions
+{
+
+/// Return a map from atom index to attachment point number.
+std::vector<unsigned int> make_attch_map(const RDKit::ROMol& mol)
+{
+    std::vector<unsigned int> attch_map(mol.getNumAtoms(), NO_ATTACHMENT);
+    for (const auto atom : mol.atoms()) {
+        if (atom->hasProp(RDKit::common_properties::molAtomMapNumber)) {
+            attch_map[atom->getIdx()] = atom->getProp<unsigned int>(
+                RDKit::common_properties::molAtomMapNumber);
+        }
+    }
+    return attch_map;
+}
+
+void neutralizeAtoms(RDKit::ROMol& mol)
+{
+    // Algorithm for neutralizing molecules from
+    // https://www.rdkit.org/docs/Cookbook.html#neutralizing-molecules by Noel
+    // O’Boyle Will neutralize the molecule by adding or removing hydrogens as
+    // needed. This will ensure SMILES can be used to match atomistic structures
+    // to the correct monomer.
+    static const std::unique_ptr<RDKit::RWMol> neutralize_query(
+        RDKit::SmartsToMol(
+            "[+1!h0!$([*]~[-1,-2,-3,-4]),-1!$([*]~[+1,+2,+3,+4])]"));
+    for (const auto& match : RDKit::SubstructMatch(mol, *neutralize_query)) {
+        auto atom = mol.getAtomWithIdx(match[0].second);
+        auto chg = atom->getFormalCharge();
+        auto hcount = atom->getTotalNumHs();
+        atom->setFormalCharge(0);
+        atom->setNumExplicitHs(hcount - chg);
+        atom->updatePropertyCache();
+    }
+
+    // This query matches the dipole representation of sulfoxides, nitro, etc.
+    static const std::unique_ptr<RDKit::RWMol> dipole_query(
+        RDKit::SmartsToMol("[S+]-[O-]"));
+    for (const auto& match : RDKit::SubstructMatch(mol, *dipole_query)) {
+        auto a1 = mol.getAtomWithIdx(match[0].second);
+        auto a2 = mol.getAtomWithIdx(match[1].second);
+        a1->setFormalCharge(0);
+        a2->setFormalCharge(0);
+        auto b = mol.getBondBetweenAtoms(a1->getIdx(), a2->getIdx());
+        b->setBondType(RDKit::Bond::DOUBLE);
+        a1->updatePropertyCache();
+        a2->updatePropertyCache();
+        b->updatePropertyCache();
+    }
+}
+
+} // namespace rdkit_extensions
+} // namespace schrodinger

--- a/src/schrodinger/rdkit_extensions/monomer_utils.h
+++ b/src/schrodinger/rdkit_extensions/monomer_utils.h
@@ -1,0 +1,29 @@
+/// This file contains utility functions used in more than one translation unit
+/// related to monomer conversion etc., but which are not meant as part of the
+/// public (Python) API.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "schrodinger/rdkit_extensions/definitions.h"
+
+#include <rdkit/GraphMol/ROMol.h>
+
+namespace schrodinger
+{
+namespace rdkit_extensions
+{
+
+inline constexpr unsigned int NO_ATTACHMENT =
+    std::numeric_limits<unsigned int>::max();
+
+/// Return the atom map number for each atom in the molecule, with a default
+/// of NO_ATTACHMENT for atoms without a map number.
+[[nodiscard]] std::vector<unsigned int> make_attch_map(const RDKit::ROMol& mol);
+
+void neutralizeAtoms(RDKit::ROMol& mol);
+
+} // namespace rdkit_extensions
+} // namespace schrodinger

--- a/src/schrodinger/rdkit_extensions/to_monomeric.cpp
+++ b/src/schrodinger/rdkit_extensions/to_monomeric.cpp
@@ -22,6 +22,7 @@
 
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
+#include "schrodinger/rdkit_extensions/monomer_utils.h"
 #include "schrodinger/rdkit_extensions/helm.h"
 #include "schrodinger/rdkit_extensions/molops.h"
 #include "schrodinger/rdkit_extensions/sup_utils.h"
@@ -72,17 +73,7 @@ ResidueQuery prepare_static_mol_query(const char* smarts_query,
     query.mol.reset(RDKit::SmartsToMol(smarts_query));
     query.name = std::move(name);
     query.use_chirality = false;
-
-    // Maps SMARTS query index to attachment point # to avoid checking the
-    // property for every match
-    query.attch_map.resize(query.mol->getNumAtoms(), NO_ATTACHMENT);
-
-    for (const auto atom : query.mol->atoms()) {
-        if (atom->hasProp(RDKit::common_properties::molAtomMapNumber)) {
-            query.attch_map[atom->getIdx()] = atom->getProp<unsigned int>(
-                RDKit::common_properties::molAtomMapNumber);
-        }
-    }
+    query.attch_map = make_attch_map(*query.mol);
     return query;
 };
 
@@ -90,13 +81,13 @@ ResidueQuery prepare_static_mol_query(const char* smarts_query,
 // attachment points 1 and 2 are backbone attachment points,
 // 8 is the side chain attachment point, 3 is cysteine's sulfur
 static const ResidueQuery CYSTEINE_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+;!$(NC(=O)N):1][CX4H]([CX4H2][S:3])[CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H]([CX4H2][S:3])[CX3:2](=[OX1])[O,N:9]",
     "CYSTEINE")}; // matches C, dC, meC
 static const ResidueQuery GENERIC_AMINO_ACID_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+;!$(NC(=O)N):1][CX4H]([*:8])[CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H]([*:8])[CX3:2](=[OX1])[O,N:9]",
     "GENERIC")};
 static const ResidueQuery GLYCINE_AMINO_ACID_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+;!$(NC(=O)N):1][CX4H2][CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H2][CX3:2](=[OX1])[O,N:9]",
     "GLYCINE")}; // no side chain
 // clang-format on
 
@@ -167,17 +158,19 @@ void addDummyAtom(RDKit::RWMol& mol_fragment, unsigned int atom_idx)
 // Add dummy atoms next to the attachment points and remove the terminal
 // atom to make a fragment representation of a monomer suitable for search
 // in the database.
-void decorateFragment(RDKit::RWMol& mol_fragment, const MonomerMatch& monomer)
+void decorateFragment(RDKit::RWMol& mol_fragment, const MonomerMatch& monomer,
+                      bool with_r1 = true, bool remove_terminal = true)
 {
     mol_fragment.beginBatchEdit();
     for (auto* at : mol_fragment.atoms()) {
         auto at_idx = at->getIdx();
         auto ref_idx = at->getProp<unsigned int>(REFERENCE_IDX);
-        if (ref_idx == monomer.terminal_atom) {
+        if (remove_terminal && ref_idx == monomer.terminal_atom) {
             // This is a chain terminating O/N. We need to remove it, since
             // in the enumeration we replace these with dummy atoms
             mol_fragment.removeAtom(at_idx);
-        } else if (ref_idx == monomer.r1 || ref_idx == monomer.r2 ||
+        } else if ((with_r1 && ref_idx == monomer.r1) ||
+                   (remove_terminal && ref_idx == monomer.r2) ||
                    ref_idx == monomer.r3) {
             addDummyAtom(mol_fragment, at_idx);
         }
@@ -217,10 +210,17 @@ std::optional<std::string> findHelmSymbol(const RDKit::ROMol& atomistic_mol,
     PRINT("  rs: {} {} {} {}\n", monomer.r1, monomer.r2, monomer.r3,
           monomer.terminal_atom);
 
-    auto mol_fragment =
-        ExtractMolFragment(atomistic_mol, monomer.atom_indices, false);
-    decorateFragment(*mol_fragment, monomer);
-    return findHelmSymbol(*mol_fragment);
+    for (bool with_r1 : {true, false}) {
+        for (bool remove_terminal : {true, false}) {
+            auto mol_fragment =
+                ExtractMolFragment(atomistic_mol, monomer.atom_indices, false);
+            decorateFragment(*mol_fragment, monomer, with_r1, remove_terminal);
+            if (auto symbol = findHelmSymbol(*mol_fragment); symbol) {
+                return symbol;
+            }
+        }
+    }
+    return {};
 }
 
 /*
@@ -1100,26 +1100,6 @@ void identifyMonomers(RDKit::RWMol& atomistic_mol,
             throw std::runtime_error(fmt::format(
                 "Atom {} does not belong to any monomer", atom->getIdx()));
         }
-    }
-}
-
-void neutralizeAtoms(RDKit::ROMol& mol)
-{
-    // Algorithm for neutralizing molecules from
-    // https://www.rdkit.org/docs/Cookbook.html#neutralizing-molecules by Noel
-    // O’Boyle Will neutralize the molecule by adding or removing hydrogens as
-    // needed. This will ensure SMILES can be used to match atomistic structures
-    // to the correct monomer.
-    static const std::unique_ptr<RDKit::RWMol> neutralize_query(
-        RDKit::SmartsToMol(
-            "[+1!h0!$([*]~[-1,-2,-3,-4]),-1!$([*]~[+1,+2,+3,+4])]"));
-    for (const auto& match : RDKit::SubstructMatch(mol, *neutralize_query)) {
-        auto atom = mol.getAtomWithIdx(match[0].second);
-        auto chg = atom->getFormalCharge();
-        auto hcount = atom->getTotalNumHs();
-        atom->setFormalCharge(0);
-        atom->setNumExplicitHs(hcount - chg);
-        atom->updatePropertyCache();
     }
 }
 


### PR DESCRIPTION
* Linked Case: SHARED-12177

### Description

This is just a cherry pick of the mmshare commit below (excluding SWIG changes and Python unit tests)

### Testing done

Build with unit tests.

### Original description

The key change here is the enumerate_tautomers() function, which is used both when generating the core SMILES lookup table for all monomers, and when generating the query molecules for the complex monomers. It is a rudimentary implementation that only handles some common imine-enamine and imidazole tautomerisms, but it is good enough to bring our success rate at generating SMILES-free HELM strings from ChEMBL from 66.7% to 96.4%, while being much faster than the RDKit tautomer canonicalizer with default settings, which was our previous, unsuccessful attempt. Still, this is a work in progress.

There were a few other changes which may seem random, but all are related with improving monomer recognition.

- neutralizeAtoms() now also standardizes the representation of sulfoxides as neutral S=O.
- changed the definition of "complex monomer" to include monomers that match the generic residue pattern only once but have the two attachment points unusually apart (!= 4 bonds)
    - also, allow the pattern to match alpha-disubstituted amino acids
- removed the urea exception from the generic amino acide SMARTS, because those are now handled by the more general complex monomer mechanism
- added a fallback to findHelmSymbol(): if there is no match, try again without removing the terminal atom and/or the R1 attachment point. The reason is that ChEMBL has many custom monomers that lack one or the other even though the SMARTS pattern would match them (typically, N- or O-substituted amino acids that are meant to be terminal)

Incidental changes:
- added a couple of missing SWIG wrappers
- moved a couple of "private" functions that were needed from one than one translation unit to the new monomer_utils.cpp

