### PR TITLE
SKETCH-2746: Fixing appearance of AMINO / NUCLEIC toggle buttons

### DIFF
--- a/src/schrodinger/sketcher/sketcher_css_style.h
+++ b/src/schrodinger/sketcher/sketcher_css_style.h
@@ -121,5 +121,12 @@ const QString CUSTOM_NUCLEOTIDE_STYLE{
 const QString ATOMISTIC_OR_MONOMERIC_BUTTON_STYLE{
     "QToolButton:checked { background-color: #aac7d8; }"};
 
+const QString AMINO_OR_NUCLEIC_TOGGLE_STYLE{
+    "QToolButton { font-size: 10px; font-weight: bold; color: #3d5d71; "
+    "    background-color: transparent; border: none; }"
+    "QToolButton:disabled { color: #E4E4E4; }"
+    "QToolButton:!checked:hover { color: #5b8aa8;}"
+    "QToolButton:checked { border-bottom: 2px solid #3d5d71; }"};
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -35,7 +35,7 @@
       <number>2</number>
      </property>
      <item>
-      <widget class="QToolButton" name="amino_monomer_btn">
+      <widget class="schrodinger::sketcher::AminoOrNucleicToggleButton" name="amino_monomer_btn">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -69,7 +69,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="nucleic_monomer_btn">
+      <widget class="schrodinger::sketcher::AminoOrNucleicToggleButton" name="nucleic_monomer_btn">
        <property name="minimumSize">
         <size>
          <width>50</width>
@@ -1233,6 +1233,11 @@
    <class>schrodinger::sketcher::ToolButtonWithPopup</class>
    <extends>QToolButton</extends>
    <header>schrodinger/sketcher/widget/tool_button_with_popup.h</header>
+  </customwidget>
+  <customwidget>
+   <class>schrodinger::sketcher::AminoOrNucleicToggleButton</class>
+   <extends>QToolButton</extends>
+   <header>schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.cpp
+++ b/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.cpp
@@ -1,0 +1,43 @@
+#include "schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h"
+
+#include <QProxyStyle>
+
+#include "schrodinger/sketcher/sketcher_css_style.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * A QProxyStyle that prevents the button's label from shifting when the button
+ * is checked. Normally the label is lowered so that the button looks like it's
+ * been pressed in.
+ */
+class NoShiftProxyStyle : public QProxyStyle
+{
+  public:
+    using QProxyStyle::QProxyStyle;
+
+    int pixelMetric(PixelMetric metric, const QStyleOption* option = nullptr,
+                    const QWidget* widget = nullptr) const override
+    {
+        if (metric == PM_ButtonShiftHorizontal ||
+            metric == PM_ButtonShiftVertical) {
+            return 0;
+        }
+        return QProxyStyle::pixelMetric(metric, option, widget);
+    }
+};
+
+AminoOrNucleicToggleButton::AminoOrNucleicToggleButton(QWidget* parent) :
+    QToolButton(parent)
+{
+    setStyleSheet(AMINO_OR_NUCLEIC_TOGGLE_STYLE);
+    auto* proxy_style = new NoShiftProxyStyle();
+    proxy_style->setParent(this);
+    setStyle(proxy_style);
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h
+++ b/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QToolButton>
+
+#include "schrodinger/sketcher/definitions.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * A QToolButton subclass used for the AMINO/NUCLEIC toggle buttons in the
+ * monomer tool widget. Applies the appropriate style sheet and a QProxyStyle
+ * that prevents the label from shifting when the button is checked.
+ */
+class SKETCHER_API AminoOrNucleicToggleButton : public QToolButton
+{
+    Q_OBJECT
+  public:
+    AminoOrNucleicToggleButton(QWidget* parent = nullptr);
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/widget/custom_nucleotide_popup.cpp
+++ b/src/schrodinger/sketcher/widget/custom_nucleotide_popup.cpp
@@ -28,6 +28,8 @@ CustomNucleotidePopup::CustomNucleotidePopup(QWidget* parent) :
         le->setValidator(alphanumeric_validator);
         connect(le, &QLineEdit::textEdited, this,
                 &CustomNucleotidePopup::onTextEdited);
+        connect(le, &QLineEdit::returnPressed, this,
+                &CustomNucleotidePopup::close);
     }
 }
 

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -44,8 +44,6 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
     }
     ui->unk_btn->setStyleSheet(UNKNOWN_MONOMER_STYLE);
     ui->na_n_btn->setStyleSheet(UNKNOWN_MONOMER_STYLE);
-    ui->amino_monomer_btn->setStyleSheet(TEXT_LINK_STYLE);
-    ui->nucleic_monomer_btn->setStyleSheet(TEXT_LINK_STYLE);
 
     using ButtonAminoAcidBimapType =
         boost::bimap<QAbstractButton*, AminoAcidTool>;


### PR DESCRIPTION
- Linked Case: SKETCH-2746

### Description

This PR fixes the appearance of the AMINO and NUCLEIC toggle buttons based on Laura's comments on the case:  The button no longer has a background color when checked.  Instead I've added a fake underline using a bottom border.  It's possible to add a real underline using `text-decoration: underline`, but the underline itself is fairly thin and not particularly noticeable.  QSS doesn't support `text-decoration-thickness` so there's no way to increase its size, so I switched to the bottom border, which makes it much easier to see which button is checked.  I also used a proxy style to prevent the text from being lowered by a few pixels on the checked button.  This lowering made sense when the background was darkened since it made the button look like it was pressed in, but it just looked strange without the background color change.

I also tweaked the custom nucleotide popup so that hitting Enter will close the popup.  All of the other requests on this case related to the buttons for the full nucleotide tools, so those will be done as part of SKETCH-2740.

### Testing Done

Ran the desktop app of Windows.
