### PR TITLE
SKETCH-2746: Fixing mmshare build errors by removing unneeded Q_OBJECT macro

### DIFF
--- a/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h
+++ b/src/schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h
@@ -16,7 +16,6 @@ namespace sketcher
  */
 class SKETCHER_API AminoOrNucleicToggleButton : public QToolButton
 {
-    Q_OBJECT
   public:
     AminoOrNucleicToggleButton(QWidget* parent = nullptr);
 };


### PR DESCRIPTION
- Linked Case: SKETCH-2746

### Description

The builds on my [mmshare PR](https://github.com/schrodinger/mmshare/pull/8848) are failing when this `Q_OBJECT` macro from https://github.com/schrodinger/sketcher/pull/335 is included, even though the `sketcher` builds have no problem with it.  I'm not entirely sure why that's the case, but the macro isn't needed since the class doesn't define any new signals or slots, so I got rid of it.

### Testing Done

Local mmshare builds fail without this change and succeed after it, and local Sketcher builds succeed with either version.  I've updated the mmshare PR with this change and I'll make sure that the builds succeed there as well.
