### PR TITLE
SHARED-12293: fix usage of uninitialized pointers

### DIFF
--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -96,9 +96,9 @@ class SKETCHER_API DrawMonomerSceneTool : public AbstractMonomerSceneTool
     MonomerType m_monomer_type;
 
     bool m_drag_ignored;
-    AbstractMonomerItem* m_drag_start_monomer_item;
+    AbstractMonomerItem* m_drag_start_monomer_item = nullptr;
     std::string m_drag_start_ap_model_name;
-    AbstractMonomerItem* m_drag_end_monomer_item;
+    AbstractMonomerItem* m_drag_end_monomer_item = nullptr;
     DragEndInfo m_drag_end_info;
     QGraphicsItemGroup m_drag_end_attachment_point_labels_group;
     std::vector<UnboundMonomericAttachmentPointItem*>


### PR DESCRIPTION
- Linked Case: SHARED-12293

### Description
These uninitialized pointers are triggering the "uninitialized value used in logic" memtest error reported in SHARED-12293.
