### PR TITLE
SKETCH-2729: Add nucleic acid analogs to the monomer palette

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ if(ENABLE_TESTING)
       test_atom_query_popup
       test_bond_order_popup
       test_bond_query_popup
+      test_nucleic_acid_symbol_popup
       test_bracket_subgroup_dialog
       test_draw_tools_widget
       test_edit_atom_properties

--- a/src/schrodinger/sketcher/model/sketcher_model.cpp
+++ b/src/schrodinger/sketcher/model/sketcher_model.cpp
@@ -20,6 +20,7 @@
 
 using MonomericNucleotide = std::tuple<QString, QString, QString>;
 Q_DECLARE_METATYPE(MonomericNucleotide);
+Q_DECLARE_METATYPE(schrodinger::sketcher::NucleicAcidMutation);
 
 namespace schrodinger
 {
@@ -69,6 +70,7 @@ std::vector<ModelKey> get_model_keys()
         ModelKey::AMINO_ACID_TOOL,
         ModelKey::AMINO_ACID_SYMBOL,
         ModelKey::NUCLEIC_ACID_TOOL,
+        ModelKey::NUCLEIC_ACID_SYMBOL,
         ModelKey::RNA_NUCLEOBASE,
         ModelKey::DNA_NUCLEOBASE,
         ModelKey::CUSTOM_NUCLEOTIDE,
@@ -248,6 +250,8 @@ void SketcherModel::reset()
         {ModelKey::AMINO_ACID_SYMBOL, QString("A")},
         {ModelKey::NUCLEIC_ACID_TOOL,
          QVariant::fromValue(NucleicAcidTool::RNA_NUCLEOTIDE)},
+        {ModelKey::NUCLEIC_ACID_SYMBOL,
+         QVariant::fromValue(NucleicAcidMutation{NucleicAcidTool::A, "A"})},
         {ModelKey::RNA_NUCLEOBASE, QVariant::fromValue(StdNucleobase::A)},
         {ModelKey::DNA_NUCLEOBASE, QVariant::fromValue(StdNucleobase::A)},
         {ModelKey::CUSTOM_NUCLEOTIDE,

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -284,24 +284,25 @@ enum class ModelKey {
     ATOM_QUERY,
     RGROUP_NUMBER,
     RESIDUE_TYPE,
-    MONOMER_TOOL_TYPE, /// whether the MONOMER tool should activate an
-                       ///   AMINO_ACID_TOOL or a NUCLEIC_ACID_TOOL
-    AMINO_ACID_TOOL,   /// the amino acid monomer to draw
-    AMINO_ACID_SYMBOL, /// the specific analog symbol (e.g. "dA") to draw
-    NUCLEIC_ACID_TOOL, /// the nucleic acid monomer or full nucleotide to draw
-    RNA_NUCLEOBASE,    /// the base to use for the RNA_NUCLEOTIDE tool
-    DNA_NUCLEOBASE,    /// the base to use for the DNA_NUCLEOTIDE tool
-    CUSTOM_NUCLEOTIDE, /// a tuple of (sugar, base, phosphate) to use for the
-                       ///   CUSTOM_NUCLEOTIDE tool
-    INTERFACE_TYPE,    /// whether the Sketcher is intended for use with
-                       ///   atomistic models, monomeric models, or both
-    TOOL_SET,          /// whether the side bar shows the atomistic tools or
-                       ///   monomeric tools, which (along with
-                       ///   MONOMER_TOOL_TYPE) controls the keyboard shortcuts
-                       ///   (i.e. should "C" activate carbon, cysteine, or
-                       ///   cytosine)
-    MOLECULE_TYPE,     /// whether the Sketcher workspace contains an atomistic
-                       ///   model, a monomeric model, or is empty
+    MONOMER_TOOL_TYPE,   /// whether the MONOMER tool should activate an
+                         ///   AMINO_ACID_TOOL or a NUCLEIC_ACID_TOOL
+    AMINO_ACID_TOOL,     /// the amino acid monomer to draw
+    AMINO_ACID_SYMBOL,   /// the specific analog symbol (e.g. "dA") to draw
+    NUCLEIC_ACID_TOOL,   /// the nucleic acid monomer or full nucleotide to draw
+    NUCLEIC_ACID_SYMBOL, /// the specific analog symbol (e.g. "5mC") to draw
+    RNA_NUCLEOBASE,      /// the base to use for the RNA_NUCLEOTIDE tool
+    DNA_NUCLEOBASE,      /// the base to use for the DNA_NUCLEOTIDE tool
+    CUSTOM_NUCLEOTIDE,   /// a tuple of (sugar, base, phosphate) to use for the
+                         ///   CUSTOM_NUCLEOTIDE tool
+    INTERFACE_TYPE,      /// whether the Sketcher is intended for use with
+                         ///   atomistic models, monomeric models, or both
+    TOOL_SET,            /// whether the side bar shows the atomistic tools or
+                         ///   monomeric tools, which (along with
+                         ///   MONOMER_TOOL_TYPE) controls the keyboard
+                         ///   shortcuts (i.e. should "C" activate carbon,
+                         ///   cysteine, or cytosine)
+    MOLECULE_TYPE,       /// whether the Sketcher workspace contains an
+                         ///   atomistic model, a monomeric model, or is empty
 };
 
 enum class MoleculeType {
@@ -435,6 +436,17 @@ const std::unordered_map<NucleicAcidTool, std::string>
         {NucleicAcidTool::P, "P"},
         {NucleicAcidTool::dR, "dR"},
     }; // clang-format on
+
+/**
+ * Carries a nucleic acid mutation request: the tool (which slot type to
+ * mutate — base/sugar/phosphate) plus the symbol to substitute. Both
+ * pieces are needed because pingValue does not update the stored model
+ * value, so the SYMBOL handler can't read the just-pinged TOOL.
+ */
+struct NucleicAcidMutation {
+    NucleicAcidTool tool;
+    QString symbol;
+};
 
 enum class StdNucleobase {
     A,

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -631,6 +631,7 @@ void Scene::onModelValuesChanged(const std::unordered_set<ModelKey>& keys)
             case ModelKey::AMINO_ACID_TOOL:
             case ModelKey::AMINO_ACID_SYMBOL:
             case ModelKey::NUCLEIC_ACID_TOOL:
+            case ModelKey::NUCLEIC_ACID_SYMBOL:
             case ModelKey::RNA_NUCLEOBASE:
             case ModelKey::DNA_NUCLEOBASE:
             case ModelKey::CUSTOM_NUCLEOTIDE:
@@ -736,8 +737,13 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
         } else {
             auto tool = m_sketcher_model->getNucleicAcidTool();
             if (NUCLEIC_ACID_TOOL_TO_RES_NAME.contains(tool)) {
-                // the tool is for a single monomer
-                auto res_name = NUCLEIC_ACID_TOOL_TO_RES_NAME.at(tool);
+                auto mutation =
+                    m_sketcher_model->getValue(ModelKey::NUCLEIC_ACID_SYMBOL)
+                        .value<NucleicAcidMutation>();
+                std::string res_name =
+                    mutation.symbol.isEmpty()
+                        ? NUCLEIC_ACID_TOOL_TO_RES_NAME.at(tool)
+                        : mutation.symbol.toStdString();
                 // HELM considers DNA to be a type of RNA, so we want an RNA
                 // chain type regardless of which nucleic acid we're drawing
                 return std::make_shared<DrawMonomerSceneTool>(

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -1472,14 +1472,14 @@ void SketcherWidget::applyModelValuePingToTargets(
             m_mol_model->mutateMonomers(atoms, symbol, MonomerType::PEPTIDE);
             break;
         }
-        case ModelKey::NUCLEIC_ACID_TOOL: {
-            auto tool = value.value<NucleicAcidTool>();
-            auto it = NUCLEIC_ACID_TOOL_TO_RES_NAME.find(tool);
-            if (it == NUCLEIC_ACID_TOOL_TO_RES_NAME.end()) {
+        case ModelKey::NUCLEIC_ACID_SYMBOL: {
+            auto mutation = value.value<NucleicAcidMutation>();
+            if (!NUCLEIC_ACID_TOOL_TO_RES_NAME.contains(mutation.tool)) {
                 break; // full nucleotide tools not supported for mutation
             }
-            auto target_type = nucleic_acid_tool_to_monomer_type(tool);
-            m_mol_model->mutateMonomers(atoms, it->second, target_type);
+            auto target_type = nucleic_acid_tool_to_monomer_type(mutation.tool);
+            m_mol_model->mutateMonomers(atoms, mutation.symbol.toStdString(),
+                                        target_type);
             break;
         }
         default:

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -149,7 +149,7 @@
         </widget>
        </item>
        <item row="4" column="0">
-        <widget class="QToolButton" name="na_a_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_a_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -196,7 +196,7 @@
         </spacer>
        </item>
        <item row="8" column="2">
-        <widget class="QToolButton" name="na_p_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_p_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -227,7 +227,7 @@
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QToolButton" name="na_c_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_c_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -274,7 +274,7 @@
         </spacer>
        </item>
        <item row="5" column="0">
-        <widget class="QToolButton" name="na_g_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_g_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -333,7 +333,7 @@
         </widget>
        </item>
        <item row="5" column="1">
-        <widget class="QToolButton" name="na_u_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_u_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -364,7 +364,7 @@
         </widget>
        </item>
        <item row="4" column="2">
-        <widget class="QToolButton" name="na_n_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_n_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -395,7 +395,7 @@
         </widget>
        </item>
        <item row="5" column="2">
-        <widget class="QToolButton" name="na_t_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_t_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -439,7 +439,7 @@
         </spacer>
        </item>
        <item row="8" column="1">
-        <widget class="QToolButton" name="na_dr_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_dr_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -470,7 +470,7 @@
         </widget>
        </item>
        <item row="8" column="0">
-        <widget class="QToolButton" name="na_r_btn">
+        <widget class="schrodinger::sketcher::ModularToolButton" name="na_r_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>

--- a/src/schrodinger/sketcher/widget/monomer_symbol_popup_utils.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_symbol_popup_utils.cpp
@@ -1,0 +1,55 @@
+#include "schrodinger/sketcher/widget/monomer_symbol_popup_utils.h"
+
+#include <QButtonGroup>
+#include <QHBoxLayout>
+#include <QToolButton>
+
+#include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/sketcher/sketcher_css_style.h"
+#include "schrodinger/sketcher/widget/modular_popup.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+QButtonGroup* build_monomer_symbol_buttons(
+    ModularPopup* popup, const std::string& object_name_prefix,
+    const std::string& standard_symbol, const std::string& standard_name,
+    const std::vector<rdkit_extensions::MonomerInfo>& analogs,
+    std::unordered_map<int, std::string>& id_to_symbol)
+{
+    auto* layout = new QHBoxLayout(popup);
+    layout->setContentsMargins(2, 2, 2, 2);
+    layout->setSpacing(0);
+
+    auto* group = new QButtonGroup(popup);
+
+    int id = 0;
+    auto make_button = [&](const std::string& symbol, const std::string& name) {
+        auto* btn = new QToolButton(popup);
+        btn->setText(QString::fromStdString(symbol));
+        btn->setToolTip(QString::fromStdString(name));
+        btn->setCheckable(true);
+        btn->setMinimumSize(32, 30);
+        btn->setMaximumSize(32, 32);
+        btn->setObjectName(
+            QString::fromStdString(object_name_prefix + "_" + symbol + "_btn"));
+        btn->setStyleSheet(symbol.size() >= COMPACT_STYLE_MIN_LENGTH
+                               ? ATOM_ELEMENT_OR_MONOMER_COMPACT_STYLE
+                               : ATOM_ELEMENT_OR_MONOMER_STYLE);
+        layout->addWidget(btn);
+        group->addButton(btn);
+        id_to_symbol[id] = symbol;
+        ++id;
+    };
+
+    make_button(standard_symbol, standard_name);
+    for (const auto& analog : analogs) {
+        make_button(analog.symbol.value_or(""), analog.name.value_or(""));
+    }
+    return group;
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/widget/monomer_symbol_popup_utils.h
+++ b/src/schrodinger/sketcher/widget/monomer_symbol_popup_utils.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "schrodinger/sketcher/definitions.h"
+
+class QButtonGroup;
+
+namespace schrodinger
+{
+namespace rdkit_extensions
+{
+struct MonomerInfo;
+}
+
+namespace sketcher
+{
+
+class ModularPopup;
+
+/**
+ * Populate `popup` with a horizontal row of QToolButtons: ID 0 is the
+ * standard monomer (text = standard_symbol, tooltip = standard_name); IDs
+ * 1+ are the analogs. Each button's object name is set to
+ * "<object_name_prefix>_<symbol>_btn", and the id->symbol mapping is
+ * written into `id_to_symbol`.
+ *
+ * @return The QButtonGroup containing the buttons. The caller must pass
+ * it to ModularPopup::setButtonGroup() to finish initialization.
+ */
+SKETCHER_API QButtonGroup* build_monomer_symbol_buttons(
+    ModularPopup* popup, const std::string& object_name_prefix,
+    const std::string& standard_symbol, const std::string& standard_name,
+    const std::vector<rdkit_extensions::MonomerInfo>& analogs,
+    std::unordered_map<int, std::string>& id_to_symbol);
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -27,6 +27,48 @@ namespace sketcher
 using AnalogMap =
     std::unordered_map<std::string, std::vector<rdkit_extensions::MonomerInfo>>;
 
+// dR has NATURAL_ANALOG=R, so it's not a key in the analog map. Pull
+// R's analogs (and R itself) into dR's popup for symmetry with R, which
+// already shows dR.
+static const std::unordered_map<std::string, std::string>
+    NA_ANALOG_LOOKUP_OVERRIDES = {{"dR", "R"}};
+
+/**
+ * Build the analog list for an NA button: optionally prepend a parent
+ * standard (e.g. R for the dR button) sourced from `standard_names`,
+ * then append the natural-analog list keyed by the override target (or
+ * `symbol` itself if no override applies), filtering out entries whose
+ * symbol matches `symbol` (the button's own standard).
+ */
+static std::vector<rdkit_extensions::MonomerInfo> get_analogs_for_na_button(
+    const std::string& symbol, const AnalogMap& analogs_by_na,
+    const std::unordered_map<std::string, std::string>& standard_names)
+{
+    std::vector<rdkit_extensions::MonomerInfo> analogs;
+    auto override_it = NA_ANALOG_LOOKUP_OVERRIDES.find(symbol);
+    const auto& lookup_key = override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()
+                                 ? override_it->second
+                                 : symbol;
+    if (override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()) {
+        auto parent_name_it = standard_names.find(lookup_key);
+        rdkit_extensions::MonomerInfo parent_entry;
+        parent_entry.symbol = lookup_key;
+        parent_entry.name = parent_name_it != standard_names.end()
+                                ? parent_name_it->second
+                                : lookup_key;
+        analogs.push_back(std::move(parent_entry));
+    }
+    auto analog_it = analogs_by_na.find(lookup_key);
+    if (analog_it != analogs_by_na.end()) {
+        for (const auto& m : analog_it->second) {
+            if (m.symbol.value_or("") != symbol) {
+                analogs.push_back(m);
+            }
+        }
+    }
+    return analogs;
+}
+
 /**
  * Return analogs for nucleic acid bases keyed by their natural analog symbol,
  * pulled from both RNA and DNA chain types and deduped by analog symbol.
@@ -187,21 +229,16 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
 
     auto analogs_by_na = get_merged_na_analogs();
 
-    static const std::vector<rdkit_extensions::MonomerInfo> empty_analogs;
     for (auto& [button, na_tool] : m_button_nucleic_acid_bimap.left) {
         auto std_name = na_tool_to_std_name(na_tool);
         if (!std_name) {
             continue; // sugar/phosphate/full-nucleotide buttons
         }
         const auto& [symbol, name] = *std_name;
-        auto analog_it = analogs_by_na.find(symbol);
-        const auto& analogs = analog_it != analogs_by_na.end()
-                                  ? analog_it->second
-                                  : empty_analogs;
+        auto analogs =
+            get_analogs_for_na_button(symbol, analogs_by_na, STANDARD_NA_NAMES);
         auto* popup = new NucleicAcidSymbolPopup(symbol, name, analogs, this);
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
-        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
-                   "Expected ModularToolButton");
         modular_btn->setPopupWidget(popup);
         modular_btn->setEnumItem(0); // default to standard base
         modular_btn->showPopupIndicator(false);
@@ -351,8 +388,6 @@ void MonomerToolWidget::updateCheckedButton()
             }
         }
         auto* modular_btn = qobject_cast<ModularToolButton*>(nucleic_button);
-        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
-                   "Expected ModularToolButton");
         for (auto& packet : active_it->second->getButtonPackets()) {
             auto packet_symbol =
                 active_it->second->getSymbolForId(packet.enum_int);
@@ -470,8 +505,6 @@ void MonomerToolWidget::onNucleicAcidClicked(QAbstractButton* button)
     auto it = m_nucleic_acid_symbol_popups.find(button);
     if (it != m_nucleic_acid_symbol_popups.end()) {
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
-        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
-                   "Expected ModularToolButton");
         auto symbol = it->second->getSymbolForId(modular_btn->getEnumItem());
         auto na_tool = m_button_nucleic_acid_bimap.left.at(button);
         ping_or_set_model_value(getModel(), ModelKey::NUCLEIC_ACID_SYMBOL,

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -15,6 +15,7 @@
 #include "schrodinger/sketcher/widget/custom_nucleotide_popup.h"
 #include "schrodinger/sketcher/widget/tool_button_with_popup.h"
 #include "schrodinger/sketcher/widget/modular_tool_button.h"
+#include "schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h"
 #include "schrodinger/sketcher/widget/nucleotide_popup.h"
 #include "schrodinger/sketcher/widget/widget_utils.h"
 
@@ -22,6 +23,34 @@ namespace schrodinger
 {
 namespace sketcher
 {
+
+using AnalogMap =
+    std::unordered_map<std::string, std::vector<rdkit_extensions::MonomerInfo>>;
+
+/**
+ * Return analogs for nucleic acid bases keyed by their natural analog symbol,
+ * pulled from both RNA and DNA chain types and deduped by analog symbol.
+ */
+static AnalogMap get_merged_na_analogs()
+{
+    auto& db = rdkit_extensions::MonomerDatabase::instance();
+    auto base = db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::RNA);
+    auto other =
+        db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::DNA);
+    for (const auto& [key, other_list] : other) {
+        auto& merged = base[key];
+        std::unordered_set<std::string> seen;
+        for (const auto& m : merged) {
+            seen.insert(m.symbol.value_or(""));
+        }
+        for (const auto& m : other_list) {
+            if (seen.insert(m.symbol.value_or("")).second) {
+                merged.push_back(m);
+            }
+        }
+    }
+    return base;
+}
 
 MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
     AbstractDrawToolWidget(parent)
@@ -131,6 +160,53 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
         modular_btn->showPopupIndicator(false);
         m_amino_acid_symbol_popups[button] = popup;
     }
+
+    // Set up nucleic acid analog popups from the monomer database. Unlike
+    // the AA loop above, we always attach a popup (even when the analog
+    // list is empty) so that the standard-base tooltip is available on
+    // every per-base button.
+    static const std::unordered_map<std::string, std::string>
+        STANDARD_NA_NAMES = {
+            {"A", "Adenine"}, {"C", "Cytosine"},     {"G", "Guanine"},
+            {"U", "Uracil"},  {"T", "Thymine"},      {"N", "Unknown"},
+            {"R", "Ribose"},  {"dR", "Deoxyribose"}, {"P", "Phosphate"},
+        };
+
+    auto na_tool_to_std_name = [](NucleicAcidTool na_tool)
+        -> std::optional<std::pair<std::string, std::string>> {
+        auto res_it = NUCLEIC_ACID_TOOL_TO_RES_NAME.find(na_tool);
+        if (res_it == NUCLEIC_ACID_TOOL_TO_RES_NAME.end()) {
+            return std::nullopt;
+        }
+        auto name_it = STANDARD_NA_NAMES.find(res_it->second);
+        if (name_it == STANDARD_NA_NAMES.end()) {
+            return std::nullopt;
+        }
+        return *name_it;
+    };
+
+    auto analogs_by_na = get_merged_na_analogs();
+
+    static const std::vector<rdkit_extensions::MonomerInfo> empty_analogs;
+    for (auto& [button, na_tool] : m_button_nucleic_acid_bimap.left) {
+        auto std_name = na_tool_to_std_name(na_tool);
+        if (!std_name) {
+            continue; // sugar/phosphate/full-nucleotide buttons
+        }
+        const auto& [symbol, name] = *std_name;
+        auto analog_it = analogs_by_na.find(symbol);
+        const auto& analogs = analog_it != analogs_by_na.end()
+                                  ? analog_it->second
+                                  : empty_analogs;
+        auto* popup = new NucleicAcidSymbolPopup(symbol, name, analogs, this);
+        auto* modular_btn = qobject_cast<ModularToolButton*>(button);
+        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
+                   "Expected ModularToolButton");
+        modular_btn->setPopupWidget(popup);
+        modular_btn->setEnumItem(0); // default to standard base
+        modular_btn->showPopupIndicator(false);
+        m_nucleic_acid_symbol_popups[button] = popup;
+    }
 }
 
 MonomerToolWidget::~MonomerToolWidget() = default;
@@ -142,6 +218,9 @@ void MonomerToolWidget::setModel(SketcherModel* model)
     m_dna_popup->setModel(model);
     m_custom_nt_popup->setModel(model);
     for (auto& [button, popup] : m_amino_acid_symbol_popups) {
+        popup->setModel(model);
+    }
+    for (auto& [button, popup] : m_nucleic_acid_symbol_popups) {
         popup->setModel(model);
     }
     updateCheckedButton();
@@ -251,6 +330,44 @@ void MonomerToolWidget::updateCheckedButton()
         }
     }
 
+    // Show the popup indicator only on the currently checked NA button
+    for (auto& [btn, popup] : m_nucleic_acid_symbol_popups) {
+        auto* modular_btn = qobject_cast<ModularToolButton*>(btn);
+        modular_btn->showPopupIndicator(btn == nucleic_button);
+    }
+
+    // Sync only the active button's popup, and skip analog matches whose
+    // symbol owns its own toolbar slot (e.g. dR appears in R's popup but
+    // belongs on the dR button).
+    auto na_analog = model->getValue(ModelKey::NUCLEIC_ACID_SYMBOL)
+                         .value<NucleicAcidMutation>()
+                         .symbol;
+    auto active_it = m_nucleic_acid_symbol_popups.find(nucleic_button);
+    if (active_it != m_nucleic_acid_symbol_popups.end()) {
+        std::unordered_set<QString> other_standards;
+        for (auto& [other_btn, other_popup] : m_nucleic_acid_symbol_popups) {
+            if (other_btn != nucleic_button) {
+                other_standards.insert(other_popup->getSymbolForId(0));
+            }
+        }
+        auto* modular_btn = qobject_cast<ModularToolButton*>(nucleic_button);
+        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
+                   "Expected ModularToolButton");
+        for (auto& packet : active_it->second->getButtonPackets()) {
+            auto packet_symbol =
+                active_it->second->getSymbolForId(packet.enum_int);
+            if (packet_symbol != na_analog) {
+                continue;
+            }
+            if (packet.enum_int != 0 &&
+                other_standards.contains(packet_symbol)) {
+                continue;
+            }
+            modular_btn->setEnumItem(packet.enum_int);
+            break;
+        }
+    }
+
     ui->na_rna_btn->setEnumItem(static_cast<int>(model->getRNANucleobase()));
     ui->na_dna_btn->setEnumItem(static_cast<int>(model->getDNANucleobase()));
 
@@ -259,6 +376,8 @@ void MonomerToolWidget::updateCheckedButton()
     const QString custom_nt_name_fmt("%1(%2)%3");
     auto custom_nt_name = custom_nt_name_fmt.arg(sugar, base, phosphate);
     ui->na_custom_nt_btn->setText(custom_nt_name);
+    ui->na_custom_nt_btn->setToolTip(
+        QString("Custom nucleotide: %1").arg(custom_nt_name));
 }
 
 void MonomerToolWidget::onAminoOrNucleicBtnClicked(QAbstractButton* button)
@@ -343,6 +462,20 @@ void MonomerToolWidget::onNucleicAcidClicked(QAbstractButton* button)
         auto key = button == ui->na_rna_btn ? ModelKey::RNA_NUCLEOBASE
                                             : ModelKey::DNA_NUCLEOBASE;
         ping_or_set_model_value(getModel(), key, base);
+    }
+
+    // Set which specific analog is selected; falls back to the standard
+    // base symbol when the button has no analog popup or the
+    // popup is on its default item.
+    auto it = m_nucleic_acid_symbol_popups.find(button);
+    if (it != m_nucleic_acid_symbol_popups.end()) {
+        auto* modular_btn = qobject_cast<ModularToolButton*>(button);
+        Q_ASSERT_X(modular_btn, "MonomerToolWidget",
+                   "Expected ModularToolButton");
+        auto symbol = it->second->getSymbolForId(modular_btn->getEnumItem());
+        auto na_tool = m_button_nucleic_acid_bimap.left.at(button);
+        ping_or_set_model_value(getModel(), ModelKey::NUCLEIC_ACID_SYMBOL,
+                                NucleicAcidMutation{na_tool, symbol});
     }
 }
 

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.h
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.h
@@ -26,6 +26,7 @@ enum class AminoAcidTool;
 enum class NucleicAcidTool;
 class AminoAcidSymbolPopup;
 class CustomNucleotidePopup;
+class NucleicAcidSymbolPopup;
 class NucleotidePopup;
 
 /**
@@ -51,6 +52,8 @@ class SKETCHER_API MonomerToolWidget : public AbstractDrawToolWidget
     CustomNucleotidePopup* m_custom_nt_popup = nullptr;
     std::unordered_map<QAbstractButton*, AminoAcidSymbolPopup*>
         m_amino_acid_symbol_popups;
+    std::unordered_map<QAbstractButton*, NucleicAcidSymbolPopup*>
+        m_nucleic_acid_symbol_popups;
 
     /**
      * Respond to the AMINO or NUCLEIC buttons being clicked, which toggles the

--- a/src/schrodinger/sketcher/widget/nucleic_acid_symbol_popup.cpp
+++ b/src/schrodinger/sketcher/widget/nucleic_acid_symbol_popup.cpp
@@ -1,4 +1,4 @@
-#include "schrodinger/sketcher/widget/amino_acid_symbol_popup.h"
+#include "schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h"
 
 #include <QButtonGroup>
 
@@ -12,20 +12,20 @@ namespace schrodinger
 namespace sketcher
 {
 
-AminoAcidSymbolPopup::AminoAcidSymbolPopup(
+NucleicAcidSymbolPopup::NucleicAcidSymbolPopup(
     const std::string& standard_symbol, const std::string& standard_name,
     const std::vector<rdkit_extensions::MonomerInfo>& analogs,
     QWidget* parent) :
     ModularPopup(parent)
 {
     auto* group =
-        build_monomer_symbol_buttons(this, "analog", standard_symbol,
+        build_monomer_symbol_buttons(this, "na_analog", standard_symbol,
                                      standard_name, analogs, m_id_to_symbol);
     setStyleSheet(ATOM_ELEMENT_OR_MONOMER_STYLE);
     setButtonGroup(group);
 }
 
-QString AminoAcidSymbolPopup::getSymbolForId(int id) const
+QString NucleicAcidSymbolPopup::getSymbolForId(int id) const
 {
     auto it = m_id_to_symbol.find(id);
     if (it == m_id_to_symbol.end()) {
@@ -34,7 +34,7 @@ QString AminoAcidSymbolPopup::getSymbolForId(int id) const
     return QString::fromStdString(it->second);
 }
 
-void AminoAcidSymbolPopup::generateButtonPackets()
+void NucleicAcidSymbolPopup::generateButtonPackets()
 {
     auto buttons = m_group->buttons();
     for (int i = 0; i < buttons.size(); ++i) {
@@ -45,7 +45,7 @@ void AminoAcidSymbolPopup::generateButtonPackets()
     }
 }
 
-int AminoAcidSymbolPopup::getButtonIDToCheck()
+int NucleicAcidSymbolPopup::getButtonIDToCheck()
 {
     auto model = getModel();
     if (model == nullptr) {
@@ -53,13 +53,14 @@ int AminoAcidSymbolPopup::getButtonIDToCheck()
     }
 
     if (model->getDrawTool() != DrawTool::MONOMER ||
-        model->getMonomerToolType() != MonomerToolType::AMINO_ACID) {
+        model->getMonomerToolType() != MonomerToolType::NUCLEIC_ACID) {
         return -1;
     }
 
-    auto analog = model->getValueString(ModelKey::AMINO_ACID_SYMBOL);
+    auto analog = model->getValue(ModelKey::NUCLEIC_ACID_SYMBOL)
+                      .value<NucleicAcidMutation>();
     for (const auto& [id, symbol] : m_id_to_symbol) {
-        if (QString::fromStdString(symbol) == analog) {
+        if (QString::fromStdString(symbol) == analog.symbol) {
             return id;
         }
     }
@@ -69,4 +70,4 @@ int AminoAcidSymbolPopup::getButtonIDToCheck()
 } // namespace sketcher
 } // namespace schrodinger
 
-#include "schrodinger/sketcher/widget/amino_acid_symbol_popup.moc"
+#include "schrodinger/sketcher/widget/nucleic_acid_symbol_popup.moc"

--- a/src/schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h
+++ b/src/schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/widget/modular_popup.h"
+
+namespace schrodinger
+{
+namespace rdkit_extensions
+{
+struct MonomerInfo;
+}
+
+namespace sketcher
+{
+
+/**
+ * Popup showing non-natural analogs for a standard nucleic acid base button.
+ *
+ * The first entry (ID 0) is the standard base; subsequent entries are
+ * non-natural analogs (e.g. 5-methylcytosine) sourced from the monomer
+ * database.
+ */
+class SKETCHER_API NucleicAcidSymbolPopup : public ModularPopup
+{
+  public:
+    NucleicAcidSymbolPopup(
+        const std::string& standard_symbol, const std::string& standard_name,
+        const std::vector<rdkit_extensions::MonomerInfo>& analogs,
+        QWidget* parent = nullptr);
+
+    /**
+     * @return The HELM symbol for the given button ID
+     */
+    QString getSymbolForId(int id) const;
+
+  protected:
+    void generateButtonPackets() override;
+    int getButtonIDToCheck() override;
+
+  private:
+    std::unordered_map<int, std::string> m_id_to_symbol;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/widget/nucleotide_popup.cpp
+++ b/src/schrodinger/sketcher/widget/nucleotide_popup.cpp
@@ -32,6 +32,16 @@ NucleotidePopup::NucleotidePopup(const NucleicAcidTool tool,
     ui->g_btn->setText(btn_name_fmt.arg(sugar, "G"));
     ui->u_or_t_btn->setText(btn_name_fmt.arg(sugar, u_or_t));
     ui->n_btn->setText(btn_name_fmt.arg(sugar, "N"));
+
+    // tooltips: human base name + polymer type, e.g. "Adenine (RNA)"
+    const QString polymer = sugar == "dR" ? "DNA" : "RNA";
+    const QString u_or_t_name = u_or_t == "T" ? "Thymine" : "Uracil";
+    QString tt_fmt("%1 (%2)");
+    ui->a_btn->setToolTip(tt_fmt.arg("Adenine", polymer));
+    ui->c_btn->setToolTip(tt_fmt.arg("Cytosine", polymer));
+    ui->g_btn->setToolTip(tt_fmt.arg("Guanine", polymer));
+    ui->u_or_t_btn->setToolTip(tt_fmt.arg(u_or_t_name, polymer));
+    ui->n_btn->setToolTip(tt_fmt.arg("Unknown", polymer));
 }
 
 NucleotidePopup::~NucleotidePopup() = default;

--- a/test/schrodinger/sketcher/model/test_sketcher_model.cpp
+++ b/test/schrodinger/sketcher/model/test_sketcher_model.cpp
@@ -94,6 +94,8 @@ BOOST_AUTO_TEST_CASE(get_set_signal)
         {ModelKey::AMINO_ACID_TOOL, QVariant::fromValue(AminoAcidTool::UNK)},
         {ModelKey::AMINO_ACID_SYMBOL, QString("dA")},
         {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(NucleicAcidTool::dR)},
+        {ModelKey::NUCLEIC_ACID_SYMBOL,
+         QVariant::fromValue(NucleicAcidMutation{NucleicAcidTool::C, "5mC"})},
         {ModelKey::RNA_NUCLEOBASE, QVariant::fromValue(StdNucleobase::G)},
         {ModelKey::DNA_NUCLEOBASE, QVariant::fromValue(StdNucleobase::U_OR_T)},
         {ModelKey::CUSTOM_NUCLEOTIDE,
@@ -111,6 +113,7 @@ BOOST_AUTO_TEST_CASE(get_set_signal)
     for (auto& key : get_model_keys()) {
         if (key == ModelKey::RESIDUE_TYPE ||
             key == ModelKey::AMINO_ACID_SYMBOL ||
+            key == ModelKey::NUCLEIC_ACID_SYMBOL ||
             key == ModelKey::CUSTOM_NUCLEOTIDE) {
             // These values are not stored as int-like objects
             continue;

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/rdkit/monomeric.h"
 #include "schrodinger/sketcher/rdkit/coord_utils.h"
@@ -536,9 +537,11 @@ BOOST_AUTO_TEST_CASE(test_pingMutateMonomersNucleicAcidBase)
     model->selectAll();
     BOOST_TEST(sk.m_sketcher_model->hasActiveSelection());
 
-    // ping with base "U" — only bases should change
-    sk.m_sketcher_model->pingValue(ModelKey::NUCLEIC_ACID_TOOL,
-                                   QVariant::fromValue(NucleicAcidTool::U));
+    // Ping NUCLEIC_ACID_SYMBOL with a NucleicAcidMutation carrying both the
+    // tool (target slot type) and the symbol — only bases should change.
+    sk.m_sketcher_model->pingValue(
+        ModelKey::NUCLEIC_ACID_SYMBOL,
+        NucleicAcidMutation{NucleicAcidTool::U, "U"});
 
     const auto* mol = model->getMol();
     int base_count = 0;
@@ -564,6 +567,58 @@ BOOST_AUTO_TEST_CASE(test_pingMutateMonomersNucleicAcidBase)
     BOOST_TEST(base_count == 2);
     BOOST_TEST(sugar_count == 2);
     BOOST_TEST(phosphate_count == 2);
+}
+
+/**
+ * Verify that pinging NUCLEIC_ACID_SYMBOL with a custom analog symbol
+ * (registered in the monomer database with NATURAL_ANALOG = "A") mutates
+ * the selected base monomers to that analog. This exercises the end-to-end
+ * popup-analog-selection pipeline at the model level.
+ */
+BOOST_AUTO_TEST_CASE(test_pingMutateMonomersNucleicAcidAnalog)
+{
+    constexpr std::string_view custom_monomer_json =
+        ("[{"
+         "\"symbol\": \"ModA\","
+         "\"polymer_type\": \"RNA\","
+         "\"natural_analog\": \"A\","
+         "\"smiles\": \"NNNN\","
+         "\"core_smiles\": \"NNNN\","
+         "\"name\": \"Modified Adenine\","
+         "\"monomer_type\": \"Backbone\","
+         "\"author\": \"test\","
+         "\"pdbcode\": \"MODA\""
+         "}]");
+    auto& monomer_db =
+        schrodinger::rdkit_extensions::MonomerDatabase::instance();
+    monomer_db.loadMonomersFromJson(std::string(custom_monomer_json));
+
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("RNA1{R(A)P.R(G)P}$$$$V2.0");
+    auto model = sk.m_mol_model;
+
+    model->selectAll();
+    BOOST_TEST(sk.m_sketcher_model->hasActiveSelection());
+
+    // Ping with tool=A (the natural analog) and symbol="ModA" — only the
+    // bases should change to "ModA".
+    sk.m_sketcher_model->pingValue(
+        ModelKey::NUCLEIC_ACID_SYMBOL,
+        NucleicAcidMutation{NucleicAcidTool::A, "ModA"});
+
+    const auto* mol = model->getMol();
+    int base_count = 0;
+    for (unsigned int i = 0; i < mol->getNumAtoms(); ++i) {
+        auto* atom = mol->getAtomWithIdx(i);
+        if (get_monomer_type(atom) == MonomerType::NA_BASE) {
+            BOOST_TEST(get_monomer_res_name(atom) == "ModA");
+            ++base_count;
+        }
+    }
+    BOOST_TEST(base_count == 2);
+
+    monomer_db.resetMonomerDefinitions();
 }
 
 /**

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -264,6 +264,22 @@ BOOST_AUTO_TEST_CASE(test_nucleic_acid_base_drag_empty_to_empty_uses_pair_ap)
 }
 
 /**
+ * Confirm that NUCLEIC_ACID_SYMBOL overrides the standard tool symbol when
+ * drawing a base. Sets the tool to A but the symbol to C -- the inserted
+ * base should be C, proving the scene tool prefers the analog symbol.
+ */
+BOOST_AUTO_TEST_CASE(test_nucleic_acid_symbol_overrides_tool)
+{
+    MonomerToolTestFixture fix;
+    fix.setNucleicAcidTool(NucleicAcidTool::A);
+    fix.m_sketcher_model->setValue(
+        ModelKey::NUCLEIC_ACID_SYMBOL,
+        QVariant::fromValue(NucleicAcidMutation{NucleicAcidTool::A, "C"}));
+    fix.mouseClick({0, 0});
+    fix.verifyHELM("RNA1{C}$$$$V2.0");
+}
+
+/**
  * Confirm that dragging from empty space to empty space with a nucleic acid
  * phosphate monomer is ignored and doesn't create any monomers
  */

--- a/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
+++ b/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
@@ -90,7 +90,9 @@ struct MonomerToolTestFixture {
              {ModelKey::TOOL_SET, QVariant::fromValue(ToolSet::MONOMERIC)},
              {ModelKey::MONOMER_TOOL_TYPE,
               QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
-             {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)}});
+             {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)},
+             {ModelKey::NUCLEIC_ACID_SYMBOL,
+              QVariant::fromValue(NucleicAcidMutation{tool, ""})}});
         process_qt_events();
     }
 

--- a/test/schrodinger/sketcher/widget/test_nucleic_acid_symbol_popup.cpp
+++ b/test/schrodinger/sketcher/widget/test_nucleic_acid_symbol_popup.cpp
@@ -1,0 +1,73 @@
+#define BOOST_TEST_MODULE Test_Sketcher
+#include <boost/test/unit_test.hpp>
+
+#include "../test_common.h"
+#include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h"
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+static rdkit_extensions::MonomerInfo make_analog(const std::string& symbol,
+                                                 const std::string& name)
+{
+    rdkit_extensions::MonomerInfo info;
+    info.symbol = symbol;
+    info.name = name;
+    return info;
+}
+
+/**
+ * Construct with no analogs: only the standard base button is present at ID 0.
+ */
+BOOST_AUTO_TEST_CASE(test_standard_only)
+{
+    NucleicAcidSymbolPopup popup("C", "Cytosine", {});
+    auto packets = popup.getButtonPackets();
+    BOOST_TEST(packets.size() == 1);
+    BOOST_TEST(popup.getSymbolForId(0).toStdString() == "C");
+    BOOST_TEST(popup.getSymbolForId(1).isEmpty());
+}
+
+/**
+ * Construct with two analogs: standard at ID 0, analogs at IDs 1 and 2.
+ */
+BOOST_AUTO_TEST_CASE(test_with_analogs)
+{
+    std::vector<rdkit_extensions::MonomerInfo> analogs = {
+        make_analog("5mC", "5-methylcytosine"),
+        make_analog("hC", "hydroxymethylcytosine"),
+    };
+    NucleicAcidSymbolPopup popup("C", "Cytosine", analogs);
+    auto packets = popup.getButtonPackets();
+    BOOST_TEST(packets.size() == 3);
+    BOOST_TEST(popup.getSymbolForId(0).toStdString() == "C");
+    BOOST_TEST(popup.getSymbolForId(1).toStdString() == "5mC");
+    BOOST_TEST(popup.getSymbolForId(2).toStdString() == "hC");
+    BOOST_TEST(popup.getSymbolForId(99).isEmpty());
+}
+
+/**
+ * Each popup button carries a tooltip set to the human-readable monomer name,
+ * which is what feeds the toolbar tooltip via ModularPopup::getToolTip().
+ */
+BOOST_AUTO_TEST_CASE(test_button_tooltips)
+{
+    std::vector<rdkit_extensions::MonomerInfo> analogs = {
+        make_analog("5mC", "5-methylcytosine"),
+    };
+    NucleicAcidSymbolPopup popup("C", "Cytosine", analogs);
+    auto packets = popup.getButtonPackets();
+    BOOST_REQUIRE(packets.size() == 2);
+    BOOST_TEST(packets[0].button->toolTip().toStdString() == "Cytosine");
+    BOOST_TEST(packets[1].button->toolTip().toStdString() ==
+               "5-methylcytosine");
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/widget/test_nucleic_acid_symbol_popup.cpp
+++ b/test/schrodinger/sketcher/widget/test_nucleic_acid_symbol_popup.cpp
@@ -1,9 +1,11 @@
 #define BOOST_TEST_MODULE Test_Sketcher
+#include <algorithm>
 #include <boost/test/unit_test.hpp>
 
 #include "../test_common.h"
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/widget/monomer_tool_widget.h"
 #include "schrodinger/sketcher/widget/nucleic_acid_symbol_popup.h"
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
@@ -67,6 +69,70 @@ BOOST_AUTO_TEST_CASE(test_button_tooltips)
     BOOST_TEST(packets[0].button->toolTip().toStdString() == "Cytosine");
     BOOST_TEST(packets[1].button->toolTip().toStdString() ==
                "5-methylcytosine");
+}
+
+namespace
+{
+// Subclass exposes the protected popup map so we can inspect what the
+// MonomerToolWidget constructor wired up for each NA button.
+class MonomerToolWidgetForTest : public MonomerToolWidget
+{
+  public:
+    using MonomerToolWidget::m_nucleic_acid_symbol_popups;
+};
+
+static std::vector<std::string>
+get_analog_symbols(const NucleicAcidSymbolPopup& popup)
+{
+    std::vector<std::string> symbols;
+    for (const auto& packet : popup.getButtonPackets()) {
+        if (packet.enum_int == 0) {
+            continue; // skip the standard at id 0
+        }
+        symbols.push_back(popup.getSymbolForId(packet.enum_int).toStdString());
+    }
+    return symbols;
+}
+
+static NucleicAcidSymbolPopup*
+find_popup_for_standard(const MonomerToolWidgetForTest& widget,
+                        const std::string& standard_symbol)
+{
+    for (const auto& [btn, popup] : widget.m_nucleic_acid_symbol_popups) {
+        if (popup->getSymbolForId(0).toStdString() == standard_symbol) {
+            return popup;
+        }
+    }
+    return nullptr;
+}
+} // namespace
+
+/**
+ * dR has NATURAL_ANALOG=R, so the analog map has no entry under "dR". The
+ * widget should pull R's analog list (and R itself) into dR's popup so it
+ * mirrors R's popup, which has long shown dR.
+ */
+BOOST_AUTO_TEST_CASE(test_dr_popup_inherits_r_analogs)
+{
+    MonomerToolWidgetForTest widget;
+    auto* dr_popup = find_popup_for_standard(widget, "dR");
+    auto* r_popup = find_popup_for_standard(widget, "R");
+    BOOST_REQUIRE(dr_popup != nullptr);
+    BOOST_REQUIRE(r_popup != nullptr);
+
+    auto dr_analogs = get_analog_symbols(*dr_popup);
+    auto r_analogs = get_analog_symbols(*r_popup);
+
+    auto contains = [](const std::vector<std::string>& v,
+                       const std::string& s) {
+        return std::find(v.begin(), v.end(), s) != v.end();
+    };
+    // R appears as a clickable analog in dR's popup (the parent of dR).
+    BOOST_TEST(contains(dr_analogs, "R"));
+    // dR is the standard at id 0, not duplicated as an analog of itself.
+    BOOST_TEST(!contains(dr_analogs, "dR"));
+    // R's popup still shows dR (existing symmetric behavior).
+    BOOST_TEST(contains(r_analogs, "dR"));
 }
 
 } // namespace sketcher


### PR DESCRIPTION
* Linked Case: SKETCH-2729

### Description
Similar to #279 , but adds support for nucleic acid analogs. A couple of unique logic needed for this PR:

1. Unlike the amino acids, nucleic acid analogs are generally absent from the DB. For consistency, I also converted each nucleic acid button to a `ModularPopupButton` to a) support custom na analogs b) tooltips are populated automatically (which in turns also solves the issue in SKETCH-2689).
2. Updating the buttons when switching analogs needs special logic for ensuring that analogs that exist in the toolbar are not affected by other buttons that could share the same analog. Example: Since we have deoxyribose `dR` as a top-level button in the toolbar (rather than having it under `R`), selecting `dR` would inadvertently also convert the `R` button to switch to its `dR` analog -- which I assume is not the expected behavior.

### Testing Done
Tests various aspects like analog mutation and popup population.
