### PR TITLE
SKETCH-2728: Adding fallback font names to generated SVG files

### DIFF
--- a/src/schrodinger/sketcher/image_generation.cpp
+++ b/src/schrodinger/sketcher/image_generation.cpp
@@ -383,6 +383,43 @@ QImage get_qimage(const T& input, const RenderOptions& opts)
     return *dynamic_cast<QImage*>(paint_device.get());
 }
 
+/**
+ * Post-process the contents of the SVG file after Qt has generated it
+ * @param svg_data The contents of the SVG file
+ * @param opts The options used to render the SVG
+ */
+void post_process_svg(QByteArray& svg_data, const RenderOptions& opts)
+{
+    // Qt defines svg size in mm, but our code needs it specified in pixels.
+    // This is a hack to make sure we get the right size definition.
+    auto start_of_size = svg_data.indexOf("svg width");
+    auto end_of_size = svg_data.indexOf(" viewBox", start_of_size);
+    if (start_of_size == -1 || end_of_size == -1) {
+        throw std::runtime_error("Failed to find svg size definition");
+    }
+    svg_data.remove(start_of_size, end_of_size - start_of_size);
+    auto height_in_pxls = QString("svg width=\"%1px\" height=\"%2px\"\n")
+                              .arg(opts.width_height.width())
+                              .arg(opts.width_height.height());
+
+    svg_data.insert(start_of_size, height_in_pxls.toUtf8());
+
+    // Remove Qt's default title and description elements for cleaner SVG
+    QString svg_string = QString::fromUtf8(svg_data);
+    svg_string.remove("<title>Qt SVG Document</title>\n");
+    svg_string.remove("<desc>Generated with Qt</desc>\n");
+
+    // make sure that the SVG specifies a list of fonts, since most people won't
+    // have Arimo installed system-wide
+    const QString svg_font_spec = R"(font-family="%1")";
+    auto font_spec_before = svg_font_spec.arg(FONT_NAME);
+    auto font_spec_after = svg_font_spec.arg(SVG_FONT_LIST.join(", "));
+    svg_string.replace(font_spec_before, font_spec_after, Qt::CaseInsensitive);
+
+    // put our edited data back into the byte array
+    svg_data = svg_string.toUtf8();
+}
+
 template <typename T> QByteArray
 get_image_bytes(const T& input, ImageFormat format, const RenderOptions& opts)
 {
@@ -405,27 +442,7 @@ get_image_bytes(const T& input, ImageFormat format, const RenderOptions& opts)
         std::shared_ptr<QBuffer> svg_buffer;
         svg_buffer.reset(dynamic_cast<QBuffer*>(svg_gen->outputDevice()));
         auto svg_data = svg_buffer->data();
-
-        // Qt defines svg size in mm, but our code needs it specified in pixels.
-        // This is a hack to make sure we get the right size definition.
-        auto start_of_size = svg_data.indexOf("svg width");
-        auto end_of_size = svg_data.indexOf(" viewBox", start_of_size);
-        if (start_of_size == -1 || end_of_size == -1) {
-            throw std::runtime_error("Failed to find svg size definition");
-        }
-        svg_data.remove(start_of_size, end_of_size - start_of_size);
-        auto height_in_pxls = QString("svg width=\"%1px\" height=\"%2px\"\n")
-                                  .arg(opts.width_height.width())
-                                  .arg(opts.width_height.height());
-
-        svg_data.insert(start_of_size, height_in_pxls.toUtf8());
-
-        // Remove Qt's default title and description elements for cleaner SVG
-        QString svg_string = QString::fromUtf8(svg_data);
-        svg_string.remove("<title>Qt SVG Document</title>\n");
-        svg_string.remove("<desc>Generated with Qt</desc>\n");
-        svg_data = svg_string.toUtf8();
-
+        post_process_svg(svg_data, opts);
         buffer.setData(svg_data);
         svg_buffer->close();
 

--- a/src/schrodinger/sketcher/molviewer/constants.h
+++ b/src/schrodinger/sketcher/molviewer/constants.h
@@ -66,7 +66,14 @@ const qreal CURSOR_SCALE = 0.8;
 const qreal CURSOR_SCALE = 1.0;
 #endif
 
+// The name of the font used in Sketcher. This should match the font loaded in
+// font_loader.
 const QString FONT_NAME = "Arimo";
+// The list of font names to reference in any generated SVG files. This list
+// should include fallback fonts in case the user doesn't have FONT_NAME
+// installed on their system.
+const QStringList SVG_FONT_LIST = {"Arimo", "Helvetica", "Arial", "sans-serif"};
+
 // Ratios for the size of specified font to the size of the atom label font.
 // Note that the atom label font size is declared in the public image_constants
 // header (mmshare/include/schrodinger/sketcher/image_constants.h) because it

--- a/test/schrodinger/sketcher/test_image_generation.cpp
+++ b/test/schrodinger/sketcher/test_image_generation.cpp
@@ -230,9 +230,10 @@ BOOST_AUTO_TEST_CASE(test_trim_image)
 }
 
 /**
- * Verify that Qt's default title and description elements are removed from SVG
+ * Verify that Qt's default title and description elements are removed from SVG,
+ * and that the font specifications are updated to include fallback fonts
  */
-BOOST_AUTO_TEST_CASE(test_SVG_title_and_description)
+BOOST_AUTO_TEST_CASE(test_SVG_post_processing)
 {
     auto rdmol = rdkit_extensions::to_rdkit("c1nccc2n1ccc2");
     RenderOptions opts;
@@ -249,6 +250,10 @@ BOOST_AUTO_TEST_CASE(test_SVG_title_and_description)
     BOOST_TEST(!svg.contains("</desc>"));
     BOOST_TEST(!svg.contains("Qt SVG Document"));
     BOOST_TEST(!svg.contains("Generated with Qt"));
+
+    // make sure that we specify fallback fonts
+    BOOST_TEST(
+        svg.contains(R"(font-family="Arimo, Helvetica, Arial, sans-serif")"));
 }
 
 /**


### PR DESCRIPTION
* Linked Case: SKETCH-2728, SKETCH-2682, LDID8-1488

### Description

@rachelnwalker finally figured out why the images in Live Design's first column aren't using the correct font: those images are rendered as SVGs, which means that the font will only be correct if the user has Arimo installed as a system-wide font.  If not, the web browser doesn't know enough about Arimo to even know that it's sans serif, so it winds up replacing it with a serif font.  To fix this, I've added a list of fallback fonts, including Arial and Helvetica, to the SVG file.  We're only including the font name in the SVG file, not the font itself, so we don't need to worry about font licensing.  With this change, the generated SVGs look correct if I open them up in my web browser, and @juzerzarif confirmed that he sees the same thing.

My first attempt at this was to specify the alternate fonts as QFont families, but QSvgGenerator ignores these.  (I checked in the Qt source code and confirmed that's the expected, but unfortunate, behavior.)  As a result, I added some logic to our SVG post processing to manually add in the additional font names.

I'm assuming that we'll want to add this commit to the release branch in both `sketcher` and `mmshare`.  I don't think I have permissions to merge a PR directly into the release branch on `sketcher`, but I can cherry-pick and manually push after this gets merged into `main`.  When I put up an `mmshare` PR, I'll do that against the release branch so it can go through engineering approval.

### Testing Done
I saved an SVG from Sketcher and confirmed that it looks correct.  I also updated the SVG unit test to include a check for the font list.
