### PR TITLE
NO_JIRA_ID: Fix compilation failure on Windows

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/polymer_group.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/polymer_group.cpp
@@ -122,11 +122,11 @@ std::string get_polymer_groups_helm_string(const ::RDKit::ROMol& mol)
 
     if (auto sgroups = get_polymer_group_substance_groups(mol);
         !sgroups.empty()) {
-        return fmt::format(
-            "{}", fmt::join(sgroups | std::views::transform([&](auto& sgroup) {
-                                return get_polymer_group_helm_string(sgroup);
-                            }),
-                            "|"));
+        std::vector<std::string> helm_strings;
+        helm_strings.reserve(sgroups.size());
+        std::ranges::transform(sgroups, std::back_inserter(helm_strings),
+                               get_polymer_group_helm_string);
+        return fmt::format("{}", fmt::join(helm_strings, "|"));
     }
 
     return {};


### PR DESCRIPTION
- Linked Case: NO_JIRA_ID

### Description

<!--Provide a detailed description what these changes are and why they are necessary -->
This was happening due to incomplete ranges support with our windows compiler.


### Testing Done

<!--Describe the testing that was done to ensure the changes are working as expected -->
