### PR TITLE
SKETCH-2746: Active AMINO/NUCLEIC tab now colored black

### DIFF
--- a/src/schrodinger/sketcher/sketcher_css_style.h
+++ b/src/schrodinger/sketcher/sketcher_css_style.h
@@ -126,7 +126,8 @@ const QString AMINO_OR_NUCLEIC_TOGGLE_STYLE{
     "    background-color: transparent; border: none; }"
     "QToolButton:disabled { color: #E4E4E4; }"
     "QToolButton:!checked:hover { color: #5b8aa8;}"
-    "QToolButton:checked { border-bottom: 2px solid #3d5d71; }"};
+    "QToolButton:checked { color: #000000;"
+    "     border-bottom: 2px solid #000000; }"};
 
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/sketcher_css_style.h
+++ b/src/schrodinger/sketcher/sketcher_css_style.h
@@ -127,7 +127,7 @@ const QString AMINO_OR_NUCLEIC_TOGGLE_STYLE{
     "QToolButton:disabled { color: #E4E4E4; }"
     "QToolButton:!checked:hover { color: #5b8aa8;}"
     "QToolButton:checked { color: #000000;"
-    "     border-bottom: 2px solid #000000; }"};
+    "     border-bottom: 2px solid #333333; }"};
 
 } // namespace sketcher
 } // namespace schrodinger


### PR DESCRIPTION
- Linked Case: SKETCH-2746

### Description

Based on Laura's comment on the Jira case, this PR changes the text and underline color of that active AMINO or NUCLEIC tab from dark blue to black, to indicate that it's active as opposed to clickable.

After the change:
<img width="100" height="145" alt="image" src="https://github.com/user-attachments/assets/1026e6c8-9991-427a-afbe-0edbad1d5d41" />

### Testing Done

Ran desktop app on Windows
