### PR TITLE
SKETCH-2742: Export monomers to file (HELM, FASTA, atomic)

### DIFF
--- a/include/schrodinger/rdkit_extensions/file_format.h
+++ b/include/schrodinger/rdkit_extensions/file_format.h
@@ -78,6 +78,17 @@ RDKIT_EXTENSIONS_API std::vector<std::string>
 get_seq_extensions(const Format format);
 
 /**
+ * @param format file format to consider
+ * @return molecule extensions if the format is a molecule format, otherwise its
+ * sequence extensions. Convenient for non-reaction contexts (e.g. file dialogs)
+ * where a format is either atomistic or sequence but never both; do not use for
+ * reactions, where a format (e.g. SMILES) maps to different extensions.
+ * @throw std::out_of_range if format is neither a molecule nor sequence format
+ */
+RDKIT_EXTENSIONS_API std::vector<std::string>
+get_mol_and_seq_extensions(const Format format);
+
+/**
  * @param filename file path
  * @return corresponding file format enum
  * @throw std::invalid_argument if file extension is unrecognized

--- a/src/schrodinger/rdkit_extensions/file_format.cpp
+++ b/src/schrodinger/rdkit_extensions/file_format.cpp
@@ -106,6 +106,16 @@ std::vector<std::string> get_seq_extensions(const Format format)
     return SEQ_FORMAT_EXTS.at(format);
 }
 
+std::vector<std::string> get_mol_and_seq_extensions(const Format format)
+{
+    // A non-reaction format lives in exactly one of these maps, so try the
+    // molecule map first and fall back to the sequence map.
+    if (auto it = MOL_FORMAT_EXTS.find(format); it != MOL_FORMAT_EXTS.end()) {
+        return it->second;
+    }
+    return SEQ_FORMAT_EXTS.at(format);
+}
+
 Format get_file_format(const boost::filesystem::path& filename)
 {
     auto extension = filename.extension().string();

--- a/src/schrodinger/sketcher/dialog/file_export_dialog.cpp
+++ b/src/schrodinger/sketcher/dialog/file_export_dialog.cpp
@@ -104,8 +104,10 @@ void FileExportDialog::showEvent(QShowEvent* event)
 std::vector<std::string> FileExportDialog::getValidExtensions() const
 {
     auto combo_format = m_ui->format_combo->currentData().value<Format>();
-    return m_model_has_reaction ? get_rxn_extensions(combo_format)
-                                : get_mol_extensions(combo_format);
+    if (m_model_has_reaction) {
+        return get_rxn_extensions(combo_format);
+    }
+    return get_mol_and_seq_extensions(combo_format);
 }
 
 void FileExportDialog::exportFile()

--- a/src/schrodinger/sketcher/dialog/file_import_export.cpp
+++ b/src/schrodinger/sketcher/dialog/file_import_export.cpp
@@ -74,7 +74,7 @@ FormatList<Format> get_import_formats()
 
 FormatList<Format> get_standard_export_formats()
 {
-    std::vector<std::tuple<Format, std::string>> mol_export_formats = {
+    std::vector<std::tuple<Format, std::string>> mol_and_seq_export_formats = {
         // Forbid MDL_MOLV2000 on export; potential stereo ambiguities
         {Format::MDL_MOLV3000, "MDL SD V3000"},
         {Format::MAESTRO, "Maestro"},
@@ -87,11 +87,16 @@ FormatList<Format> get_standard_export_formats()
         {Format::PDB, "PDB"},
         {Format::XYZ, "XYZ"},
         {Format::MRV, "Marvin Document"},
+        // Sequence formats are always offered; rdkit_extensions::to_string
+        // handles atomistic <-> monomeric conversion on the fly, and conversion
+        // failures surface through the dialog's existing error path.
+        {Format::HELM, "HELM"},
+        {Format::FASTA, "FASTA"},
     };
 
     FormatList<Format> export_formats;
-    for (const auto& [format, label] : mol_export_formats) {
-        auto extensions = rdkit_extensions::get_mol_extensions(format);
+    for (const auto& [format, label] : mol_and_seq_export_formats) {
+        auto extensions = rdkit_extensions::get_mol_and_seq_extensions(format);
         export_formats.push_back({format, label, extensions});
     }
     return export_formats;

--- a/test/schrodinger/rdkit_extensions/test_file_format.cpp
+++ b/test/schrodinger/rdkit_extensions/test_file_format.cpp
@@ -4,6 +4,10 @@
 
 #define BOOST_TEST_MODULE test_file_format
 
+#include <algorithm>
+#include <ranges>
+#include <stdexcept>
+
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/format.h>
@@ -44,6 +48,33 @@ BOOST_DATA_TEST_CASE(test_get_seq_extensions,
     for (const auto& file_extension : get_seq_extensions(sample)) {
         BOOST_TEST(get_file_format(file_extension) == sample);
     }
+}
+
+BOOST_DATA_TEST_CASE(test_get_mol_and_seq_extensions_for_mol_formats,
+                     boost::unit_test::data::make(MOL_FORMATS))
+{
+    // For molecule formats the combined helper matches get_mol_extensions
+    BOOST_TEST(get_mol_and_seq_extensions(sample) ==
+               get_mol_extensions(sample));
+}
+
+BOOST_DATA_TEST_CASE(test_get_mol_and_seq_extensions_for_seq_formats,
+                     boost::unit_test::data::make(SEQ_FORMATS))
+{
+    // Sequence-only formats fall back to get_seq_extensions; formats present in
+    // both maps (e.g. RDMOL_BINARY_BASE64) resolve to the molecule entry.
+    const auto& expected =
+        std::ranges::find(MOL_FORMATS, sample) != MOL_FORMATS.end()
+            ? get_mol_extensions(sample)
+            : get_seq_extensions(sample);
+    BOOST_TEST(get_mol_and_seq_extensions(sample) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_mol_and_seq_extensions_unsupported)
+{
+    // A format in neither the molecule nor sequence map throws
+    BOOST_CHECK_THROW(get_mol_and_seq_extensions(Format::AUTO_DETECT),
+                      std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(test_unsupported_extensions)

--- a/test/schrodinger/sketcher/dialog/test_file_export_dialog.cpp
+++ b/test/schrodinger/sketcher/dialog/test_file_export_dialog.cpp
@@ -4,6 +4,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../test_common.h"
+#include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/rdkit_extensions/helm.h"
 #include "schrodinger/sketcher/dialog/file_export_dialog.h"
 #include "schrodinger/sketcher/model/sketcher_model.h"
 #include "schrodinger/sketcher/ui/ui_file_export_dialog.h"
@@ -48,7 +50,8 @@ BOOST_AUTO_TEST_CASE(test_FileExportDialog_standard)
     TestFileExportDialog dlg(&model);
     BOOST_TEST(dlg.getComboFormat() == Format::MDL_MOLV3000);
     BOOST_TEST(dlg.m_ui->filename_le->text().toStdString() == "structure");
-    BOOST_TEST(dlg.m_ui->format_combo->count() == 8); // export formats
+    // 8 atomistic formats with extensions + HELM + FASTA = 10
+    BOOST_TEST(dlg.m_ui->format_combo->count() == 10);
     auto exts = dlg.getValidExtensions();
     BOOST_TEST(exts.size() == 8); // MDL available extensions
     BOOST_TEST(contains(exts, ".mol"));
@@ -59,6 +62,13 @@ BOOST_AUTO_TEST_CASE(test_FileExportDialog_standard)
     exts = dlg.getValidExtensions();
     BOOST_TEST(exts.size() == 6);
     BOOST_TEST(contains(exts, ".pdb"));
+
+    // HELM and FASTA are always available regardless of model state;
+    // selecting them produces sequence extensions.
+    dlg.setComboFormat(Format::HELM);
+    BOOST_TEST(contains(dlg.getValidExtensions(), ".helm"));
+    dlg.setComboFormat(Format::FASTA);
+    BOOST_TEST(contains(dlg.getValidExtensions(), ".fasta"));
 }
 
 BOOST_AUTO_TEST_CASE(test_FileExportDialog_reaction)
@@ -97,4 +107,70 @@ BOOST_AUTO_TEST_CASE(export_button)
 #else
     BOOST_TEST(dlg.m_ui->export_btn->text().toStdString() == "Save...");
 #endif
+}
+
+// Wire the dialog to a real mol so its export plumbing (combo selection ->
+// getFileContent() -> exportTextRequested signal) can be exercised end-to-end
+// against rdkit_extensions::to_string.
+static std::unique_ptr<TestFileExportDialog>
+make_dialog_for_mol(SketcherModel& model,
+                    const boost::shared_ptr<RDKit::RWMol>& mol)
+{
+    auto dlg = std::make_unique<TestFileExportDialog>(&model);
+    QObject::connect(
+        dlg.get(), &FileExportDialog::exportTextRequested,
+        [mol](Format format) {
+            return QString::fromStdString(
+                schrodinger::rdkit_extensions::to_string(*mol, format));
+        });
+    return dlg;
+}
+
+BOOST_AUTO_TEST_CASE(test_FileExportDialog_helm_roundtrip)
+{
+    using schrodinger::rdkit_extensions::to_rdkit;
+    auto source_mol = to_rdkit("PEPTIDE1{A.G.L}$$$$V2.0", Format::HELM);
+
+    SketcherModel model;
+    auto dlg = make_dialog_for_mol(model, source_mol);
+    dlg->setComboFormat(Format::HELM);
+    auto exported = dlg->getFileContent().toStdString();
+
+    auto roundtripped = to_rdkit(exported, Format::HELM);
+    BOOST_TEST(roundtripped->getNumAtoms() == source_mol->getNumAtoms());
+    BOOST_TEST(roundtripped->getNumBonds() == source_mol->getNumBonds());
+}
+
+BOOST_AUTO_TEST_CASE(test_FileExportDialog_fasta_roundtrip)
+{
+    using schrodinger::rdkit_extensions::to_rdkit;
+    auto source_mol = to_rdkit("PEPTIDE1{A.G.L}$$$$V2.0", Format::HELM);
+
+    SketcherModel model;
+    auto dlg = make_dialog_for_mol(model, source_mol);
+    dlg->setComboFormat(Format::FASTA);
+    auto exported = dlg->getFileContent().toStdString();
+
+    // FASTA reads require the specific sub-format (peptide vs DNA vs RNA);
+    // the exporter always emits Format::FASTA.
+    auto roundtripped = to_rdkit(exported, Format::FASTA_PEPTIDE);
+    BOOST_TEST(roundtripped->getNumAtoms() == source_mol->getNumAtoms());
+}
+
+BOOST_AUTO_TEST_CASE(test_FileExportDialog_monomeric_to_atomistic_export)
+{
+    using schrodinger::rdkit_extensions::to_rdkit;
+    auto source_mol = to_rdkit("PEPTIDE1{A.G.L}$$$$V2.0", Format::HELM);
+    BOOST_TEST(schrodinger::rdkit_extensions::isMonomeric(*source_mol));
+
+    SketcherModel model;
+    auto dlg = make_dialog_for_mol(model, source_mol);
+    // Picking an atomistic format on a monomeric scene should expand the
+    // monomers into their constituent atoms before serializing.
+    dlg->setComboFormat(Format::MDL_MOLV3000);
+    auto exported = dlg->getFileContent().toStdString();
+
+    auto roundtripped = to_rdkit(exported, Format::MDL_MOLV3000);
+    BOOST_TEST(!schrodinger::rdkit_extensions::isMonomeric(*roundtripped));
+    BOOST_TEST(roundtripped->getNumAtoms() > source_mol->getNumAtoms());
 }

--- a/test/schrodinger/sketcher/dialog/test_file_import_export.cpp
+++ b/test/schrodinger/sketcher/dialog/test_file_import_export.cpp
@@ -15,7 +15,20 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(Format);
 BOOST_AUTO_TEST_CASE(test_get_import_export_formats)
 {
     BOOST_TEST(get_import_formats().size() == 12);
-    BOOST_TEST(get_standard_export_formats().size() == 11);
+    // 11 atomistic + HELM + FASTA = 13
+    BOOST_TEST(get_standard_export_formats().size() == 13);
     BOOST_TEST(get_reaction_export_formats().size() == 5);
     BOOST_TEST(get_image_export_formats().size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_standard_export_formats_includes_sequence_formats)
+{
+    auto formats = get_standard_export_formats();
+    auto has_format = [&formats](Format target) {
+        return std::ranges::any_of(formats, [target](const auto& e) {
+            return std::get<0>(e) == target;
+        });
+    };
+    BOOST_TEST(has_format(Format::HELM));
+    BOOST_TEST(has_format(Format::FASTA));
 }


### PR DESCRIPTION
- Linked Case: SKETCH-2742

### Description
Supports monomers exported as both HELM and FASTA. Additionally, atomic file formats are supported (monomers are autoconverted to atomitistic models first).

### Testing Done
Added tests which verifies the new file formats during monomer export. Also testing round-tripping for HELM, FASTA, and atomistic.
