### PR TITLE
Drop JSON from prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         name: prettier
         entry: npx prettier@3.8.3
         language: system
-        files: \.(js|json|yml|yaml|md|html)$
+        files: \.(js|yml|yaml|md|html)$
         args: [--check]
 
       - id: yapf


### PR DESCRIPTION
- Linked Case: N/A

### Description

Removes `.json` from the prettier pre-commit hook's file pattern so JSON files are no longer formatted by the hook.

### Testing Done

`pre-commit run --files .pre-commit-config.yaml` passes locally.