### PR TITLE
SKETCH-2709: Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/activate-emsdk/action.yml
+++ b/.github/actions/activate-emsdk/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       with:
         repository: emscripten-core/emsdk

--- a/.github/actions/build-external/action.yml
+++ b/.github/actions/build-external/action.yml
@@ -29,7 +29,7 @@ runs:
         echo "lib-dir=${BUILD_DIR}/${{ inputs.library }}-${{ inputs.version }}" >> $GITHUB_OUTPUT
         echo "cache-key=${{ inputs.library }}-${{ inputs.version }}-${{ matrix.runner }}-${{ matrix.build-name }}${{ inputs.host-build == 'true' && '-host' || '' }}-${{ hashFiles('external/CMakeLists.txt', 'external/versions.json', 'external/sqlite_cmake/*') }}" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache-check
       with:
         path: ${{ steps.vars.outputs.lib-dir }}
@@ -54,7 +54,7 @@ runs:
     # save the dependency build even if the rest of the build fails
     - name: Save dependency to cache
       if: steps.cache-check.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.vars.outputs.lib-dir }}
         key: ${{ steps.vars.outputs.cache-key }}

--- a/.github/workflows/sketcher-builder.yml
+++ b/.github/workflows/sketcher-builder.yml
@@ -19,7 +19,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -59,7 +59,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           echo "Free space after cleanup = $(df -h / | awk 'NR==2 {print $4}')"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -267,7 +267,7 @@ jobs:
         if: always() && steps.sketcher-build.outcome == 'success'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sketcher-${{ inputs.ref || github.sha }}-${{ matrix.build-name }}
           path: |


### PR DESCRIPTION
* Linked Case: SKETCH-2709

## Description

Bumps `actions/checkout` (v4 → v6), `actions/cache` (v4 → v5), and `actions/upload-artifact` (v4 → v6) to get rid of the Node.js 20 warnings on GH. `test-summary/action` and `ilammy/msvc-dev-cmd` still emit warnings and will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)