### PR TITLE
SKETCH-2618: Ensuring unique chain names when adding monomer mols to MolModel

### DIFF
--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -1197,6 +1197,14 @@ void MolModel::addMol(RDKit::RWMol mol, const QString& description,
     // Ensure the newly added mol has coords and necessary stereo information
     prepare_mol(mol);
 
+    // if this is a monomeric molecule, make sure that the chain names are
+    // different than the chains that are currently in MolModel
+    if (rdkit_extensions::isMonomeric(mol) && isMonomeric()) {
+        // we use getMolForExport() here to ensure that the HELM_MODEL property
+        // is set
+        ensure_distinct_chain_names(mol, *getMolForExport());
+    }
+
     if (reposition_mol) {
         if (!m_mol.getNumAtoms()) {
             // if we don't have any existing structure, center the new molecule

--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 
+#include <boost/range/combine.hpp>
 #include <boost/range/join.hpp>
 
 #include <QGraphicsItem>
@@ -805,9 +806,14 @@ int get_chain_num(const std::string_view chain_name,
     }
 }
 
-std::string
-get_first_available_chain_name(const RDKit::ROMol& mol,
-                               const rdkit_extensions::ChainType chain_type)
+/**
+ * @return a list containing the num_names lowest numbered chain names (of the
+ * specified type) that don't already exist in the molecule.
+ */
+static std::vector<std::string>
+get_first_available_chain_names(const RDKit::ROMol& mol,
+                                const rdkit_extensions::ChainType chain_type,
+                                const unsigned int num_names)
 {
     auto prefix = rdkit_extensions::toString(chain_type);
     std::unordered_set<int> chain_nums;
@@ -818,11 +824,27 @@ get_first_available_chain_name(const RDKit::ROMol& mol,
         int cur_chain_num = get_chain_num(chain_name, chain_type);
         chain_nums.insert(cur_chain_num);
     }
-    int missing_num = 1;
-    while (chain_nums.contains(missing_num)) {
-        ++missing_num;
+    std::vector<int> missing_nums;
+    missing_nums.reserve(num_names);
+    int num_to_check = 1;
+    while (missing_nums.size() < num_names) {
+        if (!chain_nums.contains(num_to_check)) {
+            missing_nums.push_back(num_to_check);
+        }
+        ++num_to_check;
     }
-    return fmt::format("{}{}", prefix, missing_num);
+    std::vector<std::string> new_names;
+    std::ranges::transform(
+        missing_nums, std::back_inserter(new_names),
+        [&prefix](auto num) { return fmt::format("{}{}", prefix, num); });
+    return new_names;
+}
+
+std::string
+get_first_available_chain_name(const RDKit::ROMol& mol,
+                               const rdkit_extensions::ChainType chain_type)
+{
+    return get_first_available_chain_names(mol, chain_type, 1).front();
 }
 
 std::pair<std::string, bool>
@@ -929,6 +951,44 @@ unsigned int add_monomer_connection(RDKit::RWMol& mol, RDKit::Atom* monomer_one,
         mol, monomer_one->getIdx(), monomer_two->getIdx(), linkage,
         is_custom_bond);
     return bond->getIdx();
+}
+
+void ensure_distinct_chain_names(RDKit::ROMol& mol_to_change,
+                                 const RDKit::ROMol& reference_mol)
+{
+    using rdkit_extensions::ChainType;
+    auto ref_polymer_ids = rdkit_extensions::get_polymer_ids(reference_mol);
+    auto polymer_ids_to_change =
+        rdkit_extensions::get_polymer_ids(mol_to_change);
+    // build a list of all chain names to change, divided up by chain type
+    std::unordered_map<ChainType, std::vector<std::string>> chain_names_by_type;
+    for (const auto& cur_polymer_id : polymer_ids_to_change) {
+        auto cur_chain_type = rdkit_extensions::getChainType(cur_polymer_id);
+        chain_names_by_type[cur_chain_type].push_back(cur_polymer_id);
+    }
+    // create a map of old chain name to new chain name
+    std::unordered_map<std::string, std::string> chain_name_map;
+    for (auto [chain_type, orig_chain_names] : chain_names_by_type) {
+        auto new_chain_names = get_first_available_chain_names(
+            reference_mol, chain_type, orig_chain_names.size());
+        for (const auto& [cur_orig_chain, cur_new_chain] :
+             boost::combine(orig_chain_names, new_chain_names)) {
+            chain_name_map[cur_orig_chain] = cur_new_chain;
+        }
+    }
+    // change the chain names for each atom
+    for (auto atom : mol_to_change.atoms()) {
+        auto* monomer_info = atom->getMonomerInfo();
+        if (monomer_info == nullptr) {
+            continue;
+        }
+        auto* pdb_res_info =
+            static_cast<RDKit::AtomPDBResidueInfo*>(monomer_info);
+        auto chain_id = pdb_res_info->getChainId();
+        if (chain_name_map.contains(chain_id)) {
+            pdb_res_info->setChainId(chain_name_map.at(chain_id));
+        }
+    }
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -329,5 +329,13 @@ SKETCHER_API unsigned int add_monomer_connection(RDKit::RWMol& mol,
                                                  RDKit::Atom* const monomer_two,
                                                  const std::string_view ap_two);
 
+/**
+ * Change chain names in mol_to_change to ensure that all of the names are
+ * different from those in reference_mol
+ */
+SKETCHER_API void
+ensure_distinct_chain_names(RDKit::ROMol& mol_to_change,
+                            const RDKit::ROMol& reference_mol);
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4876,5 +4876,35 @@ BOOST_AUTO_TEST_CASE(test_addMonomer_disconnected)
     BOOST_TEST(helm == "PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$$$$V2.0");
 }
 
+/**
+ * Make sure that adding a HELM string renames any chains if they have the same
+ * name as chains that already exist in MolModel.
+ */
+BOOST_AUTO_TEST_CASE(test_helm_string_chain_renaming)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+
+    add_text_to_mol_model(model, "RNA1{R(A)P}|RNA2{R(C)P}$$$$V2.0");
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{R(A)P}|RNA2{R(C)P}$$$$V2.0");
+
+    add_text_to_mol_model(model, "RNA1{R(G)P}|RNA2{R(T)P}$$$$V2.0");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm ==
+               "RNA1{R(A)P}|RNA2{R(C)P}|RNA3{R(G)P}|RNA4{R(T)P}$$$$V2.0");
+
+    add_text_to_mol_model(model, "RNA1{[dR](A)P}|RNA2{[dR](C)P}$$$$V2.0");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{R(A)P}|RNA2{R(C)P}|RNA3{R(G)P}|RNA4{R(T)P}|RNA5{["
+                       "dR](A)P}|RNA6{[dR](C)P}$$$$V2.0");
+
+    // this PEPTIDE chain shouldn't get renumbered since it's not RNA
+    add_text_to_mol_model(model, "PEPTIDE1{W}$$$$V2.0");
+    helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{R(A)P}|RNA2{R(C)P}|RNA3{R(G)P}|RNA4{R(T)P}|RNA5{["
+                       "dR](A)P}|RNA6{[dR](C)P}|PEPTIDE1{W}$$$$V2.0");
+}
+
 } // namespace sketcher
 } // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-2618

### Description
While I was implementing SKETCH-2618, I discovered an issue that's only tangentially related to that case, but adding the nucleotides tools makes the issue far more apparent:  If you:
- importing a HELM string into Sketcher
- import another HELM string into Sketcher that contains the same chain names as the first
- export the HELM string (which currently isn't possible through the GUI, it has to be done programmatically)

Then the exported HELM string is wrong, since it merges all of the monomers with matching chain names into a single chain.  This PR fixes that issue by modifying all imported monomeric models to ensure that their chain names don't overlap with any existing chain names.

### Testing Done
Added a new MolModel unit test and confirmed that it passes.
