### PR TITLE
SKETCH-2483: Fixing minor issues with the monomer scene tool

### DIFF
--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -683,8 +683,8 @@ void MolModel::addMonomer(const std::string_view res_name,
 }
 
 static MonomerType
-monomer_type_from_chain_type(const rdkit_extensions::ChainType chain_type,
-                             const std::string_view res_name)
+get_monomer_type_from_chain_type(const rdkit_extensions::ChainType chain_type,
+                                 const std::string_view res_name)
 {
     using rdkit_extensions::ChainType;
     switch (chain_type) {
@@ -745,7 +745,7 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
 {
     using rdkit_extensions::ChainType;
 
-    auto monomer_type = monomer_type_from_chain_type(chain_type, res_name);
+    auto monomer_type = get_monomer_type_from_chain_type(chain_type, res_name);
     auto existing_res_nums = get_all_residue_numbers_of_monomer_type_in_polymer(
         monomer_type, bound_to_monomer);
 

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -682,18 +682,60 @@ void MolModel::addMonomer(const std::string_view res_name,
     doCommandUsingSnapshots(cmd_func, "Add monomer", WhatChanged::MOLECULE);
 }
 
+static MonomerType
+monomer_type_from_chain_type(const rdkit_extensions::ChainType chain_type,
+                             const std::string_view res_name)
+{
+    using rdkit_extensions::ChainType;
+    switch (chain_type) {
+        case (ChainType::PEPTIDE):
+            return MonomerType::PEPTIDE;
+        case (ChainType::CHEM):
+            return MonomerType::CHEM;
+        default:
+            return get_na_monomer_type_from_res_name(res_name);
+    }
+}
+
+/**
+ * @return a set of all residue numbers for monomers of the specified type that
+ * are in the same polymer as the given atom.
+ */
+static std::unordered_set<int>
+get_all_residue_numbers_of_monomer_type_in_polymer(
+    const MonomerType monomer_type, const RDKit::Atom* const atom_in_polymer)
+{
+    // we make a copy of the molecule so we can flag it as monomeric
+    auto mol = atom_in_polymer->getOwningMol();
+    mol.setProp(HELM_MODEL, true);
+    auto polymer_id = rdkit_extensions::get_polymer_id(atom_in_polymer);
+    auto atom_idxs =
+        rdkit_extensions::get_atoms_in_polymer_chains(mol, {polymer_id});
+    std::unordered_set<int> residue_numbers;
+    for (auto atom_idx : atom_idxs) {
+        auto* atom = mol.getAtomWithIdx(atom_idx);
+        if (get_monomer_type(atom) == monomer_type) {
+            auto res_num = rdkit_extensions::get_residue_number(atom);
+            residue_numbers.insert(res_num);
+        }
+    }
+    return residue_numbers;
+}
+
 /**
  * Determine the appropriate residue number to use for a new monomer that will
- * be connected to an existing monomer.  Note that this function does *not*
- * check for duplicate residue numbers; the new residue number is based entirely
- * off of the residue number from bound_to_monomer (and possibly incremented or
- * decremented).
+ * be connected to an existing monomer.
  * @param res_name The residue name of the monomer to be added
  * @param chain_type The type of the monomer to be added
  * @param new_monomer_ap_name The new monomer's attachment point that will be
  * used to connect it to bound_to_monomer
  * @param bound_to_monomer The existing monomer that the new monomer will be
  * bound to
+ * @return the residue number, which is guaranteed to be:
+ *   - non-negative (since get_residue_number returns unsigned ints)
+ *   - unique amongst all residues with the same monomer type (This allows,
+ *     e.g., an RNA base and sugar to have the same residue number, but ensures
+ *     that peptide monomers are uniquely numbered.)
  */
 static int
 get_residue_number_for_new_monomer(const std::string_view res_name,
@@ -702,6 +744,11 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
                                    const RDKit::Atom* const bound_to_monomer)
 {
     using rdkit_extensions::ChainType;
+
+    auto monomer_type = monomer_type_from_chain_type(chain_type, res_name);
+    auto existing_res_nums = get_all_residue_numbers_of_monomer_type_in_polymer(
+        monomer_type, bound_to_monomer);
+
     int res_num_offset = 1;
     auto bound_to_monomer_chain_type =
         rdkit_extensions::getChainType(*bound_to_monomer);
@@ -711,7 +758,6 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
         res_num_offset = -1;
     } else if (chain_type == ChainType::RNA &&
                bound_to_monomer_chain_type == ChainType::RNA) {
-        auto monomer_type = get_na_monomer_type_from_res_name(res_name);
         if (monomer_type == MonomerType::NA_SUGAR &&
             new_monomer_ap_name == ap_model_name_for(NASugarAP::THREE_PRIME)) {
             // sugars can link to the previous residue
@@ -726,84 +772,13 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
             res_num_offset = 0;
         }
     }
-    return rdkit_extensions::get_residue_number(bound_to_monomer) +
-           res_num_offset;
-}
-
-/**
- * Determine whether the described linkage is a standard bond (i.e. does not
- * need the CUSTOM_BOND property) or a custom bond (which requires the
- * CUSTOM_BOND) property
- */
-static bool get_is_custom_bond(const std::string_view res_name,
-                               const rdkit_extensions::ChainType chain_type,
-                               const RDKit::Atom* const bound_to_monomer,
-                               const std::string_view linkage)
-{
-    using rdkit_extensions::ChainType;
-    auto bound_to_monomer_chain_type =
-        rdkit_extensions::getChainType(*bound_to_monomer);
-    if (chain_type == ChainType::PEPTIDE &&
-        bound_to_monomer_chain_type == ChainType::PEPTIDE) {
-        return linkage != BACKBONE_LINKAGE;
-    } else if (chain_type == ChainType::RNA &&
-               bound_to_monomer_chain_type == ChainType::RNA) {
-        auto new_monomer_type = get_na_monomer_type_from_res_name(res_name);
-        auto bound_to_monomer_type = get_monomer_type(bound_to_monomer);
-        std::unordered_set<MonomerType> monomer_types = {new_monomer_type,
-                                                         bound_to_monomer_type};
-        if (monomer_types ==
-                std::unordered_set<MonomerType>{MonomerType::NA_SUGAR,
-                                                MonomerType::NA_BASE} &&
-            linkage == ap_model_name_for(NASugarAP::ONE_PRIME) + "-" +
-                           ap_model_name_for(NA_BASE_AP_N1_9)) {
-            // standard sugar to base linkage
-            return false;
-        } else if (monomer_types ==
-                       std::unordered_set<MonomerType>{
-                           MonomerType::NA_SUGAR, MonomerType::NA_PHOSPHATE} &&
-                   linkage == "R2-R1") {
-            // sugar to next or previous phosphate linkage
-            return false;
-        }
+    auto bound_to_res_num =
+        rdkit_extensions::get_residue_number(bound_to_monomer);
+    int new_res_num = bound_to_res_num + res_num_offset;
+    if (new_res_num < 0 || existing_res_nums.contains(new_res_num)) {
+        new_res_num = *std::ranges::max_element(existing_res_nums) + 1;
     }
-    return true;
-}
-
-/**
- * @overload
- */
-static bool get_is_custom_bond(const RDKit::Atom* const monomer_one,
-                               const RDKit::Atom* const monomer_two,
-                               const std::string_view linkage)
-{
-    auto monomer_one_res_name = get_monomer_res_name(monomer_one);
-    auto monomer_one_chain_type = rdkit_extensions::getChainType(*monomer_one);
-    return get_is_custom_bond(monomer_one_res_name, monomer_one_chain_type,
-                              monomer_two, linkage);
-}
-
-/**
- * Combine the two attachment point names to form a standardized linkage string.
- * For example, attachment points "R2" and "R1" would form the linkage string
- * "R2-R1". Note that, in a standardized linkage string, higher numbered
- * attachment points are listed before lower numbered one, and numbered
- * attachment points are listed before attachment points with custom names.
- */
-std::tuple<std::string, bool>
-build_linkage_string(const std::string_view ap_name_one,
-                     const std::string_view ap_name_two)
-{
-    auto ap_num_one = ap_name_to_num(ap_name_one);
-    auto ap_num_two = ap_name_to_num(ap_name_two);
-    bool flip = ap_num_one < ap_num_two;
-    std::string_view start_ap_name = ap_name_one;
-    std::string_view end_ap_name = ap_name_two;
-    if (flip) {
-        std::swap(start_ap_name, end_ap_name);
-    }
-    std::string linkage = fmt::format("{}-{}", start_ap_name, end_ap_name);
-    return {linkage, flip};
+    return new_res_num;
 }
 
 void MolModel::addBoundMonomer(const std::string_view res_name,

--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -824,5 +824,80 @@ get_first_available_chain_name(const RDKit::ROMol& mol,
     return fmt::format("{}{}", prefix, missing_num);
 }
 
+std::pair<std::string, bool>
+build_linkage_string(const std::string_view ap_name_one,
+                     const std::string_view ap_name_two)
+{
+    auto ap_num_one = ap_name_to_num(ap_name_one);
+    auto ap_num_two = ap_name_to_num(ap_name_two);
+    bool flip = ap_num_one < ap_num_two;
+    std::string_view start_ap_name = ap_name_one;
+    std::string_view end_ap_name = ap_name_two;
+    if (flip) {
+        std::swap(start_ap_name, end_ap_name);
+    }
+    std::string linkage = fmt::format("{}-{}", start_ap_name, end_ap_name);
+    return {linkage, flip};
+}
+
+bool get_is_custom_bond(const std::string_view res_name_one,
+                        const rdkit_extensions::ChainType chain_type_one,
+                        const std::string_view res_name_two,
+                        const rdkit_extensions::ChainType chain_type_two,
+                        const std::string_view linkage)
+{
+    using rdkit_extensions::ChainType;
+    if (chain_type_one == ChainType::PEPTIDE &&
+        chain_type_two == ChainType::PEPTIDE) {
+        return linkage != BACKBONE_LINKAGE;
+    } else if (chain_type_one == ChainType::RNA &&
+               chain_type_two == ChainType::RNA) {
+        auto monomer_type_one = get_na_monomer_type_from_res_name(res_name_one);
+        auto monomer_type_two = get_na_monomer_type_from_res_name(res_name_two);
+        std::unordered_set<MonomerType> monomer_types = {monomer_type_one,
+                                                         monomer_type_two};
+        if (monomer_types ==
+                std::unordered_set<MonomerType>{MonomerType::NA_SUGAR,
+                                                MonomerType::NA_BASE} &&
+            linkage == ap_model_name_for(NASugarAP::ONE_PRIME) + "-" +
+                           ap_model_name_for(NA_BASE_AP_N1_9)) {
+            // standard sugar to base linkage
+            return false;
+        } else if (monomer_types ==
+                       std::unordered_set<MonomerType>{
+                           MonomerType::NA_SUGAR, MonomerType::NA_PHOSPHATE} &&
+                   linkage == "R2-R1") {
+            // sugar to next or previous phosphate linkage
+            return false;
+        }
+    }
+    return true;
+}
+
+bool get_is_custom_bond(const RDKit::Atom* const monomer_one,
+                        const RDKit::Atom* const monomer_two,
+                        const std::string_view linkage)
+{
+    auto monomer_one_res_name = get_monomer_res_name(monomer_one);
+    auto monomer_one_chain_type = rdkit_extensions::getChainType(*monomer_one);
+    auto monomer_two_res_name = get_monomer_res_name(monomer_two);
+    auto monomer_two_chain_type = rdkit_extensions::getChainType(*monomer_two);
+    return get_is_custom_bond(monomer_one_res_name, monomer_one_chain_type,
+                              monomer_two_res_name, monomer_two_chain_type,
+                              linkage);
+}
+
+bool get_is_custom_bond(const std::string_view res_name_one,
+                        const rdkit_extensions::ChainType chain_type_one,
+                        const RDKit::Atom* const monomer_two,
+                        const std::string_view linkage)
+{
+    auto monomer_two_res_name = get_monomer_res_name(monomer_two);
+    auto monomer_two_chain_type = rdkit_extensions::getChainType(*monomer_two);
+    return get_is_custom_bond(res_name_one, chain_type_one,
+                              monomer_two_res_name, monomer_two_chain_type,
+                              linkage);
+}
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -263,5 +263,49 @@ SKETCHER_API std::string
 get_first_available_chain_name(const RDKit::ROMol& mol,
                                const rdkit_extensions::ChainType chain_type);
 
+/**
+ * Combine the two attachment point names to form a standardized linkage string.
+ * For example, attachment points "R2" and "R1" would form the linkage string
+ * "R2-R1". Note that, in a standardized linkage string, higher numbered
+ * attachment points are listed before lower numbered one, and numbered
+ * attachment points are listed before attachment points with custom names.
+ * @return a pair of
+ *   - the standardized linkage string
+ *   - whether the attachment point order was flipped in order to standardize
+ *     the linkage string
+ */
+SKETCHER_API std::pair<std::string, bool>
+build_linkage_string(const std::string_view ap_name_one,
+                     const std::string_view ap_name_two);
+
+/**
+ * Determine whether the described linkage is a standard bond (i.e. does not
+ * need the CUSTOM_BOND property) or a custom bond (which requires the
+ * CUSTOM_BOND) property
+ * @note the linkage string must be standardized, but the order of the monomers
+ * does not need to match the order of the linkage string. In a standardized
+ * linkage string, higher numbered attachment points are listed before lower
+ * numbered one, and numbered attachment points are listed before attachment
+ * points with custom names.
+ */
+SKETCHER_API bool
+get_is_custom_bond(const std::string_view res_name_one,
+                   const rdkit_extensions::ChainType chain_type_one,
+                   const std::string_view res_name_two,
+                   const rdkit_extensions::ChainType chain_type_two,
+                   const std::string_view linkage);
+
+/// @overload
+SKETCHER_API bool get_is_custom_bond(const RDKit::Atom* const monomer_one,
+                                     const RDKit::Atom* const monomer_two,
+                                     const std::string_view linkage);
+
+/// @overload
+SKETCHER_API bool
+get_is_custom_bond(const std::string_view res_name_one,
+                   const rdkit_extensions::ChainType chain_type_one,
+                   const RDKit::Atom* const monomer_two,
+                   const std::string_view linkage);
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -914,8 +914,9 @@ DrawMonomerSceneTool::getDragEndInfo(const QPointF& scene_pos)
                 // this would be a custom connection (i.e. not a standard
                 // backbone connection) and this monomer pair already has one
                 drag_end_ap_item = nullptr;
-            } else if (!is_custom_bond && !connection->hasProp(CUSTOM_BOND) ||
-                       contains_two_monomer_linkages(connection)) {
+            } else if (!is_custom_bond &&
+                       (!connection->hasProp(CUSTOM_BOND) ||
+                        contains_two_monomer_linkages(connection))) {
                 // this would be a standard backbone connection and this monomer
                 // pair already has one (presumably in the opposite direction,
                 // since otherwise the attachment points would have already been

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -117,22 +117,19 @@ void DrawMonomerSceneTool::updateColorsAfterBackgroundColorChange(
         is_dark_mode ? DRAG_END_INACTIVE_AP_DARK_BG : DRAG_END_INACTIVE_AP;
 }
 
+bool DrawMonomerSceneTool::isItemPartOfHintFragment(QGraphicsItem* item) const
+{
+    return m_hint_fragment_item != nullptr &&
+           (item == m_hint_fragment_item ||
+            item->group() == m_hint_fragment_item);
+}
+
 AbstractMonomerItem*
 DrawMonomerSceneTool::getTopMonomerItemAt(const QPointF& scene_pos) const
 {
-    // we're only interested in monomers that are part of the actual Sketcher
-    // structure, so we need to ignore any graphics items that belong to our
-    // hint structure
-    auto is_item_part_of_hint_fragment = [this](QGraphicsItem* item) {
-        return m_hint_fragment_item != nullptr &&
-               (item == m_hint_fragment_item ||
-                item->group() == m_hint_fragment_item);
-    };
-
-    // check to see if we're over a monomer, monomeric connector, or unbound
-    // attachment point item
+    // check to see if we're over a monomer or unbound attachment point item
     for (auto* item : m_scene->items(scene_pos)) {
-        if (is_item_part_of_hint_fragment(item)) {
+        if (isItemPartOfHintFragment(item)) {
             // ignore the fragment hint that was drawn by this class
             continue;
         }
@@ -160,7 +157,7 @@ DrawMonomerSceneTool::getTopMonomerItemAt(const QPointF& scene_pos) const
     near_scene_pos.addEllipse(scene_pos, radius, radius);
     for (auto* item : m_scene->items(near_scene_pos)) {
         if (!item_matches_type_flag(item, InteractiveItemFlag::MONOMER) ||
-            is_item_part_of_hint_fragment(item)) {
+            isItemPartOfHintFragment(item)) {
             continue;
         }
         auto* monomer_item = static_cast<AbstractMonomerItem*>(item);
@@ -175,6 +172,19 @@ DrawMonomerSceneTool::getTopMonomerItemAt(const QPointF& scene_pos) const
             if (unbound_ap_hover_area.contains(local_pos)) {
                 return monomer_item;
             }
+        }
+    }
+    return nullptr;
+}
+
+MonomerConnectorItem* DrawMonomerSceneTool::getTopMonomerConnectorItemAt(
+    const QPointF& scene_pos) const
+{
+    for (auto* item : m_scene->items(scene_pos)) {
+        if (!isItemPartOfHintFragment(item) &&
+            item_matches_type_flag(item,
+                                   InteractiveItemFlag::MONOMER_CONNECTOR)) {
+            return static_cast<MonomerConnectorItem*>(item);
         }
     }
     return nullptr;
@@ -491,12 +501,19 @@ void DrawMonomerSceneTool::onMouseMove(QGraphicsSceneMouseEvent* const event)
         return;
     }
     QPointF scene_pos = event->scenePos();
-    auto* item = getTopMonomerItemAt(scene_pos);
-    if (item != m_hovered_item) {
-        m_hovered_item = item;
-        drawAttachmentPointLabelsFor(item);
+    QGraphicsItem* hovered_item;
+    hovered_item = getTopMonomerItemAt(scene_pos);
+    bool found_monomer = hovered_item != nullptr;
+    if (!found_monomer) {
+        // if we're not over a monomer, check to see if we're over a connector
+        hovered_item = getTopMonomerConnectorItemAt(scene_pos);
+    }
+
+    if (hovered_item != m_hovered_item) {
+        m_hovered_item = hovered_item;
+        drawAttachmentPointLabelsFor(hovered_item);
         if (shouldShowPredictiveHighlighting()) {
-            m_predictive_highlighting_item.highlightItem(item);
+            m_predictive_highlighting_item.highlightItem(hovered_item);
         } else {
             m_predictive_highlighting_item.clearHighlightingPath();
         }
@@ -516,10 +533,15 @@ void DrawMonomerSceneTool::onMouseMove(QGraphicsSceneMouseEvent* const event)
 
     // we want to show either the hint fragment or the cursor hint, but not both
     bool drew_hint_fragment = hovered_ap_item != nullptr;
-    if (drew_hint_fragment == m_cursor_hint_shown) {
-        emit newCursorHintRequested(
-            drew_hint_fragment ? QPixmap() : getDefaultCursorPixmap());
-        m_cursor_hint_shown = !drew_hint_fragment;
+    setCursorHintShown(!drew_hint_fragment);
+}
+
+void DrawMonomerSceneTool::setCursorHintShown(bool show)
+{
+    if (show != m_cursor_hint_shown) {
+        emit newCursorHintRequested(show ? getDefaultCursorPixmap()
+                                         : QPixmap());
+        m_cursor_hint_shown = show;
     }
 }
 
@@ -785,7 +807,14 @@ void DrawMonomerSceneTool::onLeftButtonDragStart(
     // drag to direction, not to another's monomer attachment point
     auto dir = getDragDirection(event->scenePos());
     auto handled = createDragHintIfDragStartValid(dir);
-    if (!handled) {
+    if (handled) {
+        // hide the cursor hint while the hint structure is shown. Note that the
+        // cursor hint will have already been hidden if we started this drag
+        // from a monomer, since hovering over a monomer hides the cursor hint
+        // (since it shows the hint structure).  If this drag started from empty
+        // space, though, then this call is necessary to hide the cursor hint.
+        setCursorHintShown(false);
+    } else {
         m_drag_start_monomer_item = nullptr;
     }
     m_drag_ignored = !handled;
@@ -864,10 +893,43 @@ DrawMonomerSceneTool::getDragEndInfo(const QPointF& scene_pos)
             ? nullptr
             : getUnboundDragEndAttachmentPointAt(scene_pos);
 
+    // if we're dragging between two existing monomers, make sure that we'd be
+    // able to actually add a connection between them. Any pair of monomers can
+    // have at most one standard backbone connection and one custom connection
+    // (i.e. not a standard backbone connection) between them, since our RDKit
+    // monomer format currently doesn't support more than that
+    if (m_drag_start_monomer_item != nullptr && drag_end_ap_item != nullptr) {
+        auto* monomer_start = m_drag_start_monomer_item->getAtom();
+        auto* monomer_end = hovered_monomer_item->getAtom();
+        auto* connection = m_mol_model->getMol()->getBondBetweenAtoms(
+            monomer_start->getIdx(), monomer_end->getIdx());
+        if (connection != nullptr) {
+            auto ap_name_end =
+                drag_end_ap_item->getAttachmentPoint().model_name;
+            auto [linkage, flipped] =
+                build_linkage_string(m_drag_start_ap_model_name, ap_name_end);
+            bool is_custom_bond =
+                get_is_custom_bond(monomer_start, monomer_end, linkage);
+            if (is_custom_bond && connection->hasProp(CUSTOM_BOND)) {
+                // this would be a custom connection (i.e. not a standard
+                // backbone connection) and this monomer pair already has one
+                drag_end_ap_item = nullptr;
+            } else if (!is_custom_bond && !connection->hasProp(CUSTOM_BOND) ||
+                       contains_two_monomer_linkages(connection)) {
+                // this would be a standard backbone connection and this monomer
+                // pair already has one (presumably in the opposite direction,
+                // since otherwise the attachment points would have already been
+                // bound)
+                drag_end_ap_item = nullptr;
+            }
+        }
+    }
+
     DragEndInfo direction_or_attachment_point;
     if (drag_end_ap_item == nullptr) {
-        // there's no available attachment point at the cursor, so we drag the
-        // drag hint in a direction
+        // there's no available attachment point at the cursor (or there is one
+        // but we can't use it because this pair of monomers already has that
+        // type of connection), so we display the drag hint in a direction
         direction_or_attachment_point = getDragDirection(scene_pos);
     } else {
         direction_or_attachment_point =

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -39,6 +39,7 @@ namespace sketcher
 class MonomerHintFragmentItem;
 class UnboundMonomericAttachmentPointItem;
 struct HintFragmentMonomerInfo;
+class MonomerConnectorItem;
 
 using MonomerAndAPItems =
     std::pair<AbstractMonomerItem*, UnboundMonomericAttachmentPointItem*>;
@@ -198,6 +199,14 @@ class SKETCHER_API DrawMonomerSceneTool : public StandardSceneToolBase
      * @param scene_pos The position in Scene coordinates
      */
     AbstractMonomerItem* getTopMonomerItemAt(const QPointF& scene_pos) const;
+
+    /**
+     * Return the top graphics item representing a monomeric connector at the
+     * given coordinates. If there's no such graphics item, return nullptr.
+     * @param scene_pos The position in Scene coordinates
+     */
+    MonomerConnectorItem*
+    getTopMonomerConnectorItemAt(const QPointF& scene_pos) const;
 
     /**
      * Clear any existing attachment point labels and draw new ones for the
@@ -404,6 +413,17 @@ class SKETCHER_API DrawMonomerSceneTool : public StandardSceneToolBase
      */
     rdkit_extensions::Direction
     getDragDirection(const QPointF& cur_scene_pos) const;
+
+    /**
+     * Show or hide the cursor hint
+     */
+    void setCursorHintShown(bool show);
+
+    /**
+     * Determine whether the specified graphics item is part of this scene
+     * tool's hint fragment
+     */
+    bool isItemPartOfHintFragment(QGraphicsItem* item) const;
 };
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4371,7 +4371,6 @@ BOOST_AUTO_TEST_CASE(test_secondary_connections)
     QUndoStack undo_stack;
     TestMolModel model(&undo_stack);
 
-    // Load cyclohexane from SMILES
     add_text_to_mol_model(model,
                           "PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
     const RDKit::ROMol* mol = model.getMol();

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -493,5 +493,83 @@ BOOST_AUTO_TEST_CASE(test_drag_empty_to_ap_adds_connected_correct_aps)
         "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R3-1:R2$$$V2.0");
 }
 
+/**
+ * Make sure that dragging between two existing monomer won't create a second
+ * standard backbone connection between them (since monomer_mol can't store more
+ * than one standard backbone connection between the same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_second_backbone_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A.A}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "C");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    // the drag should have added a new monomer to the N terminus of the start
+    // monomer since we released over an invalid attachment point
+    fix.verifyHELM("PEPTIDE1{C.A.A}$$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a second
+ * custom connection (i.e. not a standard backbone connection) between them
+ * (since monomer_mol can't store more than one custom connection between the
+ * same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::PHE);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "X");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    // the drag should have added a new monomer with a side chain interaction
+    // since we released over an invalid attachment point
+    fix.verifyHELM("PEPTIDE1{C}|PEPTIDE2{A}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:R2-"
+                   "1:R2|PEPTIDE1,PEPTIDE3,1:R3-1:R3$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a third
+ * connection between them (since monomer_mol can't store more than two
+ * connections between the same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_third_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "C");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    // the drag should have added a new monomer with a side chain interaction
+    // since we released over an invalid attachment point
+    fix.verifyHELM("PEPTIDE1{C.C.C}$PEPTIDE1,PEPTIDE1,2:R3-3:R3$$$V2.0");
+}
+
 } // namespace sketcher
 } // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-2483

### Description
This fixes a handful of minor issues with the monomeric scene tool:
- Previously, hovering over a connector would label the attachment points at both ends of the connector, but I broke that at some point.  This branch fixes that so it works again.
- The cursor hint is now hidden when doing a click-and-drag from empty space.  The cursor hint had already been hidden in other scenarios where we draw a hint structure, such as click-and-drag from an existing monomer and hovering over a monomer.
- Click-and-dragging between two existing monomers will no longer attempt to add multiple standard or multiple custom connections between a pair of monomers.  The monomer mol format only allows one connection of each type between any given monomer pair, so attempting to add an additional connection would have failed.
- MolModel no longer assigns negative residue numbers to new residues.  RDKit stores the residue numbers as signed ints, but `rdkit_extensions::get_residue_number` returns them as unsigned ints, so negative numbers seem like a bad idea.
- MolModel now ensures that residue numbers for new residues are unique.  I'm actually not entirely sure whether this is necessary or not.  I was running into some issues with cleanup that I thought were caused by duplicate residue numbers, but this change didn't fix them, so my new guess is that the issues are somehow related to SKETCH-2716 (i.e. clean up on monomer mols currently seems to have problems in general).  Regardless, there's not a ton of additional logic required for this, and I could envision duplicate residue numbers causing some sort of issue in edge cases, so it seems worth leaving in for now.

I think that this PR finally finishes the monomer scene tool (outside of the crash bug that Jarrett found and has a fix for).  After this, I'll probably start working on the scene tool for adding a whole nucleotide at once.

### Testing Done
Tested the behavior on the Windows desktop app.  I also added some new integration tests to make sure that click-and-drag won't try to add too many connections to an existing Bond.