### PR TITLE
SKETCH-2745: Show corner wedge on selection when analogs are available

### DIFF
--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -186,27 +186,31 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
 
     for (auto& entry : m_button_amino_acid_bimap.left) {
         auto* button = entry.first;
-        auto aa_tool = entry.second;
-        auto symbol = AMINO_ACID_TOOL_TO_RES_NAME.at(aa_tool);
-        auto it = analogs_by_aa.find(symbol);
-        if (it == analogs_by_aa.end() || it->second.empty()) {
-            continue;
-        }
-        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
-        auto* popup = new AminoAcidSymbolPopup(symbol, name, it->second, this);
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
         Q_ASSERT_X(modular_btn, "MonomerToolWidget",
                    "Expected ModularToolButton");
+        // Hide the wedge by default for every AA button; only enable hover
+        // reveal on buttons that actually get an analog popup attached.
+        modular_btn->showPopupIndicator(false);
+
+        auto aa_tool = entry.second;
+        auto symbol = AMINO_ACID_TOOL_TO_RES_NAME.at(aa_tool);
+        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
+        auto it = analogs_by_aa.find(symbol);
+        if (it == analogs_by_aa.end() || it->second.empty()) {
+            button->setToolTip(QString::fromStdString(name));
+            continue;
+        }
+        auto* popup = new AminoAcidSymbolPopup(symbol, name, it->second, this);
         modular_btn->setPopupWidget(popup);
         modular_btn->setEnumItem(0); // default to standard AA
-        modular_btn->showPopupIndicator(false);
+        modular_btn->showPopupIndicatorOnHover(true);
         m_amino_acid_symbol_popups[button] = popup;
     }
 
-    // Set up nucleic acid analog popups from the monomer database. Unlike
-    // the AA loop above, we always attach a popup (even when the analog
-    // list is empty) so that the standard-base tooltip is available on
-    // every per-base button.
+    // Set up nucleic acid analog popups from the monomer database. Buttons
+    // without any analogs get the standard-base name as a plain tooltip and
+    // no popup is attached.
     static const std::unordered_map<std::string, std::string>
         STANDARD_NA_NAMES = {
             {"A", "Adenine"}, {"C", "Cytosine"},     {"G", "Guanine"},
@@ -235,13 +239,22 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
             continue; // sugar/phosphate/full-nucleotide buttons
         }
         const auto& [symbol, name] = *std_name;
+        auto* modular_btn = qobject_cast<ModularToolButton*>(button);
+        // Hide the wedge by default for every per-base NA button; only
+        // enable hover reveal on buttons that actually get an analog popup
+        // attached.
+        modular_btn->showPopupIndicator(false);
+
         auto analogs =
             get_analogs_for_na_button(symbol, analogs_by_na, STANDARD_NA_NAMES);
+        if (analogs.empty()) {
+            button->setToolTip(QString::fromStdString(name));
+            continue;
+        }
         auto* popup = new NucleicAcidSymbolPopup(symbol, name, analogs, this);
-        auto* modular_btn = qobject_cast<ModularToolButton*>(button);
         modular_btn->setPopupWidget(popup);
         modular_btn->setEnumItem(0); // default to standard base
-        modular_btn->showPopupIndicator(false);
+        modular_btn->showPopupIndicatorOnHover(true);
         m_nucleic_acid_symbol_popups[button] = popup;
     }
 }
@@ -500,16 +513,24 @@ void MonomerToolWidget::onNucleicAcidClicked(QAbstractButton* button)
     }
 
     // Set which specific analog is selected; falls back to the standard
-    // base symbol when the button has no analog popup or the
-    // popup is on its default item.
+    // base symbol when the button has no analog popup attached.
+    auto na_tool = m_button_nucleic_acid_bimap.left.at(button);
+    QString symbol;
     auto it = m_nucleic_acid_symbol_popups.find(button);
     if (it != m_nucleic_acid_symbol_popups.end()) {
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
-        auto symbol = it->second->getSymbolForId(modular_btn->getEnumItem());
-        auto na_tool = m_button_nucleic_acid_bimap.left.at(button);
-        ping_or_set_model_value(getModel(), ModelKey::NUCLEIC_ACID_SYMBOL,
-                                NucleicAcidMutation{na_tool, symbol});
+        symbol = it->second->getSymbolForId(modular_btn->getEnumItem());
+    } else {
+        // Full-nucleotide tools (RNA/DNA/CUSTOM_NUCLEOTIDE) have no
+        // single-residue mapping; skip the symbol ping for those.
+        auto res_it = NUCLEIC_ACID_TOOL_TO_RES_NAME.find(na_tool);
+        if (res_it == NUCLEIC_ACID_TOOL_TO_RES_NAME.end()) {
+            return;
+        }
+        symbol = QString::fromStdString(res_it->second);
     }
+    ping_or_set_model_value(getModel(), ModelKey::NUCLEIC_ACID_SYMBOL,
+                            NucleicAcidMutation{na_tool, symbol});
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/widget/tool_button_with_popup.cpp
+++ b/src/schrodinger/sketcher/widget/tool_button_with_popup.cpp
@@ -18,6 +18,7 @@ namespace sketcher
 
 ToolButtonWithPopup::ToolButtonWithPopup(QWidget* parent) : QToolButton(parent)
 {
+    setAttribute(Qt::WA_Hover, true);
     m_popup_timer = new QTimer(this);
     m_popup_timer->setSingleShot(true);
     m_popup_timer->setInterval(m_popup_delay);
@@ -37,7 +38,9 @@ void ToolButtonWithPopup::paintEvent(QPaintEvent* event)
     QStylePainter p(this);
     QStyleOptionToolButton opt;
     initStyleOption(&opt);
-    if (m_show_corner_arrow) {
+    bool hovered = opt.state & QStyle::State_MouseOver;
+    if (m_show_popup_indicator ||
+        (m_show_popup_indicator_on_hover && hovered && isEnabled())) {
         opt.features |= QStyleOptionToolButton::HasMenu;
     }
     p.drawComplexControl(QStyle::CC_ToolButton, opt);
@@ -68,8 +71,18 @@ void ToolButtonWithPopup::setPopupDelay(float popup_delay)
 
 void ToolButtonWithPopup::showPopupIndicator(bool show)
 {
-    m_show_corner_arrow = show;
+    m_show_popup_indicator = show;
     updateStyle();
+}
+
+void ToolButtonWithPopup::showPopupIndicatorOnHover(bool show)
+{
+    if (m_show_popup_indicator_on_hover == show) {
+        return;
+    }
+    m_show_popup_indicator_on_hover = show;
+    updateStyle();
+    update();
 }
 
 void ToolButtonWithPopup::showPopup()
@@ -131,7 +144,7 @@ void ToolButtonWithPopup::setStyleSheet(QString text)
 void ToolButtonWithPopup::updateStyle()
 {
     QString style;
-    if (m_show_corner_arrow) {
+    if (m_show_popup_indicator || m_show_popup_indicator_on_hover) {
         style.append(TOOL_BUTTON_CORNER_ARROW_STYLE);
     }
     style.append(m_custom_style_sheet);

--- a/src/schrodinger/sketcher/widget/tool_button_with_popup.h
+++ b/src/schrodinger/sketcher/widget/tool_button_with_popup.h
@@ -45,6 +45,15 @@ class SKETCHER_API ToolButtonWithPopup : public QToolButton
     void showPopupIndicator(bool show);
 
     /**
+     * If enabled, the popup indicator is also shown while the mouse hovers
+     * over the button, in addition to the conditions set via
+     * showPopupIndicator(). Off by default.
+     *
+     * @param show Whether to reveal the indicator on hover
+     */
+    void showPopupIndicatorOnHover(bool show);
+
+    /**
      * Apply additional style sheet parameters to the default style used for
      * this widget.
      *
@@ -116,7 +125,8 @@ class SKETCHER_API ToolButtonWithPopup : public QToolButton
   private:
     QTimer* m_popup_timer = nullptr;
     float m_popup_delay = 250;
-    bool m_show_corner_arrow = true;
+    bool m_show_popup_indicator = true;
+    bool m_show_popup_indicator_on_hover = false;
 };
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2745

### Description
Addressing UX feedback to show corner wedge on hover rather than just only on selection.

### Testing Done
Manually hovered over buttons with analogs