### PR TITLE
SKETCH-2709: Replace ilammy/msvc-dev-cmd with a PowerShell script

### DIFF
--- a/.github/actions/activate-msvc/action.yml
+++ b/.github/actions/activate-msvc/action.yml
@@ -28,5 +28,38 @@ runs:
       shell: bash
       run: echo FC=${{ steps.install-fortran.outputs.fc }} >> $GITHUB_ENV
 
+      # Find MSVC using vswhere.exe, then use vcvarsall.bat to output the
+      # appropriate environment variable updates and put them into $GITHUB_ENV
     - name: Activate MSVC
-      uses: ilammy/msvc-dev-cmd@v1.13.0
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }
+
+        $installPath = & $vswhere -latest -property installationPath
+        if (-not $installPath) { throw "vswhere did not find a Visual Studio installation" }
+
+        $vcvarsall = Join-Path $installPath 'VC\Auxiliary\Build\vcvarsall.bat'
+        if (-not (Test-Path $vcvarsall)) { throw "vcvarsall.bat not found at $vcvarsall" }
+
+        $envBefore = New-Object 'System.Collections.Generic.Dictionary[String,String]' ([StringComparer]::OrdinalIgnoreCase)
+        Get-ChildItem env: | ForEach-Object { $envBefore[$_.Name] = $_.Value }
+
+        $output = cmd /c "`"$vcvarsall`" x64 > nul && set"
+        if ($LASTEXITCODE -ne 0) { throw "vcvarsall.bat failed with exit code $LASTEXITCODE" }
+
+        foreach ($line in $output) {
+            if ($line -notmatch '^([^=]+)=(.*)$') { continue }
+            $name = $matches[1]
+            $value = $matches[2]
+
+            # Skip variables that contain a multi-line value (e.g. VERSIONS_JSON) 
+            # since vcvarsall.bat shouldn't modify them
+            if ($envBefore.ContainsKey($name) -and $envBefore[$name].Contains("`n")) {
+                continue
+            }
+
+            if (-not $envBefore.ContainsKey($name) -or $envBefore[$name] -ne $value) {
+                Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
+            }
+        }


### PR DESCRIPTION
- Linked Case: SKETCH-2709

### Description

After standup yesterday, Chris and I talked a bit more about this case.  Claude had pointed out to Chris that it wouldn't be too difficult to replace the ilammy/msvc-dev-cmd action with a PowerShell script, so I had Claude write one.  It took a handful of iterations to work out all of the kinks, but the new script correctly updates $GITHUB_ENV to use MSVC without needing to call `vcvarsall.bat` for every subsequent shell command.

This new script doesn't have all of the options of ilammy/msvc-dev-cmd, but we didn't actually use any of them so that shouldn't affect us.  If we upgrade this repo to use the windows-2025 runner (which should have MSVC 2025 as of yesterday) before the core suite upgrades to MSVC 2025 (it's still on MSVC 2022), then we might need to add an option to force MSVC 2022 if we run into compatibility issues (i.e., if code passes on this repo but fails to build in package factory).  Fortunately, that shouldn't be hard: the PowerShell script uses vswhere.exe to pick a Visual Studio, and that executable accepts an argument to specify which MSVC version(s) it should look for, so fixing that should be a simple tweak.

There's still one action that triggers a Node.js 20 warning: version 1.8 of fortran-lang/setup-fortran. (Eigen uses Fortran, a gfortran doesn't play well with MSVC.) Thankfully, there's a version 1.9 of that action, which fixes the warning. I'll put up a separate PR to switch over to that, since I'm pretty sure that we'll need IT to update their list of allowed actions to get that working.  That PR will also add the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to the build workflow, which will opt us in to the more secure version and ensure that we don't inadvertently add anything else deprecated before June, which is when Node.js 20 will be turned off by default.

### Testing Done

Successfully built Sketcher on my fork, both with and without cached dependencies.