### PR TITLE
SKETCH-2648: Add Set L/D-form and Mutate monomer in context menu

### DIFF
--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -20,10 +20,7 @@ namespace schrodinger
 namespace sketcher
 {
 
-namespace
-{
-
-bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
+static bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
 {
     if (atoms.empty()) {
         return false;
@@ -33,7 +30,8 @@ bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
     });
 }
 
-rdkit_extensions::opt_string_t peptide_natural_analog(std::string_view sym)
+static rdkit_extensions::opt_string_t
+get_peptide_natural_analog(std::string_view sym)
 {
     return rdkit_extensions::MonomerDatabase::instance().getNaturalAnalog(
         std::string(sym), rdkit_extensions::ChainType::PEPTIDE);
@@ -42,18 +40,18 @@ rdkit_extensions::opt_string_t peptide_natural_analog(std::string_view sym)
 // `dFoo` is the D-form of `Foo` iff both exist as PEPTIDEs and share
 // the same NATURAL_ANALOG. Prefix alone is unsafe — a custom DB could
 // name an entry `dXyz` with no semantic link to `Xyz`.
-bool is_d_form(std::string_view sym)
+static bool is_d_form(std::string_view sym)
 {
     if (sym.size() < 2 || sym.front() != 'd') {
         return false;
     }
-    auto sym_analog = peptide_natural_analog(sym);
-    auto stripped_analog = peptide_natural_analog(sym.substr(1));
+    auto sym_analog = get_peptide_natural_analog(sym);
+    auto stripped_analog = get_peptide_natural_analog(sym.substr(1));
     return sym_analog && stripped_analog && !sym_analog->empty() &&
            *sym_analog == *stripped_analog;
 }
 
-std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
+static std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
 {
     if (is_d_form(sym)) {
         // Stripping the prefix is safe: is_d_form only succeeds when
@@ -63,8 +61,8 @@ std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
     // L → D: candidate "d" + sym is a true D-form when both sides
     // exist in the DB AND share the same NATURAL_ANALOG.
     auto candidate = std::string("d") + std::string(sym);
-    auto candidate_analog = peptide_natural_analog(candidate);
-    auto sym_analog = peptide_natural_analog(sym);
+    auto candidate_analog = get_peptide_natural_analog(candidate);
+    auto sym_analog = get_peptide_natural_analog(sym);
     if (candidate_analog && sym_analog && !candidate_analog->empty() &&
         *candidate_analog == *sym_analog) {
         return candidate;
@@ -72,10 +70,14 @@ std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
     return std::nullopt;
 }
 
-// Target D-Form unless every atom is already D-form.
-bool should_target_d_form(const std::unordered_set<const RDKit::Atom*>& atoms)
+// True only when every atom in `atoms` is already a D-form residue.
+// Used to drive the Set D-/L-Form action label and target: when this
+// returns true, the action reads "Set L-Form" and clicking it flips
+// the residues back to L; otherwise it reads "Set D-Form".
+static bool
+all_residues_are_d_form(const std::unordered_set<const RDKit::Atom*>& atoms)
 {
-    return !std::ranges::all_of(atoms, [](const auto* a) {
+    return std::ranges::all_of(atoms, [](const auto* a) {
         return is_d_form(get_monomer_res_name(a));
     });
 }
@@ -85,7 +87,7 @@ bool should_target_d_form(const std::unordered_set<const RDKit::Atom*>& atoms)
 // no DB counterpart are dropped. Returns one MonomerMutation per
 // distinct target symbol so the receiver can coalesce them under one
 // undo entry.
-std::vector<MonomerMutation>
+static std::vector<MonomerMutation>
 build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
                    bool target_d_form)
 {
@@ -111,7 +113,7 @@ build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
 // Filter to the atoms whose current symbol differs from `target` —
 // avoids pushing a no-op mutation (and a useless undo entry) when the
 // user picks a target that the residue is already at.
-std::unordered_set<const RDKit::Atom*>
+static std::unordered_set<const RDKit::Atom*>
 atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
                        std::string_view target)
 {
@@ -123,8 +125,6 @@ atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
     }
     return out;
 }
-
-} // namespace
 
 MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     AbstractContextMenu(parent)
@@ -193,7 +193,7 @@ void MonomerContextMenu::createMutateResidueSubMenu()
 void MonomerContextMenu::createSetDFormAction()
 {
     m_set_d_form_action = addAction("Set D-Form", this, [this]() {
-        const bool target_d_form = should_target_d_form(m_atoms);
+        const bool target_d_form = !all_residues_are_d_form(m_atoms);
         auto batch = build_d_form_batch(m_atoms, target_d_form);
         if (batch.empty()) {
             return;
@@ -236,7 +236,7 @@ void MonomerContextMenu::updateActions()
             break;
         }
     }
-    const bool target_d_form = should_target_d_form(m_atoms);
+    const bool target_d_form = !all_residues_are_d_form(m_atoms);
     m_set_d_form_action->setText(target_d_form ? "Set D-Form" : "Set L-Form");
     m_set_d_form_action->setEnabled(any_d_form_toggleable);
 }

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -1,15 +1,244 @@
 #include "schrodinger/sketcher/menu/monomer_context_menu.h"
 
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <QAction>
+#include <QMenu>
+#include <rdkit/GraphMol/Atom.h>
+
+#include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/rdkit_extensions/monomer_mol.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
 namespace schrodinger
 {
 namespace sketcher
 {
 
+namespace
+{
+
+bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
+{
+    if (atoms.empty()) {
+        return false;
+    }
+    return std::ranges::all_of(atoms, [](const auto* a) {
+        return get_monomer_type(a) == MonomerType::PEPTIDE;
+    });
+}
+
+rdkit_extensions::opt_string_t peptide_natural_analog(std::string_view sym)
+{
+    return rdkit_extensions::MonomerDatabase::instance().getNaturalAnalog(
+        std::string(sym), rdkit_extensions::ChainType::PEPTIDE);
+}
+
+// `dFoo` is the D-form of `Foo` iff both exist as PEPTIDEs and share
+// the same NATURAL_ANALOG. Prefix alone is unsafe — a custom DB could
+// name an entry `dXyz` with no semantic link to `Xyz`.
+bool is_d_form(std::string_view sym)
+{
+    if (sym.size() < 2 || sym.front() != 'd') {
+        return false;
+    }
+    auto sym_analog = peptide_natural_analog(sym);
+    auto stripped_analog = peptide_natural_analog(sym.substr(1));
+    return sym_analog && stripped_analog && !sym_analog->empty() &&
+           *sym_analog == *stripped_analog;
+}
+
+std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
+{
+    if (is_d_form(sym)) {
+        // Stripping the prefix is safe: is_d_form only succeeds when
+        // the L-form counterpart exists with a matching analog.
+        return std::string(sym.substr(1));
+    }
+    // L → D: candidate "d" + sym is a true D-form when both sides
+    // exist in the DB AND share the same NATURAL_ANALOG.
+    auto candidate = std::string("d") + std::string(sym);
+    auto candidate_analog = peptide_natural_analog(candidate);
+    auto sym_analog = peptide_natural_analog(sym);
+    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
+        *candidate_analog == *sym_analog) {
+        return candidate;
+    }
+    return std::nullopt;
+}
+
+// Target D-Form unless every atom is already D-form.
+bool should_target_d_form(const std::unordered_set<const RDKit::Atom*>& atoms)
+{
+    return !std::ranges::all_of(atoms, [](const auto* a) {
+        return is_d_form(get_monomer_res_name(a));
+    });
+}
+
+// Build the per-target-symbol mutation batch for the D-form toggle.
+// Atoms already at the target form are skipped; atoms whose toggle has
+// no DB counterpart are dropped. Returns one MonomerMutation per
+// distinct target symbol so the receiver can coalesce them under one
+// undo entry.
+std::vector<MonomerMutation>
+build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                   bool target_d_form)
+{
+    std::unordered_map<std::string, std::unordered_set<const RDKit::Atom*>>
+        by_target;
+    for (const auto* a : atoms) {
+        const auto current = get_monomer_res_name(a);
+        if (is_d_form(current) == target_d_form) {
+            continue;
+        }
+        if (auto next = toggle_d_form_symbol(current)) {
+            by_target[*next].insert(a);
+        }
+    }
+    std::vector<MonomerMutation> batch;
+    batch.reserve(by_target.size());
+    for (auto& [sym, group] : by_target) {
+        batch.push_back({std::move(group), sym});
+    }
+    return batch;
+}
+
+// Filter to the atoms whose current symbol differs from `target` —
+// avoids pushing a no-op mutation (and a useless undo entry) when the
+// user picks a target that the residue is already at.
+std::unordered_set<const RDKit::Atom*>
+atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
+                       std::string_view target)
+{
+    std::unordered_set<const RDKit::Atom*> out;
+    for (const auto* a : atoms) {
+        if (get_monomer_res_name(a) != target) {
+            out.insert(a);
+        }
+    }
+    return out;
+}
+
+} // namespace
+
 MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     AbstractContextMenu(parent)
 {
     setTitle("Monomer");
+    createMutateResidueSubMenu();
+    createSetDFormAction();
+    createProtonateAction();
+    createDeleteAction();
+}
+
+void MonomerContextMenu::createMutateResidueSubMenu()
+{
+    // Palette of natural AAs each with a sub-submenu of analogs queried
+    // from the monomer DB. Captured once at construction; mid-session
+    // custom-DB updates won't reflect until the menu is rebuilt.
+    m_mutate_residue_menu = addMenu("Mutate Residue");
+    auto analogs_by_aa =
+        rdkit_extensions::MonomerDatabase::instance()
+            .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::PEPTIDE);
+
+    auto emit_mutation = [this](std::string sym) {
+        auto target_atoms = atoms_needing_mutation(m_atoms, sym);
+        if (target_atoms.empty()) {
+            return;
+        }
+        emit mutateResidueRequested({{std::move(target_atoms), std::move(sym)}},
+                                    {});
+    };
+
+    for (auto aa_tool : AMINO_ACID_TOOL_DISPLAY_ORDER) {
+        const auto& symbol = AMINO_ACID_TOOL_TO_RES_NAME.at(aa_tool);
+        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
+        const auto title = QString::fromStdString(name + " (" + symbol + ")");
+        auto* sub = m_mutate_residue_menu->addMenu(title);
+
+        const auto natural_sym = symbol;
+        sub->addAction(
+            QString::fromStdString(natural_sym), this,
+            [emit_mutation, natural_sym]() { emit_mutation(natural_sym); });
+
+        const auto it = analogs_by_aa.find(symbol);
+        if (it == analogs_by_aa.end() || it->second.empty()) {
+            continue;
+        }
+        auto analogs = it->second;
+        std::ranges::sort(analogs, {}, [](const auto& info) {
+            return info.symbol.value_or("");
+        });
+        for (const auto& info : analogs) {
+            if (!info.symbol) {
+                continue;
+            }
+            const auto sym = *info.symbol;
+            QString label = QString::fromStdString(sym);
+            if (info.name && !info.name->empty()) {
+                label +=
+                    QString(" — %1").arg(QString::fromStdString(*info.name));
+            }
+            sub->addAction(label, this,
+                           [emit_mutation, sym]() { emit_mutation(sym); });
+        }
+    }
+}
+
+void MonomerContextMenu::createSetDFormAction()
+{
+    m_set_d_form_action = addAction("Set D-Form", this, [this]() {
+        const bool target_d_form = should_target_d_form(m_atoms);
+        auto batch = build_d_form_batch(m_atoms, target_d_form);
+        if (batch.empty()) {
+            return;
+        }
+        emit mutateResidueRequested(
+            std::move(batch), target_d_form ? "Set D-Form" : "Set L-Form");
+    });
+}
+
+void MonomerContextMenu::createProtonateAction()
+{
+    // Placeholder for a future SKETCH-2648 phase — the monomer DB has
+    // no protonated/deprotonated symbol pairs today, so there's nothing
+    // to wire. Shown disabled to reserve the slot per the spec mockup.
+    m_protonate_action = addAction("Protonate");
+    m_protonate_action->setEnabled(false);
+}
+
+void MonomerContextMenu::createDeleteAction()
+{
     addAction("Delete", this, [this]() { emit deleteRequested(m_atoms); });
+}
+
+void MonomerContextMenu::updateActions()
+{
+    const bool peptide = all_peptide(m_atoms);
+
+    m_mutate_residue_menu->menuAction()->setVisible(peptide);
+    m_set_d_form_action->setVisible(peptide);
+    m_protonate_action->setVisible(peptide);
+
+    if (!peptide) {
+        return;
+    }
+
+    bool any_d_form_toggleable = false;
+    for (const auto* a : m_atoms) {
+        if (toggle_d_form_symbol(get_monomer_res_name(a)).has_value()) {
+            any_d_form_toggleable = true;
+            break;
+        }
+    }
+    const bool target_d_form = should_target_d_form(m_atoms);
+    m_set_d_form_action->setText(target_d_form ? "Set D-Form" : "Set L-Form");
+    m_set_d_form_action->setEnabled(any_d_form_toggleable);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.h
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <string>
 #include <unordered_set>
+#include <vector>
+
+#include <QString>
 
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/menu/abstract_context_menu.h"
+
+class QAction;
+class QMenu;
 
 namespace RDKit
 {
@@ -16,8 +23,22 @@ namespace sketcher
 {
 
 /**
- * Context menu for monomer beads. Currently exposes only Delete; later
- * phases of SKETCH-2648 will add monomer-type-specific actions.
+ * One unit of work for `MolModel::mutateMonomers`: a set of atoms that
+ * should all be mutated to the same target HELM symbol. Used as the
+ * batch element in `MonomerContextMenu::mutateResidueRequested`.
+ */
+struct MonomerMutation {
+    std::unordered_set<const RDKit::Atom*> atoms;
+    std::string helm_symbol;
+};
+
+/**
+ * Context menu for monomer beads.
+ *
+ * For amino-acid (PEPTIDE) selections this exposes "Mutate Residue >"
+ * with the natural AAs and their non-natural analogs, a dynamic
+ * "Set D-Form / Set L-Form" toggle, a disabled "Protonate" stub, and
+ * Delete. Other monomer types only see Delete.
  */
 class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
 {
@@ -28,8 +49,27 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
   signals:
     void deleteRequested(const std::unordered_set<const RDKit::Atom*>& atoms);
 
+    /**
+     * @brief Mutate one or more groups of monomers in a single user action.
+     * @param mutations is a list of (atoms, target HELM symbol) pairs
+     * @param description is the undo-stack label the receiver should use
+     * when coalescing a multi-pair batch into one undo entry.
+     */
+    void mutateResidueRequested(std::vector<MonomerMutation> mutations,
+                                QString description);
+
+  protected:
+    void updateActions() override;
+
   private:
-    void updateActions() override{};
+    void createMutateResidueSubMenu();
+    void createSetDFormAction();
+    void createProtonateAction();
+    void createDeleteAction();
+
+    QMenu* m_mutate_residue_menu = nullptr;
+    QAction* m_set_d_form_action = nullptr;
+    QAction* m_protonate_action = nullptr;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -367,6 +368,45 @@ const std::unordered_map<AminoAcidTool, std::string>
         {AminoAcidTool::VAL, "V"},
         {AminoAcidTool::UNK, "X"},
     }; // clang-format on
+
+const std::unordered_map<AminoAcidTool, std::string>
+    AMINO_ACID_TOOL_TO_FULL_NAME{
+        {AminoAcidTool::ALA, "Alanine"}, // clang-format off
+        {AminoAcidTool::ARG, "Arginine"},
+        {AminoAcidTool::ASN, "Asparagine"},
+        {AminoAcidTool::ASP, "Aspartate"},
+        {AminoAcidTool::CYS, "Cysteine"},
+        {AminoAcidTool::GLN, "Glutamine"},
+        {AminoAcidTool::GLU, "Glutamate"},
+        {AminoAcidTool::GLY, "Glycine"},
+        {AminoAcidTool::HIS, "Histidine"},
+        {AminoAcidTool::ILE, "Isoleucine"},
+        {AminoAcidTool::LEU, "Leucine"},
+        {AminoAcidTool::LYS, "Lysine"},
+        {AminoAcidTool::MET, "Methionine"},
+        {AminoAcidTool::PHE, "Phenylalanine"},
+        {AminoAcidTool::PRO, "Proline"},
+        {AminoAcidTool::SER, "Serine"},
+        {AminoAcidTool::THR, "Threonine"},
+        {AminoAcidTool::TRP, "Tryptophan"},
+        {AminoAcidTool::TYR, "Tyrosine"},
+        {AminoAcidTool::VAL, "Valine"},
+        {AminoAcidTool::UNK, "Unknown"},
+    }; // clang-format on
+
+// Display order for the 21 natural amino acids — mirrored by the toolbar
+// button layout (`monomer_tool_widget.cpp`) and by the Mutate Residue
+// submenu in `MonomerContextMenu`. Both call sites iterate this array so
+// they cannot drift apart.
+constexpr std::array<AminoAcidTool, 21> AMINO_ACID_TOOL_DISPLAY_ORDER{
+    AminoAcidTool::ALA, AminoAcidTool::ARG, AminoAcidTool::ASN,
+    AminoAcidTool::ASP, AminoAcidTool::CYS, AminoAcidTool::GLN,
+    AminoAcidTool::GLU, AminoAcidTool::GLY, AminoAcidTool::HIS,
+    AminoAcidTool::ILE, AminoAcidTool::LEU, AminoAcidTool::LYS,
+    AminoAcidTool::MET, AminoAcidTool::PHE, AminoAcidTool::PRO,
+    AminoAcidTool::SER, AminoAcidTool::THR, AminoAcidTool::TRP,
+    AminoAcidTool::TYR, AminoAcidTool::VAL, AminoAcidTool::UNK,
+};
 
 enum class NucleicAcidTool {
     A,

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -87,6 +87,9 @@ struct IndexedMonomerMutation {
  * add/remove/reorder). The caller resolves each batch's indices back
  * to live atoms via `getMol()->getAtomWithIdx(...)` immediately
  * before each mutation.
+ *
+ * Consumes its input — `mutations` is moved-from on return, so
+ * callers should not reference it afterwards.
  */
 static std::vector<IndexedMonomerMutation>
 capture_atom_indices(std::vector<MonomerMutation> mutations)
@@ -809,16 +812,9 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
                 }
                 auto indexed = capture_atom_indices(std::move(mutations));
 
-                // Multi-pair batches (the D-/L-Form toggle when residues map to
-                // multiple target symbols) get wrapped in a single QUndoStack
-                // macro so the user sees one undo entry.
-                const bool batch = indexed.size() > 1;
-                if (batch) {
-                    m_undo_stack->beginMacro(
-                        description.isEmpty()
-                            ? QStringLiteral("Mutate Monomers")
-                            : description);
-                }
+                auto undo_raii = m_mol_model->createUndoMacro(
+                    description.isEmpty() ? QStringLiteral("Mutate Monomers")
+                                          : description);
                 for (auto& [idxs, sym] : indexed) {
                     std::unordered_set<const RDKit::Atom*> resolved;
                     resolved.reserve(idxs.size());
@@ -828,9 +824,6 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
                     }
                     m_mol_model->mutateMonomers(resolved, sym,
                                                 MonomerType::PEPTIDE);
-                }
-                if (batch) {
-                    m_undo_stack->endMacro();
                 }
             });
 }

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -70,6 +70,41 @@ namespace sketcher
 {
 
 /**
+ * Index-keyed counterpart to MonomerMutation: the same `(atoms,
+ * helm_symbol)` pair, but with atom identity captured by index so it
+ * survives a `MolModel::mutateMonomers` call (which may invalidate
+ * raw `RDKit::Atom*` pointers via its snapshot mechanism).
+ */
+struct IndexedMonomerMutation {
+    std::vector<unsigned int> atom_indices;
+    std::string helm_symbol;
+};
+
+/**
+ * Capture atom identity by index before a sequence of
+ * `MolModel::mutateMonomers` calls. Indices are stable since the
+ * underlying `mutateMonomer` only edits properties (no atom
+ * add/remove/reorder). The caller resolves each batch's indices back
+ * to live atoms via `getMol()->getAtomWithIdx(...)` immediately
+ * before each mutation.
+ */
+static std::vector<IndexedMonomerMutation>
+capture_atom_indices(std::vector<MonomerMutation> mutations)
+{
+    std::vector<IndexedMonomerMutation> indexed;
+    indexed.reserve(mutations.size());
+    for (auto& [atoms, sym] : mutations) {
+        std::vector<unsigned int> idxs;
+        idxs.reserve(atoms.size());
+        for (const auto* a : atoms) {
+            idxs.push_back(a->getIdx());
+        }
+        indexed.push_back({std::move(idxs), std::move(sym)});
+    }
+    return indexed;
+}
+
+/**
  * Map a NucleicAcidTool to the corresponding MonomerType.
  * Only valid for individual component tools (bases, sugars, phosphate),
  * not full nucleotide tools (RNA, DNA, CUSTOM).
@@ -766,6 +801,38 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
 {
     connect(&menu, &MonomerContextMenu::deleteRequested, this,
             [this](auto atoms) { m_mol_model->remove(atoms, {}, {}, {}, {}); });
+
+    connect(&menu, &MonomerContextMenu::mutateResidueRequested, this,
+            [this](auto mutations, const QString& description) {
+                if (mutations.empty()) {
+                    return;
+                }
+                auto indexed = capture_atom_indices(std::move(mutations));
+
+                // Multi-pair batches (the D-/L-Form toggle when residues map to
+                // multiple target symbols) get wrapped in a single QUndoStack
+                // macro so the user sees one undo entry.
+                const bool batch = indexed.size() > 1;
+                if (batch) {
+                    m_undo_stack->beginMacro(
+                        description.isEmpty()
+                            ? QStringLiteral("Mutate Monomers")
+                            : description);
+                }
+                for (auto& [idxs, sym] : indexed) {
+                    std::unordered_set<const RDKit::Atom*> resolved;
+                    resolved.reserve(idxs.size());
+                    const auto* mol = m_mol_model->getMol();
+                    for (auto i : idxs) {
+                        resolved.insert(mol->getAtomWithIdx(i));
+                    }
+                    m_mol_model->mutateMonomers(resolved, sym,
+                                                MonomerType::PEPTIDE);
+                }
+                if (batch) {
+                    m_undo_stack->endMacro();
+                }
+            });
 }
 
 void SketcherWidget::connectContextMenu(const ModifyAtomsMenu& menu)

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -111,17 +111,6 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
     ui->na_custom_nt_btn->setPopupWidget(m_custom_nt_popup);
 
     // Set up amino acid analog popups from the monomer database
-    static const std::unordered_map<std::string, std::string>
-        STANDARD_AA_NAMES = {
-            {"A", "Alanine"},    {"R", "Arginine"},      {"N", "Asparagine"},
-            {"D", "Aspartate"},  {"C", "Cysteine"},      {"Q", "Glutamine"},
-            {"E", "Glutamate"},  {"G", "Glycine"},       {"H", "Histidine"},
-            {"I", "Isoleucine"}, {"L", "Leucine"},       {"K", "Lysine"},
-            {"M", "Methionine"}, {"F", "Phenylalanine"}, {"P", "Proline"},
-            {"S", "Serine"},     {"T", "Threonine"},     {"W", "Tryptophan"},
-            {"Y", "Tyrosine"},   {"V", "Valine"},        {"X", "Unknown"},
-        };
-
     auto analogs_by_aa =
         rdkit_extensions::MonomerDatabase::instance()
             .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::PEPTIDE);
@@ -134,8 +123,7 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
         if (it == analogs_by_aa.end() || it->second.empty()) {
             continue;
         }
-        auto name_it = STANDARD_AA_NAMES.find(symbol);
-        auto name = name_it != STANDARD_AA_NAMES.end() ? name_it->second : "";
+        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
         auto* popup = new AminoAcidSymbolPopup(symbol, name, it->second, this);
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
         Q_ASSERT_X(modular_btn, "MonomerToolWidget",

--- a/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
@@ -1,17 +1,26 @@
 #define BOOST_TEST_MODULE Test_Sketcher
 
 #include <algorithm>
+#include <string>
+#include <string_view>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
 #include <QAction>
+#include <QMenu>
 #include <QObject>
+#include <QString>
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/ROMol.h>
 
+#include "../../rdkit_extensions/test_common.h"
 #include "../test_common.h"
 #include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/sketcher/menu/monomer_context_menu.h"
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
@@ -21,10 +30,77 @@ namespace schrodinger
 namespace sketcher
 {
 
+class TestMonomerContextMenu : public MonomerContextMenu
+{
+  public:
+    TestMonomerContextMenu() : MonomerContextMenu()
+    {
+    }
+    using MonomerContextMenu::updateActions;
+};
+
+namespace
+{
+
+QAction* find_action(QMenu& menu, const QString& text)
+{
+    for (auto* a : menu.actions()) {
+        if (a->text() == text) {
+            return a;
+        }
+    }
+    return nullptr;
+}
+
+std::unordered_set<const RDKit::Atom*>
+atoms_from(const RDKit::ROMol& mol, std::initializer_list<unsigned int> idxs)
+{
+    std::unordered_set<const RDKit::Atom*> out;
+    for (auto i : idxs) {
+        out.insert(mol.getAtomWithIdx(i));
+    }
+    return out;
+}
+
+// Captures the most recent `mutateResidueRequested` emission.
+struct MutateRequestCapture {
+    std::vector<MonomerMutation> last_mutations;
+    QString last_description;
+    int call_count = 0;
+
+    void connectTo(MonomerContextMenu& menu)
+    {
+        QObject::connect(&menu, &MonomerContextMenu::mutateResidueRequested,
+                         &menu,
+                         [this](auto mutations, const QString& description) {
+                             last_mutations = std::move(mutations);
+                             last_description = description;
+                             ++call_count;
+                         });
+    }
+};
+
+// RAII helper for tests that need to inject custom monomer definitions.
+// Pairs with the LocalMonomerDbFixture global fixture, which redirects
+// the singleton to a per-binary scratch DB so we never touch the user's
+// real custom DB.
+struct CustomDbScope {
+    explicit CustomDbScope(std::string_view json)
+    {
+        rdkit_extensions::MonomerDatabase::instance().loadMonomersFromJson(
+            json);
+    }
+    ~CustomDbScope()
+    {
+        rdkit_extensions::MonomerDatabase::instance().resetMonomerDefinitions();
+    }
+};
+
+} // namespace
+
 /**
- * Triggering Delete must emit `deleteRequested` carrying exactly the set
- * of atoms the menu was populated with via `setContextItems`. This is the
- * contract `SketcherWidget` relies on to route the deletion to MolModel.
+ * Triggering Delete must emit `deleteRequested` carrying exactly the
+ * set of atoms the menu was populated with via `setContextItems`.
  */
 BOOST_AUTO_TEST_CASE(test_delete_emits_signal_with_context_atoms)
 {
@@ -42,14 +118,427 @@ BOOST_AUTO_TEST_CASE(test_delete_emits_signal_with_context_atoms)
                      });
 
     menu.setContextItems(input, {}, {}, {}, {});
-    auto actions = menu.actions();
-    auto it = std::ranges::find_if(
-        actions, [](auto* a) { return a->text() == "Delete"; });
-    BOOST_REQUIRE(it != actions.end());
-    (*it)->trigger();
+    auto* del = find_action(menu, "Delete");
+    BOOST_REQUIRE(del != nullptr);
+    del->trigger();
 
     BOOST_TEST(call_count == 1);
     BOOST_TEST(received == input);
+}
+
+/**
+ * On a peptide selection, all AA-specific actions are visible alongside
+ * Delete. Protonate is permanently disabled. Mutate Residue is a
+ * populated submenu with one entry per natural amino acid.
+ */
+BOOST_AUTO_TEST_CASE(test_actions_for_peptide_selection)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Residue");
+    auto* d_form = find_action(menu, "Set D-Form");
+    auto* protonate = find_action(menu, "Protonate");
+    auto* del = find_action(menu, "Delete");
+
+    BOOST_REQUIRE(mutate != nullptr);
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_REQUIRE(protonate != nullptr);
+    BOOST_REQUIRE(del != nullptr);
+
+    BOOST_TEST(mutate->isVisible());
+    BOOST_TEST(d_form->isVisible());
+    BOOST_TEST(protonate->isVisible());
+    BOOST_TEST(del->isVisible());
+    BOOST_TEST(!protonate->isEnabled());
+
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    BOOST_TEST(mutate->menu()->actions().size() == 21u);
+}
+
+/**
+ * Non-peptide selections (NA bases / sugars / phosphates / CHEM) only
+ * see Delete; AA-specific actions hide themselves.
+ */
+BOOST_AUTO_TEST_CASE(test_non_peptide_hides_aa_actions)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0, 1, 2}), {}, {}, {}, {});
+    menu.updateActions();
+
+    BOOST_TEST(!find_action(menu, "Mutate Residue")->isVisible());
+    BOOST_TEST(!find_action(menu, "Protonate")->isVisible());
+    // updateActions doesn't touch the label text when !peptide, so it
+    // still reads its constructor default "Set D-Form".
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(!d_form->isVisible());
+    BOOST_TEST(find_action(menu, "Delete")->isVisible());
+}
+
+/**
+ * Empty selection should never enter the AA branch.
+ */
+BOOST_AUTO_TEST_CASE(test_empty_selection_hides_aa_actions)
+{
+    TestMonomerContextMenu menu;
+    menu.setContextItems({}, {}, {}, {}, {});
+    menu.updateActions();
+
+    BOOST_TEST(!find_action(menu, "Mutate Residue")->isVisible());
+    BOOST_TEST(find_action(menu, "Delete")->isVisible());
+}
+
+/**
+ * A Mutate Residue leaf emits a single-pair batch with an empty
+ * description (so the receiver falls through to MolModel's default
+ * undo label).
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_residue_leaf_emits_single_pair_batch)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Residue");
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    auto* asp = find_action(*mutate->menu(), "Aspartate (D)");
+    BOOST_REQUIRE(asp != nullptr);
+    BOOST_REQUIRE(asp->menu() != nullptr);
+    auto* d_leaf = find_action(*asp->menu(), "D");
+    BOOST_REQUIRE(d_leaf != nullptr);
+    d_leaf->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description.isEmpty());
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "D");
+    BOOST_REQUIRE(capture.last_mutations[0].atoms.size() == 1u);
+    BOOST_TEST(*capture.last_mutations[0].atoms.begin() ==
+               mol->getAtomWithIdx(0));
+}
+
+/**
+ * The Mutate Residue submenu populates non-natural analogs from the DB.
+ * "meD" (N-Methyl-L-Aspartic acid) should appear under Aspartate (D) —
+ * a sentinel guarding against DB query / sort regressions.
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_residue_submenu_contains_known_analog)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Residue");
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    auto* asp = find_action(*mutate->menu(), "Aspartate (D)");
+    BOOST_REQUIRE(asp != nullptr);
+    BOOST_REQUIRE(asp->menu() != nullptr);
+
+    bool found_meD = false;
+    for (auto* a : asp->menu()->actions()) {
+        if (a->text().startsWith("meD")) {
+            found_meD = true;
+            break;
+        }
+    }
+    BOOST_TEST(found_meD);
+}
+
+/**
+ * The natural amino acid leaf must appear exactly once under its own
+ * sub-submenu — we add it explicitly while the DB query
+ * (getMonomersByNaturalAnalog) excludes it from the analog list. If
+ * that DB-side contract ever changes we'd start seeing a duplicate
+ * "D" leaf under "Aspartate (D)"; this test guards against that.
+ */
+BOOST_AUTO_TEST_CASE(test_natural_aa_appears_exactly_once_in_submenu)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Residue");
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    auto* asp = find_action(*mutate->menu(), "Aspartate (D)");
+    BOOST_REQUIRE(asp != nullptr);
+    BOOST_REQUIRE(asp->menu() != nullptr);
+
+    int d_count = 0;
+    for (auto* a : asp->menu()->actions()) {
+        if (a->text() == "D") {
+            ++d_count;
+        }
+    }
+    BOOST_TEST(d_count == 1);
+}
+
+/**
+ * Mutate Residue → X on a residue already at X must NOT emit, so we
+ * don't push a no-op mutation onto the undo stack.
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_residue_to_current_symbol_is_noop)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{D}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Residue");
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    auto* asp = find_action(*mutate->menu(), "Aspartate (D)");
+    BOOST_REQUIRE(asp != nullptr);
+    auto* d_leaf = find_action(*asp->menu(), "D");
+    BOOST_REQUIRE(d_leaf != nullptr);
+    d_leaf->trigger();
+
+    BOOST_TEST(capture.call_count == 0);
+}
+
+/**
+ * Triggering "Set L-Form" on a D residue emits a batch with the
+ * stripped (L) symbol and the matching macro label — symmetric with
+ * test_d_form_toggle_emits_grouped_batch but covering the D→L path.
+ */
+BOOST_AUTO_TEST_CASE(test_set_l_form_toggle_emits_l_symbol)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{[dD]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* l_form = find_action(menu, "Set L-Form");
+    BOOST_REQUIRE(l_form != nullptr);
+    BOOST_TEST(l_form->isEnabled());
+    l_form->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description == "Set L-Form");
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "D");
+}
+
+/**
+ * The D-/L-form action label flips based on the residue's current form.
+ */
+BOOST_AUTO_TEST_CASE(test_d_form_label_flips_with_selection)
+{
+    auto l_mol = rdkit_extensions::to_rdkit("PEPTIDE1{D}$$$$V2.0");
+    {
+        TestMonomerContextMenu menu;
+        menu.setContextItems(atoms_from(*l_mol, {0}), {}, {}, {}, {});
+        menu.updateActions();
+        BOOST_TEST(find_action(menu, "Set D-Form") != nullptr);
+        BOOST_TEST(find_action(menu, "Set L-Form") == nullptr);
+    }
+
+    auto d_mol = rdkit_extensions::to_rdkit("PEPTIDE1{[dD]}$$$$V2.0");
+    {
+        TestMonomerContextMenu menu;
+        menu.setContextItems(atoms_from(*d_mol, {0}), {}, {}, {}, {});
+        menu.updateActions();
+        BOOST_TEST(find_action(menu, "Set L-Form") != nullptr);
+        BOOST_TEST(find_action(menu, "Set D-Form") == nullptr);
+    }
+}
+
+/**
+ * Mixed L+D selection defaults to "Set D-Form" — clicking it normalises
+ * to D, leaving the existing D residue alone.
+ */
+BOOST_AUTO_TEST_CASE(test_d_form_mixed_selection_defaults_to_set_d)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{D.[dD]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0, 1}), {}, {}, {}, {});
+    menu.updateActions();
+
+    BOOST_TEST(find_action(menu, "Set D-Form") != nullptr);
+    BOOST_TEST(find_action(menu, "Set L-Form") == nullptr);
+}
+
+/**
+ * Glycine has no D-form counterpart in the DB (it's achiral), so the
+ * action must disable rather than silently do nothing on click.
+ */
+BOOST_AUTO_TEST_CASE(test_d_form_disabled_when_no_db_counterpart)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{G}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(!d_form->isEnabled());
+}
+
+/**
+ * D-Form toggle on a mixed L+D selection emits one batch entry per
+ * distinct target symbol (here only the L residue needs mutating).
+ * Description carries the macro label that the receiver feeds to
+ * QUndoStack::beginMacro.
+ */
+BOOST_AUTO_TEST_CASE(test_d_form_toggle_emits_grouped_batch)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{D.[dD]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0, 1}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(d_form->isEnabled());
+    d_form->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description == "Set D-Form");
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "dD");
+    BOOST_REQUIRE(capture.last_mutations[0].atoms.size() == 1u);
+    BOOST_TEST(*capture.last_mutations[0].atoms.begin() ==
+               mol->getAtomWithIdx(0));
+}
+
+/**
+ * A custom monomer named "dXyz" whose NATURAL_ANALOG points at an
+ * unrelated residue ("K") must NOT be classified as the D-form of
+ * "Xyz" — the prefix is meaningless without DB corroboration. The
+ * Set D-Form action stays disabled (no toggle target) and labels as
+ * "Set D-Form" (not "Set L-Form").
+ */
+BOOST_AUTO_TEST_CASE(test_custom_d_prefix_with_mismatched_analog_is_not_d_form)
+{
+    constexpr std::string_view json = R"([{
+        "symbol": "dXyz",
+        "polymer_type": "PEPTIDE",
+        "natural_analog": "K",
+        "smiles": "C[C@@H](N[H:1])C(=O)[OH:2]",
+        "core_smiles": "C[C@@H](N[H:1])C(=O)[OH:2]",
+        "name": "Custom dXyz",
+        "monomer_type": "Backbone",
+        "author": "test",
+        "pdbcode": "DXYZ"
+    }])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{[dXyz]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(!d_form->isEnabled());
+    BOOST_TEST(find_action(menu, "Set L-Form") == nullptr);
+}
+
+/**
+ * A realistic custom L+D pair: alpha-aminobutyric acid ("Abu") and its
+ * D-form ("dAbu"), both tagged as Ala-class variants
+ * (NATURAL_ANALOG="A"). Two symbols with the same NATURAL_ANALOG and
+ * the `d` prefix relationship are recognised as a stereo pair, so the
+ * toggle enables and emits "dAbu" on click.
+ */
+BOOST_AUTO_TEST_CASE(test_custom_well_formed_d_form_pair_enables_toggle)
+{
+    constexpr std::string_view json = R"([
+        {
+            "symbol": "Abu",
+            "polymer_type": "PEPTIDE",
+            "natural_analog": "A",
+            "smiles": "CC[C@H](N[H:1])C(=O)[OH:2]",
+            "core_smiles": "CC[C@H](N[H:1])C(=O)[OH:2]",
+            "name": "alpha-Aminobutyric acid",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "ABU"
+        },
+        {
+            "symbol": "dAbu",
+            "polymer_type": "PEPTIDE",
+            "natural_analog": "A",
+            "smiles": "CC[C@@H](N[H:1])C(=O)[OH:2]",
+            "core_smiles": "CC[C@@H](N[H:1])C(=O)[OH:2]",
+            "name": "D-alpha-Aminobutyric acid",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "DAB"
+        }
+    ])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{[Abu]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(d_form->isEnabled());
+    d_form->trigger();
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "dAbu");
+}
+
+/**
+ * Both symbols exist and the `d` prefix relationship looks right, but
+ * their NATURAL_ANALOGs disagree — the author has tagged them as
+ * variants of different natural amino acids, so they aren't actually
+ * stereo partners. The classifier rejects the pair.
+ */
+BOOST_AUTO_TEST_CASE(test_custom_paired_with_different_analogs_is_not_d_form)
+{
+    constexpr std::string_view json = R"([
+        {
+            "symbol": "Foo",
+            "polymer_type": "PEPTIDE",
+            "natural_analog": "A",
+            "smiles": "C[C@H](N[H:1])C(=O)[OH:2]",
+            "core_smiles": "C[C@H](N[H:1])C(=O)[OH:2]",
+            "name": "Custom Foo",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "FOO"
+        },
+        {
+            "symbol": "dFoo",
+            "polymer_type": "PEPTIDE",
+            "natural_analog": "K",
+            "smiles": "C[C@@H](N[H:1])C(=O)[OH:2]",
+            "core_smiles": "C[C@@H](N[H:1])C(=O)[OH:2]",
+            "name": "Custom dFoo",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "DFO"
+        }
+    ])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{[Foo]}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* d_form = find_action(menu, "Set D-Form");
+    BOOST_REQUIRE(d_form != nullptr);
+    BOOST_TEST(!d_form->isEnabled());
 }
 
 } // namespace sketcher


### PR DESCRIPTION
* Linked Case: SKETCH-2648

### Description
Adds the ability to Set L-form and D-form for that monomer(s) in context menu.

Not sure if there's a canonical way to do this(!!!), but settled on defining a structural set of rules for what classifies as a d-form monomer:
1. symbol begins with `d`
2. symbol is a `PEPTIDE`
3. symbol stripped of prefix `d` also exists in the DB as a peptide
4. both entries share the same `NATURAL_ANALOG` fields and are non-empty.

### Testing Done
Adds various tests for submenu/action visibility and labels depending on the selected aa monomer(s). Also included some tests against the d-amino acids ruleset.
