### PR TITLE
SKETCH-2483: Fixing HELM string output for drawn structures and adding integration tests

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -2719,10 +2719,14 @@ inline RDGeom::Point3D get_monomer_size(const RDKit::ROMol& mol,
                                         unsigned int index)
 {
     RDGeom::Point3D size(MONOMER_MINIMUM_SIZE, MONOMER_MINIMUM_SIZE, 0);
-
-    mol.getAtomWithIdx(index)->getPropIfPresent<RDGeom::Point3D>(
-        MONOMER_ITEM_SIZE, size);
-
+    auto* atom = mol.getAtomWithIdx(index);
+    try {
+        atom->getPropIfPresent<RDGeom::Point3D>(MONOMER_ITEM_SIZE, size);
+    } catch (const std::bad_any_cast&) {
+        // getPropIfPresent sometimes leaks an exception to the caller, so use
+        // the default size when that happens
+        return {MONOMER_MINIMUM_SIZE, MONOMER_MINIMUM_SIZE, 0};
+    }
     return size;
 }
 

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -658,10 +658,10 @@ void MolModel::addAttachmentPoint(const RDGeom::Point3D& coords,
  */
 static std::shared_ptr<RDKit::Atom>
 create_monomer(const std::string_view res_name, const std::string_view chain_id,
-               const int residue_number)
+               const int res_num)
 {
     auto monomer_unique_ptr =
-        rdkit_extensions::makeMonomer(res_name, chain_id, 1, false);
+        rdkit_extensions::makeMonomer(res_name, chain_id, res_num, false);
     std::shared_ptr<RDKit::Atom> monomer;
     monomer.reset(monomer_unique_ptr.release());
     set_atom_monomeric(monomer.get());
@@ -672,9 +672,7 @@ void MolModel::addMonomer(const std::string_view res_name,
                           const rdkit_extensions::ChainType chain_type,
                           const RDGeom::Point3D& coords)
 {
-    // we'll renumber the chains in assignChains, so for now we just need
-    // something with the correct prefix and a unique number
-    auto chain_id = rdkit_extensions::toString(chain_type) + "999999";
+    auto chain_id = get_first_available_chain_name(m_mol, chain_type);
     auto create_atom = std::bind(create_monomer, res_name, chain_id, 1);
     auto cmd_func = [this, create_atom, coords]() {
         addAtomChainCommandFunc(create_atom, {coords}, make_new_single_bond,
@@ -815,13 +813,12 @@ void MolModel::addBoundMonomer(const std::string_view res_name,
                                const RDKit::Atom* const bound_to_monomer,
                                const std::string_view bound_to_monomer_ap_name)
 {
-    auto chain_id = rdkit_extensions::get_polymer_id(bound_to_monomer);
-    auto res_num = get_residue_number_for_new_monomer(
-        res_name, chain_type, new_monomer_ap_name, bound_to_monomer);
-    auto create_atom = std::bind(create_monomer, res_name, chain_id, res_num);
-
     auto [linkage, flip_monomer_order] =
         build_linkage_string(bound_to_monomer_ap_name, new_monomer_ap_name);
+    // To standardize the linkage string, make sure that the higher numbered
+    // attachment point is first. rdkit_extensions::addConnection will do this
+    // flip for us, but we do it here anyway since it allows us to simplify
+    // get_is_custom_bond
     size_t bond_start_idx = bound_to_monomer->getIdx();
     size_t bond_end_idx = m_mol.getNumAtoms();
     if (flip_monomer_order) {
@@ -829,6 +826,22 @@ void MolModel::addBoundMonomer(const std::string_view res_name,
     }
     bool is_custom_bond =
         get_is_custom_bond(res_name, chain_type, bound_to_monomer, linkage);
+
+    std::string chain_id;
+    int res_num;
+    if (!is_custom_bond) {
+        // if this is a standard backbone connection, put the new monomer in the
+        // same chain as bound_to_monomer
+        chain_id = rdkit_extensions::get_polymer_id(bound_to_monomer);
+        res_num = get_residue_number_for_new_monomer(
+            res_name, chain_type, new_monomer_ap_name, bound_to_monomer);
+    } else {
+        // otherwise, put the new monomer in its own chain
+        chain_id = get_first_available_chain_name(m_mol, chain_type);
+        res_num = 1;
+    }
+
+    auto create_atom = std::bind(create_monomer, res_name, chain_id, res_num);
 
     auto cmd_func = [this, create_atom, coords, bond_start_idx, bond_end_idx,
                      linkage, is_custom_bond]() {
@@ -890,11 +903,8 @@ determine_if_merge_needed(const RDKit::Atom* const monomer_one,
     if (polymer_id_one == polymer_id_two) {
         return std::nullopt;
     }
-    auto chain_type_name = rdkit_extensions::toString(chain_type_one);
-    auto polymer_num_one =
-        std::stoi(polymer_id_one.substr(chain_type_name.size()));
-    auto polymer_num_two =
-        std::stoi(polymer_id_two.substr(chain_type_name.size()));
+    auto polymer_num_one = get_chain_num(polymer_id_one, chain_type_one);
+    auto polymer_num_two = get_chain_num(polymer_id_two, chain_type_two);
     auto merge_from = polymer_id_two;
     auto merge_to = polymer_id_one;
     if (polymer_num_two < polymer_num_one) {

--- a/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
@@ -69,7 +69,7 @@ static QPainterPath calculate_hover_area(QRectF ap_bounding_rect,
  * @param dir The direction
  * @return vector pointing in that direction
  */
-static QPointF direction_to_qt_vector(Direction dir)
+QPointF direction_to_qt_vector(Direction dir)
 {
     auto mol_vec = rdkit_extensions::direction_to_vector(dir);
     return QPointF(mol_vec.x, -mol_vec.y);

--- a/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h
+++ b/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h
@@ -35,6 +35,15 @@ get_hover_area_for_unbound_monomer_attachment_point_item(
     const AbstractMonomerItem* const parent_monomer, const Fonts& fonts);
 
 /**
+ * Convert a Direction to a vector in Qt coordinates. Vectors in cardinal
+ * directions will be 1 unit long, and vectors in diagonal directions will have
+ * positive or negative 1 for their X and Y coordinates. (I.e. they'll be
+ * slightly longer that the cardinal vectors.) Note that in Qt coordinates, +X
+ * is right and +Y is down (unlike RDKit coordinates).
+ */
+SKETCHER_API QPointF direction_to_qt_vector(Direction dir);
+
+/**
  * A graphics item for representing an unbound (available) attachment point
  * on a monomer. Draws a short line extending from the monomer with a text
  * label indicating the attachment point name.

--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <numeric>
 #include <optional>
+#include <string>
 
 #include <boost/range/join.hpp>
 
@@ -783,6 +784,44 @@ void merge_chains(RDKit::ROMol& mol, const std::string_view merge_from,
         res_info->setChainId(merge_to);
         res_info->setResidueNumber(++new_res_num);
     }
+}
+
+int get_chain_num(const std::string_view chain_name,
+                  const rdkit_extensions::ChainType chain_type)
+{
+    auto prefix = rdkit_extensions::toString(chain_type);
+    auto first_num_char = prefix.size();
+    if (chain_name.substr(0, first_num_char) != prefix) {
+        return -1;
+    }
+    auto chain_num_text = chain_name.substr(first_num_char);
+    try {
+        return std::stoi(std::string(chain_num_text));
+    } catch (const std::invalid_argument&) {
+        return -1;
+    } catch (const std::out_of_range&) {
+        return -1;
+    }
+}
+
+std::string
+get_first_available_chain_name(const RDKit::ROMol& mol,
+                               const rdkit_extensions::ChainType chain_type)
+{
+    auto prefix = rdkit_extensions::toString(chain_type);
+    std::unordered_set<int> chain_nums;
+    for (auto chain_name : rdkit_extensions::get_polymer_ids(mol)) {
+        if (!chain_name.starts_with(prefix)) {
+            continue;
+        }
+        int cur_chain_num = get_chain_num(chain_name, chain_type);
+        chain_nums.insert(cur_chain_num);
+    }
+    int missing_num = 1;
+    while (chain_nums.contains(missing_num)) {
+        ++missing_num;
+    }
+    return fmt::format("{}{}", prefix, missing_num);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -10,6 +10,7 @@
 #include <Qt>
 
 #include "schrodinger/rdkit_extensions/monomer_directions.h"
+#include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/sketcher/definitions.h"
 
 class QGraphicsItem;
@@ -241,6 +242,26 @@ SKETCHER_API int ap_name_to_num(const std::string_view attachment_point_name);
 SKETCHER_API void merge_chains(RDKit::ROMol& mol,
                                const std::string_view merge_from,
                                const std::string& merge_to);
+
+/**
+ * Return the numeric component of the chain name as an integer, e.g. 3 for
+ * "PEPTIDE3". If the chain name cannot be parsed, -1 will be returned.
+ * @param chain_name the chain name to parse
+ * @param chain_type the type of chain_name
+ */
+SKETCHER_API int get_chain_num(const std::string_view chain_name,
+                               const rdkit_extensions::ChainType chain_type);
+
+/**
+ * @return the lowest numbered chain name (of the specified type) that doesn't
+ * already exist in the molecule. For example, if a molecule already has
+ * "PEPTIDE1" and "PEPTIDE2" chains, "PEPTIDE3" will be returned when
+ * ChainType::PEPTIDE is passed in. Alternatively, "RNA1" would be returned if
+ * ChainType::RNA was passed in.
+ */
+SKETCHER_API std::string
+get_first_available_chain_name(const RDKit::ROMol& mol,
+                               const rdkit_extensions::ChainType chain_type);
 
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -44,7 +44,7 @@ using rdkit_extensions::Direction;
  * click-and-drags from a monomer)
  */
 struct HintFragmentMonomerInfo {
-    RDKit::Atom* monomer;
+    std::unique_ptr<RDKit::Atom> monomer;
     MonomerType monomer_type;
     RDGeom::Point3D pos;
     // the model name of this monomer's attachment point that's connected to the
@@ -597,34 +597,36 @@ void DrawMonomerSceneTool::drawBoundMonomerHintFor(
 }
 
 void DrawMonomerSceneTool::createHintFragmentItem(
-    const HintFragmentMonomerInfo& monomer_one_info,
-    const HintFragmentMonomerInfo& monomer_two_info)
+    HintFragmentMonomerInfo& monomer_one_info,
+    HintFragmentMonomerInfo& monomer_two_info)
 {
-    m_frag = std::make_shared<RDKit::RWMol>();
-    m_frag->setProp(HELM_MODEL, true);
+    auto frag = std::make_shared<RDKit::RWMol>();
+    frag->setProp(HELM_MODEL, true);
 
     // create the two monomers
-    auto first_idx = m_frag->addAtom(monomer_one_info.monomer, true, true);
-    auto second_idx = m_frag->addAtom(monomer_two_info.monomer, true, true);
+    auto first_idx =
+        frag->addAtom(monomer_one_info.monomer.release(), true, true);
+    auto second_idx =
+        frag->addAtom(monomer_two_info.monomer.release(), true, true);
 
     // create the connection between them
     auto linkage = fmt::format("{}-{}", monomer_one_info.ap_model_name,
                                monomer_two_info.ap_model_name);
-    rdkit_extensions::addConnection(*m_frag, first_idx, second_idx, linkage);
+    rdkit_extensions::addConnection(*frag, first_idx, second_idx, linkage);
     auto bond_index_to_label =
-        m_frag->getBondBetweenAtoms(first_idx, second_idx)->getIdx();
+        frag->getBondBetweenAtoms(first_idx, second_idx)->getIdx();
 
     // flag the atoms as monomeric
-    for (auto* atom : m_frag->atoms()) {
+    for (auto* atom : frag->atoms()) {
         set_atom_monomeric(atom);
     }
 
     // Add a conformer with the atom coordinates
-    auto* frag_conf = new RDKit::Conformer(m_frag->getNumAtoms());
+    auto* frag_conf = new RDKit::Conformer(frag->getNumAtoms());
     frag_conf->set3D(false);
     frag_conf->setAtomPos(first_idx, monomer_one_info.pos);
     frag_conf->setAtomPos(second_idx, monomer_two_info.pos);
-    m_frag->addConformer(frag_conf, true);
+    frag->addConformer(frag_conf, true);
 
     // hide the monomers that already exist in the Scene
     std::vector<size_t> atom_indices_to_hide;
@@ -636,7 +638,7 @@ void DrawMonomerSceneTool::createHintFragmentItem(
     }
 
     m_hint_fragment_item = new MonomerHintFragmentItem(
-        m_frag, m_fonts, atom_indices_to_hide, bond_index_to_label,
+        frag, m_fonts, atom_indices_to_hide, bond_index_to_label,
         m_monomer_background_color);
     m_scene->addItem(m_hint_fragment_item);
 }
@@ -658,9 +660,9 @@ DrawMonomerSceneTool::createHintFragmentMonomerInfoForHintFromEmptySpace(
     auto monomer_pos = to_mol_xy(scene_pos);
     auto linkage_start = getDefaultDragStartAPModelName();
     // returned monomer is owned by the calling scope
-    return HintFragmentMonomerInfo(monomer.release(), m_monomer_type,
+    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type,
                                    monomer_pos, linkage_start,
-                                   NEW_MONOMER_FROM_DRAG);
+                                   NEW_MONOMER_FROM_DRAG};
 }
 
 HintFragmentMonomerInfo DrawMonomerSceneTool::
@@ -670,10 +672,11 @@ HintFragmentMonomerInfo DrawMonomerSceneTool::
 {
     auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
     // returned monomer is owned by the calling scope
-    auto copy_of_monomer = new RDKit::Atom(*monomer);
+    auto copy_of_monomer = std::make_unique<RDKit::Atom>(*monomer);
     auto monomer_pos = get_coords_for_monomer(monomer);
-    return HintFragmentMonomerInfo(copy_of_monomer, monomer_type, monomer_pos,
-                                   ap_model_name, monomer->getIdx());
+    auto monomer_idx = static_cast<int>(monomer->getIdx());
+    return HintFragmentMonomerInfo{std::move(copy_of_monomer), monomer_type,
+                                   monomer_pos, ap_model_name, monomer_idx};
 }
 
 HintFragmentMonomerInfo DrawMonomerSceneTool::
@@ -704,8 +707,8 @@ DrawMonomerSceneTool::createHintFragmentMonomerInfoForHintToDirection(
     auto ap_model_name = get_attachment_point_for_new_monomer(
         start_monomer_info.monomer_type, start_monomer_info.ap_model_name,
         m_monomer_type);
-    return HintFragmentMonomerInfo(monomer.release(), m_monomer_type, pos,
-                                   ap_model_name, NEW_MONOMER_FROM_DRAG);
+    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type, pos,
+                                   ap_model_name, NEW_MONOMER_FROM_DRAG};
 }
 
 void DrawMonomerSceneTool::onLeftButtonClick(
@@ -1093,7 +1096,6 @@ void DrawMonomerSceneTool::clearHintFragmentItem()
 {
     delete m_hint_fragment_item;
     m_hint_fragment_item = nullptr;
-    m_frag.reset();
 }
 
 void DrawMonomerSceneTool::clearDragEndAttachmentPointsLabels()

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -98,7 +98,6 @@ class SKETCHER_API DrawMonomerSceneTool : public StandardSceneToolBase
     const UnboundMonomericAttachmentPointItem* m_hovered_ap_item = nullptr;
     std::vector<UnboundMonomericAttachmentPointItem*> m_unbound_ap_items;
     MonomerHintFragmentItem* m_hint_fragment_item = nullptr;
-    std::shared_ptr<RDKit::RWMol> m_frag = nullptr;
     QColor m_monomer_background_color = LIGHT_BACKGROUND_COLOR;
     QColor m_unbound_ap_label_color = UNBOUND_AP_LABEL_COLOR;
     QColor m_bound_ap_label_color = BOUND_AP_LABEL_COLOR;
@@ -292,10 +291,12 @@ class SKETCHER_API DrawMonomerSceneTool : public StandardSceneToolBase
 
     /**
      * Create a hint fragment containing the two specified monomers and the
-     * connection between them, then add this hint fragment to the scene.
+     * connection between them, then add this hint fragment to the scene. Note
+     * that this function will transfer ownership of the monomers themselves to
+     * RDKit.
      */
-    void createHintFragmentItem(const HintFragmentMonomerInfo& monomer_one,
-                                const HintFragmentMonomerInfo& monomer_two);
+    void createHintFragmentItem(HintFragmentMonomerInfo& monomer_one,
+                                HintFragmentMonomerInfo& monomer_two);
 
     /**
      * If the user has started a "valid" click-and-drag operation, create the

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -71,6 +71,7 @@ static auto no_r_group_num = std::nullopt;
 BOOST_TEST_DONT_PRINT_LOG_VALUE(r_group_num_t);
 BOOST_TEST_DONT_PRINT_LOG_VALUE(decltype(no_r_group_num));
 
+using schrodinger::rdkit_extensions::ChainType;
 using schrodinger::rdkit_extensions::Format;
 
 namespace schrodinger
@@ -4528,6 +4529,42 @@ BOOST_AUTO_TEST_CASE(test_addBoundMonomer)
 }
 
 /**
+ * Use addBoundMonomer to extend a peptide chain in the opposite direction,
+ * building from C terminus to N terminus. We also add a side chain interaction
+ * to a new chain and confirm that the new chain remains separate
+ */
+BOOST_AUTO_TEST_CASE(test_addBoundMonomer_N_terminus)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+
+    model.addMonomer("A", ChainType::PEPTIDE, {0.0, 0.0, 0.0});
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{A}$$$$V2.0");
+
+    auto ala_monomer = model.getMol()->getAtomWithIdx(0);
+    model.addBoundMonomer("C", ChainType::PEPTIDE, {-50.0, 0.0, 0.0}, "R2",
+                          ala_monomer, "R1");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{C.A}$$$$V2.0");
+
+    auto cys_monomer = model.getMol()->getAtomWithIdx(1);
+    model.addBoundMonomer("F", ChainType::PEPTIDE, {-100.0, 0.0, 0.0}, "R2",
+                          cys_monomer, "R1");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{F.C.A}$$$$V2.0");
+
+    // now add the side chain interaction
+    ala_monomer = model.getMol()->getAtomWithIdx(0);
+    model.addBoundMonomer("W", ChainType::PEPTIDE, {-100.0, 0.0, 0.0}, "R3",
+                          ala_monomer, "R3");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(
+        helm ==
+        "PEPTIDE1{F.C.A}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,3:R3-1:R3$$$V2.0");
+}
+
+/**
  * Use addBoundMonomer to build two full nucleotides: one 3' to an existing
  * nucleotide and one 5' to the same existing nucleotide.
  */
@@ -4780,6 +4817,29 @@ BOOST_AUTO_TEST_CASE(test_addMonomericConnection_pairing_two_nucleotides)
     auto helm = get_mol_text(&model, Format::HELM);
     BOOST_TEST(helm ==
                "RNA1{R(A)P}|RNA2{R(C)P}$RNA1,RNA2,2:pair-2:pair$$$V2.0");
+}
+
+/**
+ * Make sure that adding disconnected monomers via addMonomer results in the
+ * expected HELM strings, which should contain properly numbered chains without
+ * any connection between the monomers.
+ */
+BOOST_AUTO_TEST_CASE(test_addMonomer_disconnected)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+
+    model.addMonomer("A", ChainType::PEPTIDE, {0.0, 0.0, 0.0});
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{A}$$$$V2.0");
+
+    model.addMonomer("C", ChainType::PEPTIDE, {50.0, 0.0, 0.0});
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+
+    model.addMonomer("F", ChainType::PEPTIDE, {100.0, 0.0, 0.0});
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$$$$V2.0");
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -378,20 +378,22 @@ BOOST_AUTO_TEST_CASE(test_get_chain_num)
 BOOST_AUTO_TEST_CASE(test_get_first_available_chain_name)
 {
     using rdkit_extensions::ChainType;
-    
-    
+
     auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}|PEPTIDE2{A}$$$$V2.0");
-    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE3");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) ==
+               "PEPTIDE3");
     BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA1");
 
     mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}|PEPTIDE3{A}$$$$V2.0");
-    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE2");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) ==
+               "PEPTIDE2");
     BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA1");
 
     mol = rdkit_extensions::to_rdkit(
         "RNA1{R(A)P.R(C)P.R(G)P}|RNA2{P.R(C)P.R(G)P.R(T)}$$$$V2.0");
     BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA3");
-    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE1");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) ==
+               "PEPTIDE1");
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -355,5 +355,44 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
     }
 }
 
+/**
+ * Make sure that get_attachment_points returns the correct number for parseable
+ * chain name, and returns -1 when the chain name can't be parsed.
+ */
+BOOST_AUTO_TEST_CASE(test_get_chain_num)
+{
+    using rdkit_extensions::ChainType;
+    BOOST_TEST(get_chain_num("PEPTIDE1", ChainType::PEPTIDE) == 1);
+    BOOST_TEST(get_chain_num("PEPTIDE3", ChainType::PEPTIDE) == 3);
+    BOOST_TEST(get_chain_num("PEPTIDE", ChainType::PEPTIDE) == -1);
+    BOOST_TEST(get_chain_num("ABCDEFG", ChainType::PEPTIDE) == -1);
+    BOOST_TEST(get_chain_num("ABCDEFG2", ChainType::PEPTIDE) == -1);
+    BOOST_TEST(get_chain_num("PEPTIDE1", ChainType::RNA) == -1);
+    BOOST_TEST(get_chain_num("RNA2", ChainType::RNA) == 2);
+}
+
+/**
+ * Make sure that get_first_available_chain_name returns the expected chain name
+ * of the appropriate chain type.
+ */
+BOOST_AUTO_TEST_CASE(test_get_first_available_chain_name)
+{
+    using rdkit_extensions::ChainType;
+    
+    
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}|PEPTIDE2{A}$$$$V2.0");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE3");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA1");
+
+    mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}|PEPTIDE3{A}$$$$V2.0");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE2");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA1");
+
+    mol = rdkit_extensions::to_rdkit(
+        "RNA1{R(A)P.R(C)P.R(G)P}|RNA2{P.R(C)P.R(G)P.R(T)}$$$$V2.0");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::RNA) == "RNA3");
+    BOOST_TEST(get_first_available_chain_name(*mol, ChainType::PEPTIDE) == "PEPTIDE1");
+}
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/test/schrodinger/sketcher/test_common.h
+++ b/test/schrodinger/sketcher/test_common.h
@@ -109,6 +109,7 @@ class TestScene : public Scene
     using Scene::m_mol_model;
     using Scene::m_selection_highlighting_item;
     using Scene::m_sketcher_model;
+    using Scene::mouseMoveEvent;
     using Scene::mousePressEvent;
     using Scene::mouseReleaseEvent;
 

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -116,7 +116,6 @@ struct MonomerToolTestFixture {
     QPointF getAttachmentPointPos(unsigned int monomer_idx,
                                   const std::string& ap_display_name)
     {
-        auto mol = m_mol_model->getMol();
         auto monomer_pos = getMonomerPos(monomer_idx);
         auto* monomer_item = m_scene->getTopInteractiveItemAt(
             monomer_pos, InteractiveItemFlag::MONOMER);

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -1,0 +1,503 @@
+#define BOOST_TEST_MODULE test_draw_monomer_scene_tool_integration_tests
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <QApplication>
+#include <QEvent>
+#include <QGraphicsSceneMouseEvent>
+#include <QPointF>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "../test_common.h"
+#include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/scene_utils.h"
+#include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
+#include "schrodinger/sketcher/public_constants.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
+#include <QtDebug>
+
+namespace bdata = boost::unit_test::data;
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Process all Qt events, includeing DeferredDelete events.
+ */
+void process_qt_events()
+{
+    // call processEvents multiple times in case an any current events put new
+    // events on the queue (e.g. starting a timer with a timeout of 0)
+    for (int i = 0; i < 3; ++i) {
+        QApplication::processEvents();
+        // processEvents will never process DeferredDelete events, but
+        // sendPostedEvents will if we explicitly pass their event type.
+        // (Despite what Qt's documentation claims, passing 0 as the event type
+        // processes everything *other than* DeferredDeletes.)
+        QApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    }
+}
+
+/**
+ * Set both the scene and screen pos for an event
+ */
+void set_event_pos(QGraphicsSceneMouseEvent& event, const QPointF& pos)
+{
+    event.setScenePos(pos);
+    event.setScreenPos(pos.toPoint());
+}
+
+/**
+ * Fixture that provides a clean Scene with MolModel and SketcherModel for
+ * testing monomer drawing tools.
+ */
+struct MonomerToolTestFixture {
+    std::shared_ptr<TestScene> m_scene;
+    MolModel* m_mol_model;
+    SketcherModel* m_sketcher_model;
+
+    MonomerToolTestFixture()
+    {
+        m_scene = TestScene::getScene();
+        m_mol_model = m_scene->m_mol_model;
+        m_sketcher_model = m_scene->m_sketcher_model;
+        m_sketcher_model->setValue(
+            ModelKey::INTERFACE_TYPE,
+            static_cast<int>(InterfaceType::ATOMISTIC_OR_MONOMERIC));
+        process_qt_events();
+    }
+
+    void setAminoAcidTool(AminoAcidTool tool)
+    {
+        m_sketcher_model->setValues(
+            {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
+             {ModelKey::MONOMER_TOOL_TYPE,
+              QVariant::fromValue(MonomerToolType::AMINO_ACID)},
+             {ModelKey::AMINO_ACID_TOOL, QVariant::fromValue(tool)},
+             {ModelKey::AMINO_ACID_SYMBOL, QString("")}});
+        process_qt_events();
+    }
+
+    void setNucleicAcidTool(NucleicAcidTool tool)
+    {
+        m_sketcher_model->setValues(
+            {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
+             {ModelKey::MONOMER_TOOL_TYPE,
+              QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
+             {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)}});
+        process_qt_events();
+    }
+
+    void importMolText(const std::string& text)
+    {
+        import_mol_text(m_mol_model, text);
+        process_qt_events();
+    }
+
+    QPointF getMonomerPos(unsigned int monomer_idx)
+    {
+        auto mol = m_mol_model->getMol();
+        BOOST_REQUIRE(mol);
+        BOOST_REQUIRE(monomer_idx < mol->getNumAtoms());
+        return to_scene_xy(mol->getConformer().getAtomPos(monomer_idx));
+    }
+
+    QPointF getAttachmentPointPos(unsigned int monomer_idx,
+                                  const std::string& ap_display_name)
+    {
+        auto mol = m_mol_model->getMol();
+        auto monomer_pos = getMonomerPos(monomer_idx);
+        auto* monomer_item = m_scene->getTopInteractiveItemAt(
+            monomer_pos, InteractiveItemFlag::MONOMER);
+        BOOST_REQUIRE(monomer_item != nullptr);
+
+        // Search through child items to find the attachment point
+        for (auto* child : monomer_item->childItems()) {
+            auto* ap_item =
+                qgraphicsitem_cast<UnboundMonomericAttachmentPointItem*>(child);
+            if (ap_item) {
+                auto ap = ap_item->getAttachmentPoint();
+                if (ap.display_name == ap_display_name) {
+                    auto offset_vec = direction_to_qt_vector(ap.direction);
+                    auto offset_dist = UNBOUND_AP_LINE_LENGTH - 1 +
+                                       STANDARD_AA_BORDER_WIDTH / 2;
+                    return monomer_pos + offset_dist * offset_vec;
+                }
+            }
+        }
+        throw std::runtime_error("Attachment point " + ap_display_name +
+                                 " not found");
+    }
+
+    void verifyHELM(const std::string& expected)
+    {
+        auto actual = get_mol_text(m_mol_model, rdkit_extensions::Format::HELM);
+        BOOST_TEST(actual == expected);
+    }
+
+    void mouseMove(const QPointF& pos,
+                   const Qt::MouseButtons btns = Qt::NoButton)
+    {
+        QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMouseMove);
+        set_event_pos(event, pos);
+        event.setButton(Qt::NoButton);
+        event.setButtons(btns);
+        m_scene->mouseMoveEvent(&event);
+        process_qt_events();
+    }
+
+    void mousePress(const QPointF& pos)
+    {
+        QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMousePress);
+        set_event_pos(event, pos);
+        event.setButton(Qt::LeftButton);
+        event.setButtons(Qt::LeftButton);
+        m_scene->mousePressEvent(&event);
+        process_qt_events();
+    }
+
+    void mouseRelease(const QPointF& pos)
+    {
+        QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMouseRelease);
+        set_event_pos(event, pos);
+        event.setButton(Qt::LeftButton);
+        event.setButtons(Qt::NoButton);
+        m_scene->mouseReleaseEvent(&event);
+        process_qt_events();
+    }
+
+    void mouseClick(const QPointF& pos)
+    {
+        mouseMove(pos);
+        mousePress(pos);
+        mouseRelease(pos);
+    }
+
+    void mouseDrag(const QPointF& start, const QPointF& end)
+    {
+        mouseMove(start);
+        mousePress(start);
+        mouseMove(end, Qt::LeftButton);
+        mouseRelease(end);
+    }
+
+    void confirmIsEmpty()
+    {
+        auto mol = m_mol_model->getMol();
+        BOOST_TEST(mol->getNumAtoms() == 0);
+    }
+};
+
+/**
+ * Confirm that clicking in empty space adds the appropriate monomer
+ */
+BOOST_AUTO_TEST_CASE(test_click_empty_space_adds_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseClick({0, 0});
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an existing monomer with the equivalent monomer tool
+ * adds a new monomer via the default attachment point.
+ */
+BOOST_AUTO_TEST_CASE(test_click_existing_monomer_same_residue_adds_residue)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto pos = fix.getMonomerPos(0);
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{A.A}$$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an existing monomer with a different monomer tool of
+ * the same monomer type mutates the monomer.
+ */
+BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_residue_mutates)
+{
+    MonomerToolTestFixture fix;
+
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto pos = fix.getMonomerPos(0);
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an existing monomer with a monomer tool of
+ * a different monomer type has no effect.
+ */
+BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto pos = fix.getMonomerPos(0);
+    fix.setNucleicAcidTool(NucleicAcidTool::P);
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an unbounnd attachment point of an existing monomer
+ * adds a new monomer via the clicked attachment point.
+ */
+BOOST_AUTO_TEST_CASE(test_click_attachment_point)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto monomer_pos = fix.getMonomerPos(0);
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    // hover over the monomer to trigger AP label creation
+    fix.mouseMove(monomer_pos);
+
+    // click on the N terminus attachment point
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    fix.mouseMove(monomer_pos);
+    auto n_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseClick(n_ap_pos);
+    fix.verifyHELM("PEPTIDE1{C.A}$$$$V2.0");
+
+    // click on the C terminus attachment point
+    fix.setAminoAcidTool(AminoAcidTool::PHE);
+    fix.mouseMove(monomer_pos);
+    auto c_ap_pos = fix.getAttachmentPointPos(0, "C");
+    fix.mouseClick(c_ap_pos);
+    fix.verifyHELM("PEPTIDE1{C.A.F}$$$$V2.0");
+
+    // click on the side chain attachment point
+    fix.setAminoAcidTool(AminoAcidTool::TRP);
+    fix.mouseMove(monomer_pos);
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseClick(x_ap_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C.A.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:R3-1:R3$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer adds a new monomer using
+ * the default attachment point
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_empty_adds_connected_default_ap)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+
+    // Drag from the monomer to the right
+    auto start_pos = fix.getMonomerPos(0);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer adds a new monomer using
+ * the default attachment point, even when the monomer tool is equivalent to the
+ * existing monomer (e.g. ALA tool on an A monomer).
+ */
+BOOST_AUTO_TEST_CASE(
+    test_drag_monomer_to_empty_adds_connected_default_ap_same_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+
+    // Drag from the monomer to the right
+    auto start_pos = fix.getMonomerPos(0);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A.A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from the attachment point of an existing monomer
+ * to empty space adds a new monomer via the specified attachment point of the
+ * existing monomer
+ */
+BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty_adds_connected_via_dragged_ap)
+{
+    MonomerToolTestFixture fix;
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+
+    // Add initial monomer
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+
+    // hover over the monomer so that the attachment point graphics items are
+    // created
+    auto ala_pos = fix.getMonomerPos(0);
+    fix.mouseMove(ala_pos);
+
+    // Drag from N attachment point to empty space
+    auto start_pos = fix.getAttachmentPointPos(0, "N");
+    auto end_pos = start_pos + QPointF(-100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{C.A}$$$$V2.0");
+
+    // hover over the first monomer so that its attachment point graphics items
+    // are created again
+    fix.setAminoAcidTool(AminoAcidTool::PHE);
+    fix.mouseMove(ala_pos);
+
+    // Drag from C attachment point to empty space
+    start_pos = fix.getAttachmentPointPos(0, "C");
+    end_pos = start_pos + QPointF(100, 100);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{C.A.F}$$$$V2.0");
+
+    // hover over the first monomer so that its attachment point graphics items
+    // are created again
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseMove(ala_pos);
+
+    // Drag from C attachment point to empty space
+    start_pos = fix.getAttachmentPointPos(0, "X");
+    end_pos = start_pos + QPointF(-50, 100);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM(
+        "PEPTIDE1{C.A.F}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,2:R3-1:R3$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer to an existing monomer
+ * connects them via the default attachment points
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_monomer_connects_default_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    auto pos1 = fix.getMonomerPos(0);
+    auto pos2 = fix.getMonomerPos(1);
+    fix.mouseDrag(pos1, pos2);
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from the attachment point of one existing monomer
+ * to the attachment point of another existing monomer connects the monomer via
+ * the specified attachment points.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_ap_to_ap_connects_via_both_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    auto ala_pos = fix.getMonomerPos(0);
+    auto cys_pos = fix.getMonomerPos(1);
+    fix.mouseMove(ala_pos);
+    auto start_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_pos);
+    fix.mousePress(start_pos);
+    // first, drag to the cysteine to make its attachment points appear
+    fix.mouseMove(cys_pos, Qt::LeftButton);
+    auto end_pos = fix.getAttachmentPointPos(1, "N");
+    fix.mouseMove(end_pos, Qt::LeftButton);
+    fix.mouseRelease(end_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R1-1:R1$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to empty space with a peptide monomer
+ * creates a dimer with a backbone connection
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_empty_adds_two_connected_default_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.verifyHELM("PEPTIDE1{A.A}$$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to empty space with a nucleic acid
+ * base monomer creates two paired bases
+ */
+BOOST_AUTO_TEST_CASE(test_nucleic_acid_base_drag_empty_to_empty_uses_pair_ap)
+{
+    MonomerToolTestFixture fix;
+    fix.setNucleicAcidTool(NucleicAcidTool::A);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.verifyHELM("RNA1{A}|RNA2{A}$RNA1,RNA2,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to empty space with a nucleic acid
+ * phosphate monomer is ignored and doesn't create any monomers
+ */
+BOOST_AUTO_TEST_CASE(test_nucleic_acid_sugar_drag_empty_to_empty_ignored)
+{
+    MonomerToolTestFixture fix;
+    fix.setNucleicAcidTool(NucleicAcidTool::R);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.confirmIsEmpty();
+}
+
+/**
+ * Confirm that dragging from empty space to an existing monomer creates a new
+ * monomer and connects it to the default attachment point of the existing
+ * monomer
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_monomer_adds_connected_default_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = fix.getMonomerPos(0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to an existing monomer creates a new
+ * monomer and connects it to the specified attachment point of the existing
+ * monomer
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_ap_adds_connected_correct_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    auto start_pos = QPointF(100, 100);
+    auto monomer_pos = fix.getMonomerPos(0);
+    fix.mouseMove(start_pos);
+    fix.mousePress(start_pos);
+    // first, drag to the existing monomer to make its attachment points appear
+    fix.mouseMove(monomer_pos);
+    auto end_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseMove(end_pos);
+    fix.mouseRelease(end_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R3-1:R2$$$V2.0");
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -8,7 +8,6 @@
 #include <QEvent>
 #include <QGraphicsSceneMouseEvent>
 #include <QPointF>
-#include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "../test_common.h"
@@ -20,10 +19,6 @@
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
 #include "schrodinger/sketcher/public_constants.h"
 #include "schrodinger/sketcher/rdkit/monomeric.h"
-
-#include <QtDebug>
-
-namespace bdata = boost::unit_test::data;
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
 


### PR DESCRIPTION
* Linked Case: SKETCH-2483

There are two main changes here:

- I've added a bunch of integration tests for the monomer scene tool.  These tests mimic clicks and click-and-drags and then confirm that the generated HELM string matches the expected value. I had Claude write the initial version of these tests but almost all of them crashed, which Claude "helpfully" fixed by replacing all of the crashing tests with TODOs. I pulled the deleted test bodies out of my git history and wound up rewriting almost the entirety of the file.  The tests now all pass, and the test fixture is rich enough that it's fairly trivial to add new scenarios.
- I fixed some of the real bugs that Claude managed to uncover before it replaced all of the tests with TODOs These bugs related to HELM string generation: Monomers are now properly assigned to chains if they share a standard backbone bond, and chain number now starts at 1 instead of consistently using 99999.  I also added some MolModel unit tests that reproduced these failures, since the issues were in the data that MolModel was passing to monomer_mol.

### Testing Done
Added new unit tests and confirmed that they passed.
