### PR TITLE
SKETCH-2765: Prevent drifting of sugar-base bond lengths

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <iterator>
 #include <map>
@@ -3090,6 +3091,13 @@ void update_monomer_sizes(
     }
 }
 
+void store_initial_monomer_sizes(
+    RDKit::ROMol& mol,
+    const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes)
+{
+    update_monomer_sizes(mol, monomer_sizes);
+}
+
 bool is_geometrically_regular_ring_2d(const RDKit::ROMol& mol,
                                       const std::vector<int>& ring_atoms,
                                       double radius_tol, double angle_tol)
@@ -3186,12 +3194,24 @@ RingResizeInfo compute_ring_info_for_resize(RDKit::ROMol& mol)
  * @param mol           The molecule containing the monomers to resize.
  * @param monomer_sizes A map from atom indices to their new desired sizes.
  */
-void resize_monomers(RDKit::ROMol& mol,
-                     std::unordered_map<int, RDGeom::Point3D> monomer_sizes)
+void resize_monomers(
+    RDKit::ROMol& mol,
+    const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes)
 {
     if (monomer_sizes.empty()) {
         return;
     }
+
+    // callers must call store_initial_monomer_sizes first on any
+    // monomer that's never been sized. Otherwise the default-vs-actual size
+    // gap shows up here as a phantom resize and shifts neighbors.
+#ifndef NDEBUG
+    for (const auto& [idx, _] : monomer_sizes) {
+        assert(mol.getAtomWithIdx(idx)->hasProp(MONOMER_ITEM_SIZE) &&
+               "resize_monomers called on monomer without prior "
+               "store_initial_monomer_sizes");
+    }
+#endif
 
     // override ring info to ensure rings are fully perceived.
     compute_full_ring_info(mol);

--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.h
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.h
@@ -84,7 +84,16 @@ double RDKIT_EXTENSIONS_API get_position_in_coils_double(
  */
 void RDKIT_EXTENSIONS_API
 resize_monomers(RDKit::ROMol& monomer_mol,
-                std::unordered_map<int, RDGeom::Point3D> monomer_sizes);
+                const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes);
+
+/**
+ * Persist sizes on monomer atoms without computing displacement. Use this for
+ * first-time sizing of new monomers; resize_monomers would otherwise treat
+ * the default-vs-actual size gap as a resize event.
+ */
+void RDKIT_EXTENSIONS_API store_initial_monomer_sizes(
+    RDKit::ROMol& monomer_mol,
+    const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes);
 
 /**
  * Check whether any bonds in the given monomer mol cross each other or are

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -3312,10 +3312,16 @@ void add_text_to_mol_model(MolModel& mol_model, const std::string& text,
                                      recenter_view);
 }
 
-void MolModel::setMonomerSizes(
-    std::unordered_map<int, RDGeom::Point3D> monomer_sizes)
+void MolModel::resizeMonomers(
+    const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes)
 {
     rdkit_extensions::resize_monomers(m_mol, monomer_sizes);
+}
+
+void MolModel::storeInitialMonomerSizes(
+    const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes)
+{
+    rdkit_extensions::store_initial_monomer_sizes(m_mol, monomer_sizes);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -974,8 +974,16 @@ class SKETCHER_API MolModel : public AbstractUndoableModel
      * @param monomer_sizes A map from monomer index to its size in mol
      * coordinates (x is width, y is height, z is ignored)
      */
-    void
-    setMonomerSizes(std::unordered_map<int, RDGeom::Point3D> monomer_sizes);
+    void resizeMonomers(
+        const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes);
+
+    /**
+     * Persist sizes for monomers that have never been sized before, without
+     * triggering resize_monomers' displacement. Called by Scene on newly-added
+     * monomers so existing ones don't get pushed around.
+     */
+    void storeInitialMonomerSizes(
+        const std::unordered_map<int, RDGeom::Point3D>& monomer_sizes);
 
   signals:
 

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -20,6 +20,7 @@
 #include <QWidget>
 
 #include "schrodinger/rdkit_extensions/file_format.h"
+#include "schrodinger/rdkit_extensions/helm/monomer_coordgen.h"
 
 #include "schrodinger/sketcher/dialog/file_import_export.h"
 #include "schrodinger/sketcher/model/non_molecular_object.h"
@@ -891,7 +892,11 @@ void Scene::updateMonomerLabelSizeOnModel()
     if (!m_mol_model->isMonomeric()) {
         return;
     }
-    std::unordered_map<int, RDGeom::Point3D> sizes;
+    // split into "first-time sizing" vs "resize". First-time must
+    // skip resize_monomers' displacement, else every new monomer's default-vs-
+    // actual size gap pushes existing monomers outward on every add.
+    std::unordered_map<int, RDGeom::Point3D> initial_sizes;
+    std::unordered_map<int, RDGeom::Point3D> resize_sizes;
     for (auto atom : m_mol_model->getMol()->atoms()) {
         if (!is_atom_monomeric(atom)) {
             continue;
@@ -899,12 +904,22 @@ void Scene::updateMonomerLabelSizeOnModel()
         // create a temporary graphics item to figure out the label size
         auto* item = get_monomer_graphics_item(atom, m_fonts);
         const auto bounding_rect = item->boundingRect();
-        sizes[atom->getIdx()] =
-            RDGeom::Point3D(bounding_rect.width() / VIEW_SCALE,
-                            bounding_rect.height() / VIEW_SCALE, 0);
+        RDGeom::Point3D size(bounding_rect.width() / VIEW_SCALE,
+                             bounding_rect.height() / VIEW_SCALE, 0);
         delete item;
+
+        if (atom->hasProp(rdkit_extensions::MONOMER_ITEM_SIZE)) {
+            resize_sizes[atom->getIdx()] = size;
+        } else {
+            initial_sizes[atom->getIdx()] = size;
+        }
     }
-    m_mol_model->setMonomerSizes(sizes);
+    if (!initial_sizes.empty()) {
+        m_mol_model->storeInitialMonomerSizes(initial_sizes);
+    }
+    if (!resize_sizes.empty()) {
+        m_mol_model->resizeMonomers(resize_sizes);
+    }
 }
 
 const QGraphicsItem*

--- a/test/schrodinger/sketcher/tool/test_draw_nucleotide_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_nucleotide_scene_tool_integration_tests.cpp
@@ -1,14 +1,104 @@
 #define BOOST_TEST_MODULE test_draw_nucleotide_scene_tool_integration_tests
 
+#include <algorithm>
+#include <vector>
+
 #include <QPointF>
 #include <boost/test/unit_test.hpp>
 
+#include "schrodinger/rdkit_extensions/helm.h"
 #include "./test_monomer_integration_tests_common.h"
 
 namespace schrodinger
 {
 namespace sketcher
 {
+
+namespace
+{
+// SKETCH-2765 helper: gather every sugar->base (branch) bond length in the
+// current mol so the test can assert they stay uniform as the chain grows.
+std::vector<double> collect_branch_bond_lengths(MolModel* mol_model)
+{
+    auto mol = mol_model->getMol();
+    BOOST_REQUIRE(mol);
+    const auto& conf = mol->getConformer();
+    std::vector<double> lengths;
+    for (const auto* bond : mol->bonds()) {
+        const auto* a = bond->getBeginAtom();
+        const auto* b = bond->getEndAtom();
+        bool a_branch =
+            a->hasProp(BRANCH_MONOMER) && a->getProp<bool>(BRANCH_MONOMER);
+        bool b_branch =
+            b->hasProp(BRANCH_MONOMER) && b->getProp<bool>(BRANCH_MONOMER);
+        if (!a_branch && !b_branch) {
+            continue;
+        }
+        const auto& pa = conf.getAtomPos(a->getIdx());
+        const auto& pb = conf.getAtomPos(b->getIdx());
+        lengths.push_back((pa - pb).length());
+    }
+    return lengths;
+}
+
+// Canonical sugar->base distance produced by coordgen
+// (rdkit_extensions::MONOMER_BOND_LENGTH = SIDE_TO_SIDE_DISTANCE 0.7 +
+// MONOMER_MINIMUM_SIZE 0.8).
+constexpr double EXPECTED_BRANCH_BOND_LENGTH = 1.5;
+
+void check_branch_bonds_stable(MolModel* mol_model, size_t expected_count,
+                               int add_number)
+{
+    auto lengths = collect_branch_bond_lengths(mol_model);
+    BOOST_REQUIRE_EQUAL(lengths.size(), expected_count);
+    auto [min_it, max_it] = std::minmax_element(lengths.begin(), lengths.end());
+    BOOST_TEST(*max_it - *min_it < 1e-6,
+               "branch bond lengths drifted after add #"
+                   << add_number << ": min=" << *min_it << " max=" << *max_it);
+    // Pin to the canonical value so a future bug that uniformly shrinks or
+    // stretches every bond can't slip past the uniformity check.
+    BOOST_TEST(std::abs(*min_it - EXPECTED_BRANCH_BOND_LENGTH) < 1e-6,
+               "branch bond length is " << *min_it << " after add #"
+                                        << add_number << ", expected "
+                                        << EXPECTED_BRANCH_BOND_LENGTH);
+}
+} // namespace
+
+// SKETCH-2765: adding R(A)P units used to drift the sugar->base bond longer
+// on every add — resize_monomers treated first-time sizing of a new monomer
+// as a resize event and pushed every other monomer outward.
+BOOST_AUTO_TEST_CASE(test_sketch_2765_branch_bond_growth_separate_polymers)
+{
+    MonomerToolTestFixture fix;
+    fix.setRNANucleotideTool(StdNucleobase::A);
+
+    for (int i = 0; i < 7; ++i) {
+        QPointF pos(i * 200.0, 0.0);
+        fix.mouseClick(pos);
+        check_branch_bonds_stable(fix.m_mol_model, static_cast<size_t>(i + 1),
+                                  i + 1);
+    }
+}
+
+// SKETCH-2765: same regression, but exercised against a single connected chain
+// (the actual user-reported repro from the screenshot).
+BOOST_AUTO_TEST_CASE(test_sketch_2765_branch_bond_growth_single_chain)
+{
+    MonomerToolTestFixture fix;
+    fix.setRNANucleotideTool(StdNucleobase::A);
+    fix.mouseClick({0, 0});
+
+    for (int i = 1; i < 7; ++i) {
+        // The RNA nucleotide tool emits monomers in (R, A, P) triples in that
+        // canonical HELM order, so the trailing phosphate of the i-th
+        // nucleotide sits at atom index 3*i - 1 (2, 5, 8, ...).
+        auto phos_pos = fix.getMonomerPos(3 * i - 1);
+        fix.mouseMove(phos_pos);
+        fix.mouseClick(phos_pos);
+        check_branch_bonds_stable(fix.m_mol_model, static_cast<size_t>(i + 1),
+                                  i + 1);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(test_click_empty_space_adds_nucleotide)
 {


### PR DESCRIPTION
- Linked Case: SKETCH-2765

### Description
As nucleic acid chains grew, so did the sugar-base bond. Seems like existing monomers grew by roughly 0.12 units because all monomers in the nascent chain goes through the `resize_monomers` pass. Added a new function which initially sets the `MONOMER_ITEM_SIZE` atom property via `update_monomer_size` call. Now, subsequent calls to `updateMonomerLabelSizeOnModel` will check if the atom label has this already set and only perform displacement on those without it.

renamed `setMonomerSizes` to `resizeMonomers` so that it's clear that one function is responsible for the initial set, while another performs the update.

Additional change: also added const-refs to places where it made sense.

Adding @ZontaNicola since this seems like his wheelhouse.

### Testing Done
Created some tests to ensure prevention of bead-drifting as it grows.
