### PR TITLE
SKETCH-2498: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version corresponding to the branch to use'
+        required: true
+        type: string
+
+jobs:
+  build:
+    uses: ./.github/workflows/sketcher-builder.yml
+    with:
+      ref: ${{ inputs.version }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: sketcher-${{ inputs.version }}-*
+
+      - name: Package release assets
+        run: |
+          shopt -s extglob
+          for dir in artifacts/sketcher-*-!(memtest); do
+            (cd "$dir" && zip -r "../../$(basename "$dir").zip" .)
+          done
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ inputs.version }}"
+          git tag -f "$tag"
+          git push -f origin "$tag"
+          if gh release view "$tag" &>/dev/null; then
+            gh release upload "$tag" sketcher-${{ inputs.version }}-*.zip --clobber
+          else
+            gh release create "$tag" sketcher-${{ inputs.version }}-*.zip \
+              --title "Schrödinger Sketcher ${{ inputs.version }} release" \
+              --target "${{ inputs.version }}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Package release assets
         run: |
-          shopt -s extglob
-          for dir in artifacts/sketcher-*-!(memtest); do
+          for dir in artifacts/sketcher-*; do
+            [[ "$dir" == *-memtest ]] && continue
             (cd "$dir" && zip -r "../../$(basename "$dir").zip" .)
           done
 
@@ -44,10 +44,7 @@ jobs:
           tag="v${{ inputs.version }}"
           git tag -f "$tag"
           git push -f origin "$tag"
-          if gh release view "$tag" &>/dev/null; then
-            gh release upload "$tag" sketcher-${{ inputs.version }}-*.zip --clobber
-          else
-            gh release create "$tag" sketcher-${{ inputs.version }}-*.zip \
-              --title "Schrödinger Sketcher ${{ inputs.version }} release" \
-              --target "${{ inputs.version }}"
-          fi
+          gh release delete "$tag" --yes 2>/dev/null || true
+          gh release create "$tag" sketcher-${{ inputs.version }}-*.zip \
+            --title "Schrödinger Sketcher ${{ inputs.version }} release" \
+            --target "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.version }}
 
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           pattern: sketcher-${{ inputs.version }}-*


### PR DESCRIPTION
* Linked Case: SKETCH-2498

### Description

From our conversation today -- adds a GH action for creating a release tag and uploading the macos/linux/windows/wasm assets to https://github.com/schrodinger/sketcher/releases. If we need to patch, it's possible to rerun the workflow -- if a release for the version already exists, the tag is moved to the current branch HEAD and the artifacts are updated in place.

### Testing Done

I can't run this until it's committed....

🤖 Generated with [Claude Code](https://claude.com/claude-code)