### PR TITLE
SKETCH-2618: Fixing ribose attachment point naming

### DIFF
--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -42,7 +42,7 @@ const std::unordered_map<MonomerType, std::vector<std::string>>
     NUMBERED_AP_NAMES_BY_MONOMER_TYPE = {
         {MonomerType::PEPTIDE, {"N", "C", "X"}},
         {MonomerType::NA_BASE, {"N1/9"}},
-        {MonomerType::NA_SUGAR, {"3'", "5'", "1'"}},
+        {MonomerType::NA_SUGAR, {"5'", "3'", "1'"}},
 };
 
 // standard attachment point names that don't follow the "R#" naming scheme

--- a/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
@@ -22,10 +22,10 @@ namespace sketcher
 
 // The HELM string we use to generate the nucleotide fragments and the
 // associated atom indices of the monomers.
-constexpr std::string_view NT_HELM_FMT = "RNA1{{{}.{}({})}}$$$$V2.0";
-constexpr unsigned int PHOS_IDX = 0;
-constexpr unsigned int SUGAR_IDX = 1;
-constexpr unsigned int BASE_IDX = 2;
+constexpr std::string_view NT_HELM_FMT = "RNA1{{{}({}){}}}$$$$V2.0";
+constexpr unsigned int SUGAR_IDX = 0;
+constexpr unsigned int BASE_IDX = 1;
+constexpr unsigned int PHOS_IDX = 2;
 
 /**
  * We round the drag angle to 8 increments, i.e., 45 degree increments, instead
@@ -39,10 +39,10 @@ constexpr int DRAG_ANGLE_ROUNDING = 8;
  * with a base.
  */
 const std::vector<MonomerFragmentAttachmentInfo> NUCLEOTIDE_ATTACHMENT_INFO = {
-    {MonomerType::NA_PHOSPHATE, ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR),
-     SUGAR_IDX, ap_model_name_for(NASugarAP::THREE_PRIME)},
-    {MonomerType::NA_SUGAR, ap_model_name_for(NASugarAP::THREE_PRIME), PHOS_IDX,
-     ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)},
+    {MonomerType::NA_PHOSPHATE, ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR),
+     SUGAR_IDX, ap_model_name_for(NASugarAP::FIVE_PRIME)},
+    {MonomerType::NA_SUGAR, ap_model_name_for(NASugarAP::FIVE_PRIME), PHOS_IDX,
+     ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR)},
     {MonomerType::NA_BASE, NA_BASE_AP_PAIR, BASE_IDX, NA_BASE_AP_PAIR}};
 
 /**
@@ -65,8 +65,8 @@ get_nucleotide_fragment_scene_tool(const std::string& sugar,
         }
     };
 
-    auto nt_helm = fmt::format(NT_HELM_FMT, to_helm_monomer(phos),
-                               to_helm_monomer(sugar), to_helm_monomer(base));
+    auto nt_helm = fmt::format(NT_HELM_FMT, to_helm_monomer(sugar),
+                               to_helm_monomer(base), to_helm_monomer(phos));
     auto mol =
         rdkit_extensions::to_rdkit(nt_helm, rdkit_extensions::Format::HELM);
     prepare_mol(*mol);

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(start_phos);
         exp_bound = {{"R2", "", 2, start_sugar, false, Direction::E}};
-        exp_available = {{"R1", "3'", 1, Direction::W}};
+        exp_available = {{"R1", "5'", 1, Direction::W}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(term_phosphate);
         exp_bound = {{"R1", "", 1, term_sugar, false, Direction::W}};
-        exp_available = {{"R2", "5'", 2, Direction::E}};
+        exp_available = {{"R2", "3'", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(term_phos_chain_3);
         exp_bound = {{"R1", "", 1, term_phos_chain_2, false, Direction::W}};
-        exp_available = {{"R2", "5'", 2, Direction::E}};
+        exp_available = {{"R2", "3'", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }

--- a/test/schrodinger/sketcher/tool/test_draw_nucleotide_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_nucleotide_scene_tool_integration_tests.cpp
@@ -15,22 +15,22 @@ BOOST_AUTO_TEST_CASE(test_click_empty_space_adds_nucleotide)
     MonomerToolTestFixture fix;
     fix.setRNANucleotideTool(StdNucleobase::A);
     fix.mouseClick({0, 0});
-    fix.verifyHELM("RNA1{P.R(A)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P}$$$$V2.0");
 
     fix.setRNANucleotideTool(StdNucleobase::U_OR_T);
     fix.mouseClick({200, 0});
-    fix.verifyHELM("RNA1{P.R(A)}|RNA2{P.R(U)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P}|RNA2{R(U)P}$$$$V2.0");
 
     // create a DNA nucleotide
     fix.setDNANucleotideTool(StdNucleobase::U_OR_T);
     fix.mouseClick({400, 0});
-    fix.verifyHELM("RNA1{P.R(A)}|RNA2{P.R(U)}|RNA3{P.[dR](T)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P}|RNA2{R(U)P}|RNA3{[dR](T)P}$$$$V2.0");
 
     // create a custom nucleotide
     fix.setCustomNucleotideTool("Tho", "I", "PS");
     fix.mouseClick({600, 0});
-    fix.verifyHELM("RNA1{P.R(A)}|RNA2{P.R(U)}|RNA3{P.[dR](T)}|RNA4{[PS].[Tho]("
-                   "I)}$$$$V2.0");
+    fix.verifyHELM(
+        "RNA1{R(A)P}|RNA2{R(U)P}|RNA3{[dR](T)P}|RNA4{[Tho](I)[PS]}$$$$V2.0");
 }
 
 BOOST_AUTO_TEST_CASE(test_click_existing_monomers)
@@ -38,53 +38,52 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomers)
     MonomerToolTestFixture fix;
     fix.setRNANucleotideTool(StdNucleobase::A);
     fix.mouseClick({0, 0});
-    fix.verifyHELM("RNA1{P.R(A)}$$$$V2.0");
-
-    // click on the sugar of the first nucleotide
-    fix.setRNANucleotideTool(StdNucleobase::C);
-    auto sugar_pos = fix.getMonomerPos(1);
-    fix.mouseMove(sugar_pos);
-    fix.mouseClick(sugar_pos);
-    fix.verifyHELM("RNA1{P.R(A)P.R(C)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P}$$$$V2.0");
 
     // click on the phosphate of the first nucleotide
-    fix.setRNANucleotideTool(StdNucleobase::G);
-    auto phos_pos = fix.getMonomerPos(0);
+    fix.setRNANucleotideTool(StdNucleobase::C);
+    auto phos_pos = fix.getMonomerPos(2);
     fix.mouseMove(phos_pos);
     fix.mouseClick(phos_pos);
-    fix.verifyHELM("RNA1{P.R(G)P.R(A)P.R(C)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P.R(C)P}$$$$V2.0");
+
+    // click on the sugar of the first nucleotide
+    fix.setRNANucleotideTool(StdNucleobase::G);
+    auto sugar_pos = fix.getMonomerPos(0);
+    fix.mouseMove(sugar_pos);
+    fix.mouseClick(sugar_pos);
+    fix.verifyHELM("RNA1{R(G)P.R(A)P.R(C)P}$$$$V2.0");
 
     // click on the base of the first nucleotide
     fix.setRNANucleotideTool(StdNucleobase::U_OR_T);
-    auto base_pos = fix.getMonomerPos(2);
+    auto base_pos = fix.getMonomerPos(1);
     fix.mouseMove(base_pos);
     fix.mouseClick(base_pos);
     fix.verifyHELM(
-        "RNA1{P.R(G)P.R(A)P.R(C)}|RNA2{P.R(U)}$RNA1,RNA2,6:pair-3:pair$$$V2.0");
+        "RNA1{R(G)P.R(A)P.R(C)P}|RNA2{R(U)P}$RNA1,RNA2,5:pair-2:pair$$$V2.0");
 
     // clicking on the same spots again shouldn't have any effect since those
     // monomers no longer have attachment points available
 
     // recalculate the coordinates first in case anything has been adjusted to
     // fit the labels
-    sugar_pos = fix.getMonomerPos(1);
-    phos_pos = fix.getMonomerPos(0);
-    base_pos = fix.getMonomerPos(2);
+    sugar_pos = fix.getMonomerPos(0);
+    base_pos = fix.getMonomerPos(1);
+    phos_pos = fix.getMonomerPos(2);
 
     fix.mouseMove(sugar_pos);
     fix.mouseClick(sugar_pos);
     fix.verifyHELM(
-        "RNA1{P.R(G)P.R(A)P.R(C)}|RNA2{P.R(U)}$RNA1,RNA2,6:pair-3:pair$$$V2.0");
+        "RNA1{R(G)P.R(A)P.R(C)P}|RNA2{R(U)P}$RNA1,RNA2,5:pair-2:pair$$$V2.0");
 
     fix.mouseMove(phos_pos);
     fix.mouseClick(phos_pos);
     fix.verifyHELM(
-        "RNA1{P.R(G)P.R(A)P.R(C)}|RNA2{P.R(U)}$RNA1,RNA2,6:pair-3:pair$$$V2.0");
-
+        "RNA1{R(G)P.R(A)P.R(C)P}|RNA2{R(U)P}$RNA1,RNA2,5:pair-2:pair$$$V2.0");
     fix.mouseMove(base_pos);
     fix.mouseClick(base_pos);
     fix.verifyHELM(
-        "RNA1{P.R(G)P.R(A)P.R(C)}|RNA2{P.R(U)}$RNA1,RNA2,6:pair-3:pair$$$V2.0");
+        "RNA1{R(G)P.R(A)P.R(C)P}|RNA2{R(U)P}$RNA1,RNA2,5:pair-2:pair$$$V2.0");
 }
 
 BOOST_AUTO_TEST_CASE(test_click_existing_monomer_attachment_points)
@@ -113,7 +112,7 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_attachment_points)
     auto ap_5p_pos = fix.getAttachmentPointPos(0, "5'");
     fix.mouseMove(ap_5p_pos);
     fix.mouseClick(ap_5p_pos);
-    fix.verifyHELM("RNA1{R.P.R(A)}$$$$V2.0");
+    fix.verifyHELM("RNA1{R(A)P.R}$$$$V2.0");
 }
 
 } // namespace sketcher


### PR DESCRIPTION
* Linked Case: SKETCH-2618

### Description
I somehow managed to get attachment point naming correct in the `NASugarAP` enum in monomeric.h, but I swapped 5' and 3' in `NUMBERED_AP_NAMES_BY_MONOMER_TYPE` in monomeric.cpp.  This finally explains why I kept getting myself super confused when implementing the nucleotide tools.  This PR fixes the issue and corrects all of the downstream consequences (which is mostly test HELM strings and atom indices).

### Testing Done
Pasting an RNA HELM string into Sketcher now produces a 5' to 3' structure instead of a backwards 3' to 5' structure.  I also compared the result of a paste into Sketcher with pasting the same string into Pistoia's HELM editor, and the structures now match.
