### PR TITLE
SKETCH-2648: Foundation for monomer context menu

### DIFF
--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -50,6 +50,7 @@ class BracketSubgroupContextMenu;
 class ModifyAtomsMenu;
 class ModifyBondsMenu;
 class MolModel;
+class MonomerContextMenu;
 class NonMolecularObject;
 class Scene;
 class SelectionContextMenu;
@@ -356,6 +357,7 @@ class SKETCHER_API SketcherWidget : public QWidget
     SelectionContextMenu* m_selection_context_menu = nullptr;
     BracketSubgroupContextMenu* m_sgroup_context_menu = nullptr;
     BackgroundContextMenu* m_background_context_menu = nullptr;
+    MonomerContextMenu* m_monomer_context_menu = nullptr;
 
     /**
      * Dialogs
@@ -395,6 +397,7 @@ class SKETCHER_API SketcherWidget : public QWidget
     void connectContextMenu(const SelectionContextMenu& menu);
     void connectContextMenu(const BracketSubgroupContextMenu& menu);
     void connectContextMenu(const BackgroundContextMenu& menu);
+    void connectContextMenu(const MonomerContextMenu& menu);
 
     /**
      * Show the relevant context menu given some combination of atoms, bonds,

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -1,0 +1,18 @@
+#include "schrodinger/sketcher/menu/monomer_context_menu.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
+    AbstractContextMenu(parent)
+{
+    setTitle("Monomer");
+    addAction("Delete", this, [this]() { emit deleteRequested(m_atoms); });
+}
+
+} // namespace sketcher
+} // namespace schrodinger
+
+#include "schrodinger/sketcher/menu/monomer_context_menu.moc"

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.h
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/menu/abstract_context_menu.h"
+
+namespace RDKit
+{
+class Atom;
+} // namespace RDKit
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Context menu for monomer beads. Currently exposes only Delete; later
+ * phases of SKETCH-2648 will add monomer-type-specific actions.
+ */
+class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
+{
+    Q_OBJECT
+  public:
+    MonomerContextMenu(QWidget* parent = nullptr);
+
+  signals:
+    void deleteRequested(const std::unordered_set<const RDKit::Atom*>& atoms);
+
+  private:
+    void updateActions() override{};
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -37,6 +37,7 @@
 #include "schrodinger/sketcher/menu/background_context_menu.h"
 #include "schrodinger/sketcher/menu/bond_context_menu.h"
 #include "schrodinger/sketcher/menu/bracket_subgroup_context_menu.h"
+#include "schrodinger/sketcher/menu/monomer_context_menu.h"
 #include "schrodinger/sketcher/menu/selection_context_menu.h"
 #include "schrodinger/sketcher/model/mol_model.h"
 #include "schrodinger/sketcher/model/non_molecular_object.h"
@@ -46,6 +47,7 @@
 #include "schrodinger/sketcher/molviewer/bond_item.h"
 #include "schrodinger/sketcher/molviewer/constants.h"
 #include "schrodinger/sketcher/molviewer/non_molecular_item.h"
+#include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/molviewer/view.h"
@@ -223,6 +225,9 @@ SketcherWidget::SketcherWidget(QWidget* parent,
     connectContextMenu(*m_selection_context_menu);
     connectContextMenu(*m_sgroup_context_menu);
     connectContextMenu(*m_background_context_menu);
+
+    m_monomer_context_menu = new MonomerContextMenu(this);
+    connectContextMenu(*m_monomer_context_menu);
 
     // create the file and image export dialogs
     m_file_export_dialog = new FileExportDialog(m_sketcher_model, window());
@@ -736,6 +741,12 @@ void SketcherWidget::connectContextMenu(const AttachmentPointContextMenu& menu)
             });
 }
 
+void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
+{
+    connect(&menu, &MonomerContextMenu::deleteRequested, this,
+            [this](auto atoms) { m_mol_model->remove(atoms, {}, {}, {}, {}); });
+}
+
 void SketcherWidget::connectContextMenu(const ModifyAtomsMenu& menu)
 {
     using RDKitAtoms = std::unordered_set<const RDKit::Atom*>;
@@ -918,7 +929,16 @@ void SketcherWidget::showContextMenu(
     } else if (atoms.size() && bond_selected) {
         menu = m_selection_context_menu;
     } else if (atoms.size()) {
-        menu = m_atom_context_menu;
+        bool all_monomeric =
+            !filtered_atoms.empty() &&
+            std::ranges::all_of(filtered_atoms, [](const auto* atom) {
+                return is_atom_monomeric(atom);
+            });
+        if (all_monomeric) {
+            menu = m_monomer_context_menu;
+        } else {
+            menu = m_atom_context_menu;
+        }
     } else if (bond_selected) {
         menu = m_bond_context_menu;
     } else if (non_molecular_objects.size()) {

--- a/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
@@ -1,0 +1,56 @@
+#define BOOST_TEST_MODULE Test_Sketcher
+
+#include <algorithm>
+#include <unordered_set>
+
+#include <boost/test/unit_test.hpp>
+
+#include <QAction>
+#include <QObject>
+#include <rdkit/GraphMol/Atom.h>
+#include <rdkit/GraphMol/ROMol.h>
+
+#include "../test_common.h"
+#include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/sketcher/menu/monomer_context_menu.h"
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Triggering Delete must emit `deleteRequested` carrying exactly the set
+ * of atoms the menu was populated with via `setContextItems`. This is the
+ * contract `SketcherWidget` relies on to route the deletion to MolModel.
+ */
+BOOST_AUTO_TEST_CASE(test_delete_emits_signal_with_context_atoms)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A.G}$$$$V2.0");
+    const std::unordered_set<const RDKit::Atom*> input = {
+        mol->getAtomWithIdx(0), mol->getAtomWithIdx(1)};
+
+    MonomerContextMenu menu;
+    std::unordered_set<const RDKit::Atom*> received;
+    int call_count = 0;
+    QObject::connect(&menu, &MonomerContextMenu::deleteRequested, &menu,
+                     [&](auto atoms) {
+                         received = std::move(atoms);
+                         ++call_count;
+                     });
+
+    menu.setContextItems(input, {}, {}, {}, {});
+    auto actions = menu.actions();
+    auto it = std::ranges::find_if(
+        actions, [](auto* a) { return a->text() == "Delete"; });
+    BOOST_REQUIRE(it != actions.end());
+    (*it)->trigger();
+
+    BOOST_TEST(call_count == 1);
+    BOOST_TEST(received == input);
+}
+
+} // namespace sketcher
+} // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-2648

### Description
Adds a `MonomerContextMenu` which just initially exposes the `Delete` function. This context menu replaces the prior behavior of showing the atomistic version.

### Testing Done
Tests that `deleteRequested` is emitted.
