### PR TITLE
SHARED-12285: Avoid bad_any_cast exception by storing size as std::array

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iterator>
 #include <map>
@@ -2714,20 +2715,17 @@ void assign_clusters(std::vector<MonomerResizeData>& resize_data,
 /**
  * Read the stored monomer size for an atom.
  * Falls back to MONOMER_MINIMUM_SIZE when not present.
+ * Stored as std::array<double, 3> rather than RDGeom::Point3D: on macOS arm64
+ * with hidden visibility, std::any_cast<Point3D> spuriously throws (libc++
+ * non-unique RTTI bit, SHARED-12285); std::array's typeinfo is immune.
  */
 inline RDGeom::Point3D get_monomer_size(const RDKit::ROMol& mol,
                                         unsigned int index)
 {
-    RDGeom::Point3D size(MONOMER_MINIMUM_SIZE, MONOMER_MINIMUM_SIZE, 0);
     auto* atom = mol.getAtomWithIdx(index);
-    try {
-        atom->getPropIfPresent<RDGeom::Point3D>(MONOMER_ITEM_SIZE, size);
-    } catch (const std::bad_any_cast&) {
-        // getPropIfPresent sometimes leaks an exception to the caller, so use
-        // the default size when that happens
-        return {MONOMER_MINIMUM_SIZE, MONOMER_MINIMUM_SIZE, 0};
-    }
-    return size;
+    std::array<double, 3> stored{MONOMER_MINIMUM_SIZE, MONOMER_MINIMUM_SIZE, 0};
+    atom->getPropIfPresent<std::array<double, 3>>(MONOMER_ITEM_SIZE, stored);
+    return {stored[0], stored[1], stored[2]};
 }
 
 struct RingResizeInfo {
@@ -3087,8 +3085,8 @@ void update_monomer_sizes(
     const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes)
 {
     for (const auto& r : monomer_sizes) {
-        mol.getAtomWithIdx(r.first)->setProp<RDGeom::Point3D>(MONOMER_ITEM_SIZE,
-                                                              r.second);
+        mol.getAtomWithIdx(r.first)->setProp<std::array<double, 3>>(
+            MONOMER_ITEM_SIZE, {r.second.x, r.second.y, r.second.z});
     }
 }
 


### PR DESCRIPTION
* Linked Case: SHARED-12285

### Description

I had a quick look when Kevin first saw this, but didn't see anything weird in `RDProp`/`RDKit::Dict`/`RDValue`. I pointed Claude to that class to look a little bit further, and it was also confused until we digged deeper into the llvm's `std::any`'s `operator==` against `typeinfo` which is responsible for throwing the cast or not.

Seems like an odd quirk with type_info and visibility settings when RDKit is statically linked with `-fvisibility=hidden`. Even though the `__type_name` field is the same address, stored value sets the high bit as a flag for visibility, but when it's read, the flag isn't loaded--perhaps the typeid for RDGeom::Point3D is just inlined without doing a proper load?

```
stored_raw = 0x8000000105787d48 high bit set    (non-unique RTTI)                         
query_raw  = 0x0000000105787d48 high bit clear  (unique RTTI)
```

This only happens under certain circumstances: 1) build with statically linked RDKit; 2) macOS (arm64?); 3) classes tagged with `-fvisibility=hidden`. Since library containers seem to have default visibility, it seems to break condition 3, so I went with `std::array<double, 3>` as the closest representative to `RDKit::Point3D`.

### Testing Done
Ran the test locally (before I can hit the same exception), with `std::array`, it now runs clean.
