### PR TITLE
SKETCH-2726: Replacing unneeded import in monomer_database.h with forward declaration to prevent Sketcher linker errors

### DIFF
--- a/src/schrodinger/rdkit_extensions/monomer_database.h
+++ b/src/schrodinger/rdkit_extensions/monomer_database.h
@@ -11,12 +11,17 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/filesystem/path.hpp>
-#include <rdkit/GraphMol/ROMol.h>
+#include <boost/shared_ptr.hpp>
 
 struct sqlite3;
 
 inline constexpr std::string_view CUSTOM_MONOMER_DB_PATH_ENV_VAR =
     "SCHRODINGER_CUSTOM_MONOMER_DB_PATH";
+
+namespace RDKit
+{
+class RWMol;
+}
 
 namespace schrodinger
 {


### PR DESCRIPTION
* Linked Case: SKETCH-2726

### Description
When I try to run buildinger on my Windows machine, I get the following errors
```
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual class RDGeom::Point * __cdecl RDGeom::Point3D::copy(void)const " (?copy@Point3D@RDGeom@@UEBAPEAVPoint@2@XZ)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual unsigned int __cdecl RDGeom::Point3D::dimension(void)const " (?dimension@Point3D@RDGeom@@UEBAIXZ)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual double __cdecl RDGeom::Point3D::operator[](unsigned int)const " (??APoint3D@RDGeom@@UEBANI@Z)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual double & __cdecl RDGeom::Point3D::operator[](unsigned int)" (??APoint3D@RDGeom@@UEAAAEANI@Z)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl RDGeom::Point3D::normalize(void)" (?normalize@Point3D@RDGeom@@UEAAXXZ)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual double __cdecl RDGeom::Point3D::length(void)const " (?length@Point3D@RDGeom@@UEBANXZ)
main.cpp.obj : error LNK2001: unresolved external symbol "public: virtual double __cdecl RDGeom::Point3D::lengthSq(void)const " (?lengthSq@Point3D@RDGeom@@UEBANXZ)
main.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual __cdecl RDGeom::Point3D::~Point3D(void)" (__imp_??1Point3D@RDGeom@@UEAA@XZ) referenced in function "public: virtual void * __cdecl RDGeom::Point3D::`scalar deleting destructor'(unsigned int)" (??_GPoint3D@RDGeom@@UEAAPEAXI@Z)
sketcher_app\schrodinger_sketcher.exe : fatal error LNK1120: 8 unresolved externals
```
The GitHub builders don't seem to be running into these issues, so I'm assuming it's buildinger-only.  The fact that it involves external symbols makes me assume that it's Windows-only, since Windows defaults to a much more restrictive behavior than do other platforms.

Jarrett fed the issues into Claude, and Claude correctly identified the culprit as a new
```cpp
#include <rdkit/GraphMol/ROMol.h>
```
line in monomer_database.h, which brings in the `Point3D` class to consumers of `rdkit_extensions`.  I've now replaced that include with a forward declaration, which fixes the issue and thankfully still builds, despite the header containing a `boost::shared_ptr<RDKit::RWMol>` declaration.

Interestingly, I'm not having any issues with mmshare builds, despite mmshare containing the same include.  Presumably, there are some differences in the mmshare build process related to linking rdkit_extensions in to the executables.

### Testing Done
Local Windows build now works.
