### PR TITLE
SKETCH-2750: Refresh HELM_MODEL stale state when dealing with atoms

### DIFF
--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -161,6 +161,7 @@ void strip_notes_and_mol_model_tags(RDKit::ROMol& mol)
         bond->clearProp(RDKit::common_properties::bondNote);
     }
     mol.clearProp(RDKit::common_properties::molNote);
+    mol.clearProp(HELM_MODEL);
     mol.clearAllAtomBookmarks();
     mol.clearAllBondBookmarks();
 
@@ -225,11 +226,14 @@ boost::shared_ptr<RDKit::ROMol> MolModel::getMolForExport() const
 {
     // TODO: add API to export selection as atom/bond properties
     auto mol_copy = boost::make_shared<RDKit::ROMol>(m_mol);
-    if (contains_monomeric_atom(m_mol)) {
+    // Determine HELM-ness from the selection's atom content before stripping,
+    // since stripping also clears the per-atom monomeric flags.
+    const bool is_monomeric = contains_monomeric_atom(*mol_copy);
+    strip_notes_and_mol_model_tags(*mol_copy);
+    if (is_monomeric) {
         // RDKit uses a mol-level property to indicate HELM mols
         mol_copy->setProp(HELM_MODEL, true);
     }
-    strip_notes_and_mol_model_tags(*mol_copy);
     return mol_copy;
 }
 
@@ -256,7 +260,13 @@ boost::shared_ptr<RDKit::ROMol> MolModel::getSelectedMolForExport()
         mol_copy.removeAtom(getAtomFromTag(atom_tag)->getIdx());
     }
     mol_copy.commitBatchEdit();
+    // Determine HELM-ness from the selection's atom content before stripping,
+    // since stripping also clears the per-atom monomeric flags.
+    const bool is_monomeric = contains_monomeric_atom(mol_copy);
     strip_notes_and_mol_model_tags(mol_copy);
+    if (is_monomeric) {
+        mol_copy.setProp(HELM_MODEL, true);
+    }
     return boost::make_shared<RDKit::ROMol>(mol_copy);
 }
 
@@ -678,6 +688,10 @@ void MolModel::addMonomer(const std::string_view res_name,
         addAtomChainCommandFunc(create_atom, {coords}, make_new_single_bond,
                                 AtomTag(-1));
         rdkit_extensions::assignChains(m_mol);
+        // assignChains sets HELM_MODEL on the mol, but per-atom flags are the
+        // source of truth inside MolModel; clearing it here keeps it from
+        // leaking into export copies after monomers are removed.
+        m_mol.clearProp(HELM_MODEL);
     };
     doCommandUsingSnapshots(cmd_func, "Add monomer", WhatChanged::MOLECULE);
 }
@@ -854,6 +868,8 @@ void MolModel::addMonomericConnectionCommandFunc(const size_t bond_start_idx,
         }
     }
     rdkit_extensions::assignChains(m_mol);
+    // see note in addMonomer about why we clear this here
+    m_mol.clearProp(HELM_MODEL);
 }
 
 /**

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4127,6 +4127,54 @@ BOOST_AUTO_TEST_CASE(test_clean_up_does_not_distort_addMonomer_SKETCH_2716,
 }
 
 /**
+ * Reproduce the bug where placing a monomer, deleting it, then placing an
+ * atomistic atom and copy/cutting it throws "Atom does not have monomer info".
+ *
+ * The molecule-level HELM_MODEL property gets set when a monomer is added but
+ * is never cleared when the monomer is deleted. A subsequent
+ * getSelectedMolForExport then returns an atomistic mol still tagged
+ * HELM_MODEL=true, which routes downstream serialization through the
+ * monomeric code path and explodes.
+ */
+BOOST_AUTO_TEST_CASE(test_getSelectedMolForExport_after_monomer_deleted)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    const auto* mol = model.getMol();
+
+    // Place a monomer; assignChains sets HELM_MODEL transiently but addMonomer
+    // clears it before returning so the property doesn't leak.
+    model.addMonomer("A", rdkit_extensions::ChainType::PEPTIDE,
+                     RDGeom::Point3D(0.0, 0.0, 0.0));
+    BOOST_TEST(!mol->hasProp(HELM_MODEL));
+    BOOST_TEST(contains_monomeric_atom(*mol));
+
+    // Delete the monomer.
+    model.selectAll();
+    model.removeSelected();
+    BOOST_TEST(mol->getNumAtoms() == 0);
+
+    // Place an atomistic atom and select it.
+    model.addAtom(Element::C, RDGeom::Point3D(1.0, 2.0, 0.0));
+    BOOST_TEST(mol->getNumAtoms() == 1);
+    auto* c_atom = mol->getAtomWithIdx(0);
+    BOOST_TEST(!is_atom_monomeric(c_atom));
+    model.select({c_atom}, {}, {}, {}, {}, SelectMode::SELECT);
+
+    // The exported selection must not claim to be monomeric.
+    auto exported = model.getSelectedMolForExport();
+    BOOST_TEST(exported->getNumAtoms() == 1);
+    BOOST_TEST(!contains_monomeric_atom(*exported));
+    BOOST_TEST(!rdkit_extensions::isMonomeric(*exported));
+    BOOST_TEST(!exported->hasProp(HELM_MODEL));
+
+    // Round-tripping the exported mol through to_string (what cut/copy does)
+    // must not throw "Atom does not have monomer info".
+    BOOST_CHECK_NO_THROW(rdkit_extensions::to_string(
+        *exported, rdkit_extensions::Format::SMILES));
+}
+
+/**
  * Verify that mutateMonomers changes the res name of all peptide monomers
  * and that the mutation is undoable.
  */


### PR DESCRIPTION
- Linked Case: SKETCH-2750

### Description
Bug occurred when attempting to cut/paste atoms after being in monomer mode for a while: 'Atom has no monomer info'.

Tracked it down to `HELM_MODEL` state not being properly cleared--which is now done in `strip_notes_and_mol_model_tags`. Monomer state is checked again so that it isn't stale over time.

### Testing Done
Added a test that reproduced the issue from my steps programmatically.
```
    BOOST_TEST(!contains_monomeric_atom(*exported));
    BOOST_TEST(!rdkit_extensions::isMonomeric(*exported));
    BOOST_TEST(!exported->hasProp(HELM_MODEL));
```
Should now be correct for atomistic mode after dealing with monomers.