### PR TITLE
SKETCH-2762: Add context menus for nucleic acid mutations

### DIFF
--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -48,6 +48,7 @@ namespace schrodinger
 namespace sketcher
 {
 
+class AbstractContextMenu;
 class AttachmentPointContextMenu;
 class AtomContextMenu;
 class BackgroundContextMenu;
@@ -443,7 +444,22 @@ class SKETCHER_API SketcherWidget : public QWidget
         const std::unordered_set<const RDKit::Bond*>& secondary_connections,
         const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
         const std::unordered_set<const NonMolecularObject*>&
-            non_molecular_objects);
+            non_molecular_objects,
+        const RDKit::Atom* primary_atom = nullptr);
+
+    /**
+     * Pick the appropriate context menu for a given selection. Pure routing —
+     * no side effects. Returns nullptr when the selection has no menu (e.g.
+     * a non-molecular object). Exposed for unit testing the routing logic.
+     */
+    AbstractContextMenu* chooseContextMenu(
+        const std::unordered_set<const RDKit::Atom*>& filtered_atoms,
+        const std::unordered_set<const RDKit::Bond*>& filtered_bonds,
+        const std::unordered_set<const RDKit::Bond*>& secondary_connections,
+        const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
+        const std::unordered_set<const NonMolecularObject*>&
+            non_molecular_objects,
+        bool only_attachment_points);
 
     /**
      * Show or hide the toolbars

--- a/src/schrodinger/sketcher/menu/abstract_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/abstract_context_menu.cpp
@@ -15,13 +15,15 @@ void AbstractContextMenu::setContextItems(
     const std::unordered_set<const RDKit::Bond*>& bonds,
     const std::unordered_set<const RDKit::Bond*>& secondary_connections,
     const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
-    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects)
+    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects,
+    const RDKit::Atom* primary_atom)
 {
     m_atoms = atoms;
     m_bonds = bonds;
     m_secondary_connections = secondary_connections;
     m_sgroups = sgroups;
     m_non_molecular_objects = non_molecular_objects;
+    m_primary_atom = primary_atom;
 }
 
 void AbstractContextMenu::showEvent(QShowEvent* event)

--- a/src/schrodinger/sketcher/menu/abstract_context_menu.h
+++ b/src/schrodinger/sketcher/menu/abstract_context_menu.h
@@ -43,7 +43,8 @@ class SKETCHER_API AbstractContextMenu : public QMenu
         const std::unordered_set<const RDKit::Bond*>& secondary_connections,
         const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
         const std::unordered_set<const NonMolecularObject*>&
-            non_molecular_objects);
+            non_molecular_objects,
+        const RDKit::Atom* primary_atom = nullptr);
 
   protected:
     /**
@@ -61,6 +62,10 @@ class SKETCHER_API AbstractContextMenu : public QMenu
     std::unordered_set<const RDKit::Bond*> m_secondary_connections;
     std::unordered_set<const RDKit::SubstanceGroup*> m_sgroups;
     std::unordered_set<const NonMolecularObject*> m_non_molecular_objects;
+    // Atom under the cursor at right-click time, or null. Sourced from
+    // `getTopInteractiveItemAt(pos)` independently of `m_atoms`, so it
+    // is not guaranteed to be a member of `m_atoms`.
+    const RDKit::Atom* m_primary_atom = nullptr;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/menu/abstract_context_menu.h
+++ b/src/schrodinger/sketcher/menu/abstract_context_menu.h
@@ -36,6 +36,9 @@ class SKETCHER_API AbstractContextMenu : public QMenu
      * 3. immediately hidden when an action is clicked
      * In other words, we expect that the model will not change for the
      * duration of the context menu being shown.
+     *
+     * `primary_atom` is the atom under the cursor at right-click (or null);
+     * see `m_primary_atom` for how it relates to `atoms`.
      */
     virtual void setContextItems(
         const std::unordered_set<const RDKit::Atom*>& atoms,

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -30,6 +30,17 @@ static bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
     });
 }
 
+static bool
+all_of_monomer_type(const std::unordered_set<const RDKit::Atom*>& atoms,
+                    MonomerType type)
+{
+    if (atoms.empty()) {
+        return false;
+    }
+    return std::ranges::all_of(
+        atoms, [type](const auto* a) { return get_monomer_type(a) == type; });
+}
+
 static rdkit_extensions::opt_string_t
 get_peptide_natural_analog(std::string_view sym)
 {
@@ -126,6 +137,106 @@ atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
     return out;
 }
 
+// Default DB tags sugars as RNA, but custom DBs may register them under
+// DNA — try RNA first, then fall back to DNA so either works.
+static rdkit_extensions::opt_string_t
+get_na_natural_analog(std::string_view sym)
+{
+    auto& db = rdkit_extensions::MonomerDatabase::instance();
+    if (auto rna = db.getNaturalAnalog(std::string(sym),
+                                       rdkit_extensions::ChainType::RNA);
+        rna && !rna->empty()) {
+        return rna;
+    }
+    return db.getNaturalAnalog(std::string(sym),
+                               rdkit_extensions::ChainType::DNA);
+}
+
+// Sugar parallel of `is_d_form`: `dX` is the deoxy form of `X` iff both
+// exist in the DB and share the same NATURAL_ANALOG. Prefix alone is
+// unsafe — a custom `dXyz` might be unrelated to `Xyz`.
+static bool is_deoxy_sugar(std::string_view sym)
+{
+    if (sym.size() < 2 || sym.front() != 'd') {
+        return false;
+    }
+    auto sym_analog = get_na_natural_analog(sym);
+    auto stripped_analog = get_na_natural_analog(sym.substr(1));
+    return sym_analog && stripped_analog && !sym_analog->empty() &&
+           *sym_analog == *stripped_analog;
+}
+
+// Returns the symbol on the other side of the R↔dR toggle for `sym`,
+// or nullopt when no DB-corroborated counterpart exists.
+static std::optional<std::string> toggle_sugar_symbol(std::string_view sym)
+{
+    if (is_deoxy_sugar(sym)) {
+        return std::string(sym.substr(1));
+    }
+    auto candidate = std::string("d") + std::string(sym);
+    auto candidate_analog = get_na_natural_analog(candidate);
+    auto sym_analog = get_na_natural_analog(sym);
+    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
+        *candidate_analog == *sym_analog) {
+        return candidate;
+    }
+    return std::nullopt;
+}
+
+// Sugar-toggle batch with direction fixed by the caller. Skips atoms
+// already at `target_sym` and atoms whose toggle leads elsewhere
+// (defensive against custom DBs that mix unrelated sugar symbols).
+static std::vector<MonomerMutation>
+build_sugar_toggle_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                         const std::string& target_sym)
+{
+    std::unordered_set<const RDKit::Atom*> group;
+    for (const auto* a : atoms) {
+        if (get_monomer_res_name(a) == target_sym) {
+            continue;
+        }
+        if (auto next = toggle_sugar_symbol(get_monomer_res_name(a));
+            next && *next == target_sym) {
+            group.insert(a);
+        }
+    }
+    if (group.empty()) {
+        return {};
+    }
+    return {{std::move(group), target_sym}};
+}
+
+// Base analogs merged across RNA and DNA chains, deduped by symbol —
+// custom DBs may register variants under either polymer type. Same
+// pattern as `monomer_tool_widget.cpp::get_merged_na_analogs`.
+static std::unordered_map<std::string,
+                          std::vector<rdkit_extensions::MonomerInfo>>
+get_merged_base_analogs()
+{
+    auto rna =
+        rdkit_extensions::MonomerDatabase::instance()
+            .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::RNA);
+    auto dna =
+        rdkit_extensions::MonomerDatabase::instance()
+            .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::DNA);
+    for (auto& [analog, infos] : dna) {
+        auto& dest = rna[analog];
+        std::unordered_set<std::string> seen;
+        for (const auto& info : dest) {
+            if (info.symbol) {
+                seen.insert(*info.symbol);
+            }
+        }
+        for (auto& info : infos) {
+            if (info.symbol && !seen.contains(*info.symbol)) {
+                seen.insert(*info.symbol);
+                dest.push_back(std::move(info));
+            }
+        }
+    }
+    return rna;
+}
+
 MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     AbstractContextMenu(parent)
 {
@@ -133,6 +244,8 @@ MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     createMutateResidueSubMenu();
     createSetDFormAction();
     createProtonateAction();
+    createMutateBaseSubMenu();
+    createSugarToggleAction();
     createDeleteAction();
 }
 
@@ -161,10 +274,8 @@ void MonomerContextMenu::createMutateResidueSubMenu()
         const auto title = QString::fromStdString(name + " (" + symbol + ")");
         auto* sub = m_mutate_residue_menu->addMenu(title);
 
-        const auto natural_sym = symbol;
-        sub->addAction(
-            QString::fromStdString(natural_sym), this,
-            [emit_mutation, natural_sym]() { emit_mutation(natural_sym); });
+        sub->addAction(QString::fromStdString(symbol), this,
+                       [emit_mutation, sym = symbol]() { emit_mutation(sym); });
 
         const auto it = analogs_by_aa.find(symbol);
         if (it == analogs_by_aa.end() || it->second.empty()) {
@@ -212,6 +323,79 @@ void MonomerContextMenu::createProtonateAction()
     m_protonate_action->setEnabled(false);
 }
 
+void MonomerContextMenu::createMutateBaseSubMenu()
+{
+    // Same shape as Mutate Residue. Analogs captured once at construction;
+    // mid-session custom-DB updates won't reflect until the menu rebuilds.
+    m_mutate_base_menu = addMenu("Mutate Base");
+    auto analogs_by_base = get_merged_base_analogs();
+
+    auto emit_mutation = [this](std::string sym) {
+        auto target_atoms = atoms_needing_mutation(m_atoms, sym);
+        if (target_atoms.empty()) {
+            return;
+        }
+        emit mutateResidueRequested({{std::move(target_atoms), std::move(sym)}},
+                                    {});
+    };
+
+    for (auto base_tool : NA_BASE_DISPLAY_ORDER) {
+        const auto& symbol = NUCLEIC_ACID_TOOL_TO_RES_NAME.at(base_tool);
+        const auto& name = NA_BASE_TO_FULL_NAME.at(base_tool);
+        const auto title = QString::fromStdString(name + " (" + symbol + ")");
+        auto* sub = m_mutate_base_menu->addMenu(title);
+
+        sub->addAction(QString::fromStdString(symbol), this,
+                       [emit_mutation, sym = symbol]() { emit_mutation(sym); });
+
+        const auto it = analogs_by_base.find(symbol);
+        if (it == analogs_by_base.end() || it->second.empty()) {
+            continue;
+        }
+        auto analogs = it->second;
+        std::ranges::sort(analogs, {}, [](const auto& info) {
+            return info.symbol.value_or("");
+        });
+        for (const auto& info : analogs) {
+            if (!info.symbol) {
+                continue;
+            }
+            const auto sym = *info.symbol;
+            QString label = QString::fromStdString(sym);
+            if (info.name && !info.name->empty()) {
+                label +=
+                    QString(" — %1").arg(QString::fromStdString(*info.name));
+            }
+            sub->addAction(label, this,
+                           [emit_mutation, sym]() { emit_mutation(sym); });
+        }
+    }
+}
+
+void MonomerContextMenu::createSugarToggleAction()
+{
+    m_sugar_toggle_action = addAction("Change R to dR", this, [this]() {
+        if (m_primary_atom == nullptr) {
+            return;
+        }
+        const auto target =
+            toggle_sugar_symbol(get_monomer_res_name(m_primary_atom));
+        if (!target) {
+            return;
+        }
+        auto batch = build_sugar_toggle_batch(m_atoms, *target);
+        if (batch.empty()) {
+            return;
+        }
+        const auto from = get_monomer_res_name(m_primary_atom);
+        const auto description =
+            QString("Change %1 to %2")
+                .arg(QString::fromStdString(std::string(from)))
+                .arg(QString::fromStdString(*target));
+        emit mutateResidueRequested(std::move(batch), description);
+    });
+}
+
 void MonomerContextMenu::createDeleteAction()
 {
     addAction("Delete", this, [this]() { emit deleteRequested(m_atoms); });
@@ -220,25 +404,52 @@ void MonomerContextMenu::createDeleteAction()
 void MonomerContextMenu::updateActions()
 {
     const bool peptide = all_peptide(m_atoms);
+    const bool na_base = all_of_monomer_type(m_atoms, MonomerType::NA_BASE);
+    const bool na_sugar = all_of_monomer_type(m_atoms, MonomerType::NA_SUGAR);
 
     m_mutate_residue_menu->menuAction()->setVisible(peptide);
     m_set_d_form_action->setVisible(peptide);
     m_protonate_action->setVisible(peptide);
+    m_mutate_base_menu->menuAction()->setVisible(na_base);
+    m_sugar_toggle_action->setVisible(na_sugar);
 
-    if (!peptide) {
-        return;
+    if (peptide) {
+        bool any_d_form_toggleable = false;
+        for (const auto* a : m_atoms) {
+            if (toggle_d_form_symbol(get_monomer_res_name(a)).has_value()) {
+                any_d_form_toggleable = true;
+                break;
+            }
+        }
+        const bool target_d_form = !all_residues_are_d_form(m_atoms);
+        m_set_d_form_action->setText(target_d_form ? "Set D-Form"
+                                                   : "Set L-Form");
+        m_set_d_form_action->setEnabled(any_d_form_toggleable);
     }
 
-    bool any_d_form_toggleable = false;
-    for (const auto* a : m_atoms) {
-        if (toggle_d_form_symbol(get_monomer_res_name(a)).has_value()) {
-            any_d_form_toggleable = true;
-            break;
+    if (na_sugar) {
+        // Direction comes from the right-clicked atom so a mixed {R, dR}
+        // selection acts on whatever the user clicked. Disabled when the
+        // primary atom is unavailable — no unambiguous direction.
+        std::optional<std::string> target;
+        std::string from;
+        if (m_primary_atom != nullptr &&
+            get_monomer_type(m_primary_atom) == MonomerType::NA_SUGAR) {
+            from = std::string(get_monomer_res_name(m_primary_atom));
+            target = toggle_sugar_symbol(from);
+        }
+        if (target) {
+            m_sugar_toggle_action->setText(
+                QString("Change %1 to %2")
+                    .arg(QString::fromStdString(from))
+                    .arg(QString::fromStdString(*target)));
+            m_sugar_toggle_action->setEnabled(
+                !build_sugar_toggle_batch(m_atoms, *target).empty());
+        } else {
+            m_sugar_toggle_action->setText("Change R to dR");
+            m_sugar_toggle_action->setEnabled(false);
         }
     }
-    const bool target_d_form = !all_residues_are_d_form(m_atoms);
-    m_set_d_form_action->setText(target_d_form ? "Set D-Form" : "Set L-Form");
-    m_set_d_form_action->setEnabled(any_d_form_toggleable);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -1,241 +1,20 @@
 #include "schrodinger/sketcher/menu/monomer_context_menu.h"
 
 #include <algorithm>
-#include <optional>
 #include <string>
-#include <string_view>
-#include <unordered_map>
 
 #include <QAction>
 #include <QMenu>
 #include <rdkit/GraphMol/Atom.h>
 
-#include "schrodinger/rdkit_extensions/monomer_database.h"
-#include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/rdkit/monomer_analog.h"
 #include "schrodinger/sketcher/rdkit/monomeric.h"
 
 namespace schrodinger
 {
 namespace sketcher
 {
-
-static bool all_peptide(const std::unordered_set<const RDKit::Atom*>& atoms)
-{
-    if (atoms.empty()) {
-        return false;
-    }
-    return std::ranges::all_of(atoms, [](const auto* a) {
-        return get_monomer_type(a) == MonomerType::PEPTIDE;
-    });
-}
-
-static bool
-all_of_monomer_type(const std::unordered_set<const RDKit::Atom*>& atoms,
-                    MonomerType type)
-{
-    if (atoms.empty()) {
-        return false;
-    }
-    return std::ranges::all_of(
-        atoms, [type](const auto* a) { return get_monomer_type(a) == type; });
-}
-
-static rdkit_extensions::opt_string_t
-get_peptide_natural_analog(std::string_view sym)
-{
-    return rdkit_extensions::MonomerDatabase::instance().getNaturalAnalog(
-        std::string(sym), rdkit_extensions::ChainType::PEPTIDE);
-}
-
-// `dFoo` is the D-form of `Foo` iff both exist as PEPTIDEs and share
-// the same NATURAL_ANALOG. Prefix alone is unsafe — a custom DB could
-// name an entry `dXyz` with no semantic link to `Xyz`.
-static bool is_d_form(std::string_view sym)
-{
-    if (sym.size() < 2 || sym.front() != 'd') {
-        return false;
-    }
-    auto sym_analog = get_peptide_natural_analog(sym);
-    auto stripped_analog = get_peptide_natural_analog(sym.substr(1));
-    return sym_analog && stripped_analog && !sym_analog->empty() &&
-           *sym_analog == *stripped_analog;
-}
-
-static std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
-{
-    if (is_d_form(sym)) {
-        // Stripping the prefix is safe: is_d_form only succeeds when
-        // the L-form counterpart exists with a matching analog.
-        return std::string(sym.substr(1));
-    }
-    // L → D: candidate "d" + sym is a true D-form when both sides
-    // exist in the DB AND share the same NATURAL_ANALOG.
-    auto candidate = std::string("d") + std::string(sym);
-    auto candidate_analog = get_peptide_natural_analog(candidate);
-    auto sym_analog = get_peptide_natural_analog(sym);
-    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
-        *candidate_analog == *sym_analog) {
-        return candidate;
-    }
-    return std::nullopt;
-}
-
-// True only when every atom in `atoms` is already a D-form residue.
-// Used to drive the Set D-/L-Form action label and target: when this
-// returns true, the action reads "Set L-Form" and clicking it flips
-// the residues back to L; otherwise it reads "Set D-Form".
-static bool
-all_residues_are_d_form(const std::unordered_set<const RDKit::Atom*>& atoms)
-{
-    return std::ranges::all_of(atoms, [](const auto* a) {
-        return is_d_form(get_monomer_res_name(a));
-    });
-}
-
-// Build the per-target-symbol mutation batch for the D-form toggle.
-// Atoms already at the target form are skipped; atoms whose toggle has
-// no DB counterpart are dropped. Returns one MonomerMutation per
-// distinct target symbol so the receiver can coalesce them under one
-// undo entry.
-static std::vector<MonomerMutation>
-build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
-                   bool target_d_form)
-{
-    std::unordered_map<std::string, std::unordered_set<const RDKit::Atom*>>
-        by_target;
-    for (const auto* a : atoms) {
-        const auto current = get_monomer_res_name(a);
-        if (is_d_form(current) == target_d_form) {
-            continue;
-        }
-        if (auto next = toggle_d_form_symbol(current)) {
-            by_target[*next].insert(a);
-        }
-    }
-    std::vector<MonomerMutation> batch;
-    batch.reserve(by_target.size());
-    for (auto& [sym, group] : by_target) {
-        batch.push_back({std::move(group), sym});
-    }
-    return batch;
-}
-
-// Filter to the atoms whose current symbol differs from `target` —
-// avoids pushing a no-op mutation (and a useless undo entry) when the
-// user picks a target that the residue is already at.
-static std::unordered_set<const RDKit::Atom*>
-atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
-                       std::string_view target)
-{
-    std::unordered_set<const RDKit::Atom*> out;
-    for (const auto* a : atoms) {
-        if (get_monomer_res_name(a) != target) {
-            out.insert(a);
-        }
-    }
-    return out;
-}
-
-// Default DB tags sugars as RNA, but custom DBs may register them under
-// DNA — try RNA first, then fall back to DNA so either works.
-static rdkit_extensions::opt_string_t
-get_na_natural_analog(std::string_view sym)
-{
-    auto& db = rdkit_extensions::MonomerDatabase::instance();
-    if (auto rna = db.getNaturalAnalog(std::string(sym),
-                                       rdkit_extensions::ChainType::RNA);
-        rna && !rna->empty()) {
-        return rna;
-    }
-    return db.getNaturalAnalog(std::string(sym),
-                               rdkit_extensions::ChainType::DNA);
-}
-
-// Sugar parallel of `is_d_form`: `dX` is the deoxy form of `X` iff both
-// exist in the DB and share the same NATURAL_ANALOG. Prefix alone is
-// unsafe — a custom `dXyz` might be unrelated to `Xyz`.
-static bool is_deoxy_sugar(std::string_view sym)
-{
-    if (sym.size() < 2 || sym.front() != 'd') {
-        return false;
-    }
-    auto sym_analog = get_na_natural_analog(sym);
-    auto stripped_analog = get_na_natural_analog(sym.substr(1));
-    return sym_analog && stripped_analog && !sym_analog->empty() &&
-           *sym_analog == *stripped_analog;
-}
-
-// Returns the symbol on the other side of the R↔dR toggle for `sym`,
-// or nullopt when no DB-corroborated counterpart exists.
-static std::optional<std::string> toggle_sugar_symbol(std::string_view sym)
-{
-    if (is_deoxy_sugar(sym)) {
-        return std::string(sym.substr(1));
-    }
-    auto candidate = std::string("d") + std::string(sym);
-    auto candidate_analog = get_na_natural_analog(candidate);
-    auto sym_analog = get_na_natural_analog(sym);
-    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
-        *candidate_analog == *sym_analog) {
-        return candidate;
-    }
-    return std::nullopt;
-}
-
-// Sugar-toggle batch with direction fixed by the caller. Skips atoms
-// already at `target_sym` and atoms whose toggle leads elsewhere
-// (defensive against custom DBs that mix unrelated sugar symbols).
-static std::vector<MonomerMutation>
-build_sugar_toggle_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
-                         const std::string& target_sym)
-{
-    std::unordered_set<const RDKit::Atom*> group;
-    for (const auto* a : atoms) {
-        if (get_monomer_res_name(a) == target_sym) {
-            continue;
-        }
-        if (auto next = toggle_sugar_symbol(get_monomer_res_name(a));
-            next && *next == target_sym) {
-            group.insert(a);
-        }
-    }
-    if (group.empty()) {
-        return {};
-    }
-    return {{std::move(group), target_sym}};
-}
-
-// Base analogs merged across RNA and DNA chains, deduped by symbol —
-// custom DBs may register variants under either polymer type. Same
-// pattern as `monomer_tool_widget.cpp::get_merged_na_analogs`.
-static std::unordered_map<std::string,
-                          std::vector<rdkit_extensions::MonomerInfo>>
-get_merged_base_analogs()
-{
-    auto rna =
-        rdkit_extensions::MonomerDatabase::instance()
-            .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::RNA);
-    auto dna =
-        rdkit_extensions::MonomerDatabase::instance()
-            .getMonomersByNaturalAnalog(rdkit_extensions::ChainType::DNA);
-    for (auto& [analog, infos] : dna) {
-        auto& dest = rna[analog];
-        std::unordered_set<std::string> seen;
-        for (const auto& info : dest) {
-            if (info.symbol) {
-                seen.insert(*info.symbol);
-            }
-        }
-        for (auto& info : infos) {
-            if (info.symbol && !seen.contains(*info.symbol)) {
-                seen.insert(*info.symbol);
-                dest.push_back(std::move(info));
-            }
-        }
-    }
-    return rna;
-}
 
 MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     AbstractContextMenu(parent)
@@ -264,7 +43,7 @@ void MonomerContextMenu::createMutateResidueSubMenu()
         if (target_atoms.empty()) {
             return;
         }
-        emit mutateResidueRequested({{std::move(target_atoms), std::move(sym)}},
+        emit mutateMonomerRequested({{std::move(target_atoms), std::move(sym)}},
                                     {});
     };
 
@@ -309,7 +88,7 @@ void MonomerContextMenu::createSetDFormAction()
         if (batch.empty()) {
             return;
         }
-        emit mutateResidueRequested(
+        emit mutateMonomerRequested(
             std::move(batch), target_d_form ? "Set D-Form" : "Set L-Form");
     });
 }
@@ -328,14 +107,14 @@ void MonomerContextMenu::createMutateBaseSubMenu()
     // Same shape as Mutate Residue. Analogs captured once at construction;
     // mid-session custom-DB updates won't reflect until the menu rebuilds.
     m_mutate_base_menu = addMenu("Mutate Base");
-    auto analogs_by_base = get_merged_base_analogs();
+    auto analogs_by_base = get_merged_na_analogs();
 
     auto emit_mutation = [this](std::string sym) {
         auto target_atoms = atoms_needing_mutation(m_atoms, sym);
         if (target_atoms.empty()) {
             return;
         }
-        emit mutateResidueRequested({{std::move(target_atoms), std::move(sym)}},
+        emit mutateMonomerRequested({{std::move(target_atoms), std::move(sym)}},
                                     {});
     };
 
@@ -388,11 +167,10 @@ void MonomerContextMenu::createSugarToggleAction()
             return;
         }
         const auto from = get_monomer_res_name(m_primary_atom);
-        const auto description =
-            QString("Change %1 to %2")
-                .arg(QString::fromStdString(std::string(from)))
-                .arg(QString::fromStdString(*target));
-        emit mutateResidueRequested(std::move(batch), description);
+        const auto description = QString("Change %1 to %2")
+                                     .arg(QString::fromStdString(from))
+                                     .arg(QString::fromStdString(*target));
+        emit mutateMonomerRequested(std::move(batch), description);
     });
 }
 
@@ -403,17 +181,20 @@ void MonomerContextMenu::createDeleteAction()
 
 void MonomerContextMenu::updateActions()
 {
-    const bool peptide = all_peptide(m_atoms);
-    const bool na_base = all_of_monomer_type(m_atoms, MonomerType::NA_BASE);
-    const bool na_sugar = all_of_monomer_type(m_atoms, MonomerType::NA_SUGAR);
+    const bool all_peptide =
+        all_monomers_have_type(m_atoms, MonomerType::PEPTIDE);
+    const bool all_na_base =
+        all_monomers_have_type(m_atoms, MonomerType::NA_BASE);
+    const bool all_na_sugar =
+        all_monomers_have_type(m_atoms, MonomerType::NA_SUGAR);
 
-    m_mutate_residue_menu->menuAction()->setVisible(peptide);
-    m_set_d_form_action->setVisible(peptide);
-    m_protonate_action->setVisible(peptide);
-    m_mutate_base_menu->menuAction()->setVisible(na_base);
-    m_sugar_toggle_action->setVisible(na_sugar);
+    m_mutate_residue_menu->menuAction()->setVisible(all_peptide);
+    m_set_d_form_action->setVisible(all_peptide);
+    m_protonate_action->setVisible(all_peptide);
+    m_mutate_base_menu->menuAction()->setVisible(all_na_base);
+    m_sugar_toggle_action->setVisible(all_na_sugar);
 
-    if (peptide) {
+    if (all_peptide) {
         bool any_d_form_toggleable = false;
         for (const auto* a : m_atoms) {
             if (toggle_d_form_symbol(get_monomer_res_name(a)).has_value()) {
@@ -427,7 +208,7 @@ void MonomerContextMenu::updateActions()
         m_set_d_form_action->setEnabled(any_d_form_toggleable);
     }
 
-    if (na_sugar) {
+    if (all_na_sugar) {
         // Direction comes from the right-clicked atom so a mixed {R, dR}
         // selection acts on whatever the user clicked. Disabled when the
         // primary atom is unavailable — no unambiguous direction.
@@ -435,7 +216,7 @@ void MonomerContextMenu::updateActions()
         std::string from;
         if (m_primary_atom != nullptr &&
             get_monomer_type(m_primary_atom) == MonomerType::NA_SUGAR) {
-            from = std::string(get_monomer_res_name(m_primary_atom));
+            from = get_monomer_res_name(m_primary_atom);
             target = toggle_sugar_symbol(from);
         }
         if (target) {

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.h
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.h
@@ -33,12 +33,11 @@ struct MonomerMutation {
 };
 
 /**
- * Context menu for monomer beads.
- *
- * For amino-acid (PEPTIDE) selections this exposes "Mutate Residue >"
- * with the natural AAs and their non-natural analogs, a dynamic
- * "Set D-Form / Set L-Form" toggle, a disabled "Protonate" stub, and
- * Delete. Other monomer types only see Delete.
+ * Context menu for monomer beads. Dispatches by monomer type:
+ *   - PEPTIDE: Mutate Residue, Set D/L-Form, Protonate (stub), Delete
+ *   - NA_BASE: Mutate Base (A/C/G/U/T + DB analogs), Delete
+ *   - NA_SUGAR: Change R↔dR (direction from m_primary_atom), Delete
+ *   - NA_PHOSPHATE / CHEM: Delete only
  */
 class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
 {
@@ -65,11 +64,15 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
     void createMutateResidueSubMenu();
     void createSetDFormAction();
     void createProtonateAction();
+    void createMutateBaseSubMenu();
+    void createSugarToggleAction();
     void createDeleteAction();
 
     QMenu* m_mutate_residue_menu = nullptr;
     QAction* m_set_d_form_action = nullptr;
     QAction* m_protonate_action = nullptr;
+    QMenu* m_mutate_base_menu = nullptr;
+    QAction* m_sugar_toggle_action = nullptr;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.h
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -8,6 +7,7 @@
 
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/menu/abstract_context_menu.h"
+#include "schrodinger/sketcher/rdkit/monomer_analog.h"
 
 class QAction;
 class QMenu;
@@ -21,16 +21,6 @@ namespace schrodinger
 {
 namespace sketcher
 {
-
-/**
- * One unit of work for `MolModel::mutateMonomers`: a set of atoms that
- * should all be mutated to the same target HELM symbol. Used as the
- * batch element in `MonomerContextMenu::mutateResidueRequested`.
- */
-struct MonomerMutation {
-    std::unordered_set<const RDKit::Atom*> atoms;
-    std::string helm_symbol;
-};
 
 /**
  * Context menu for monomer beads. Dispatches by monomer type:
@@ -54,7 +44,7 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
      * @param description is the undo-stack label the receiver should use
      * when coalescing a multi-pair batch into one undo entry.
      */
-    void mutateResidueRequested(std::vector<MonomerMutation> mutations,
+    void mutateMonomerRequested(std::vector<MonomerMutation> mutations,
                                 QString description);
 
   protected:

--- a/src/schrodinger/sketcher/menu/selection_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/selection_context_menu.cpp
@@ -72,14 +72,18 @@ void SelectionContextMenu::setContextItems(
     const std::unordered_set<const RDKit::Bond*>& bonds,
     const std::unordered_set<const RDKit::Bond*>& secondary_connections,
     const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
-    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects)
+    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects,
+    const RDKit::Atom* primary_atom)
 {
     m_modify_atoms_menu->setContextItems(atoms, bonds, secondary_connections,
-                                         sgroups, non_molecular_objects);
+                                         sgroups, non_molecular_objects,
+                                         primary_atom);
     m_modify_bonds_menu->setContextItems(atoms, bonds, secondary_connections,
-                                         sgroups, non_molecular_objects);
+                                         sgroups, non_molecular_objects,
+                                         primary_atom);
     AbstractContextMenu::setContextItems(atoms, bonds, secondary_connections,
-                                         sgroups, non_molecular_objects);
+                                         sgroups, non_molecular_objects,
+                                         primary_atom);
 }
 
 void SelectionContextMenu::updateActions()

--- a/src/schrodinger/sketcher/menu/selection_context_menu.h
+++ b/src/schrodinger/sketcher/menu/selection_context_menu.h
@@ -47,7 +47,8 @@ class SKETCHER_API SelectionContextMenu : public AbstractContextMenu
         const std::unordered_set<const RDKit::Bond*>& secondary_connections,
         const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
         const std::unordered_set<const NonMolecularObject*>&
-            non_molecular_objects);
+            non_molecular_objects,
+        const RDKit::Atom* primary_atom) override;
 
     ModifyAtomsMenu* m_modify_atoms_menu = nullptr;
     ModifyBondsMenu* m_modify_bonds_menu = nullptr;
@@ -81,7 +82,7 @@ class SKETCHER_API SelectionContextMenu : public AbstractContextMenu
     QAction* m_clean_up_region_action = nullptr;
 
   protected slots:
-    virtual void updateActions();
+    void updateActions() override;
 
   private:
     QMenu* createAddToSelectionMenu();

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -437,6 +437,19 @@ const std::unordered_map<NucleicAcidTool, std::string>
         {NucleicAcidTool::dR, "dR"},
     }; // clang-format on
 
+const std::unordered_map<NucleicAcidTool, std::string> NA_BASE_TO_FULL_NAME{
+    {NucleicAcidTool::A, "Adenine"}, {NucleicAcidTool::C, "Cytosine"},
+    {NucleicAcidTool::G, "Guanine"}, {NucleicAcidTool::U, "Uracil"},
+    {NucleicAcidTool::T, "Thymine"},
+};
+
+// Display order for the 5 natural NA bases — used by the Mutate Base submenu
+// in `MonomerContextMenu`.
+constexpr std::array<NucleicAcidTool, 5> NA_BASE_DISPLAY_ORDER{
+    NucleicAcidTool::A, NucleicAcidTool::C, NucleicAcidTool::G,
+    NucleicAcidTool::U, NucleicAcidTool::T,
+};
+
 /**
  * Carries a nucleic acid mutation request: the tool (which slot type to
  * mutate — base/sugar/phosphate) plus the symbol to substitute. Both

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -24,6 +24,7 @@
 #include "schrodinger/sketcher/dialog/file_import_export.h"
 #include "schrodinger/sketcher/model/non_molecular_object.h"
 #include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/molviewer/abstract_atom_or_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/abstract_graphics_item.h"
 #include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/atom_item.h"
@@ -465,8 +466,19 @@ void Scene::showContextMenu(QGraphicsSceneMouseEvent* event)
     auto pos = event->scenePos();
     auto [atoms, bonds, secondary_connections, sgroups, non_molecular_objects] =
         getModelObjects(SceneSubset::HOVERED, &pos);
+    // The atom under the cursor at right-click time, for menus that act
+    // on the clicked atom rather than the whole selection (e.g. NA sugar
+    // toggle). Null when the cursor isn't on an atom/monomer item.
+    const RDKit::Atom* primary_atom = nullptr;
+    if (auto* top_item =
+            getTopInteractiveItemAt(pos, InteractiveItemFlag::ALL)) {
+        if (auto* atom_item =
+                dynamic_cast<AbstractAtomOrMonomerItem*>(top_item)) {
+            primary_atom = atom_item->getAtom();
+        }
+    }
     emit showContextMenuRequested(event, atoms, bonds, secondary_connections,
-                                  sgroups, non_molecular_objects);
+                                  sgroups, non_molecular_objects, primary_atom);
 }
 
 std::unordered_set<QGraphicsItem*> Scene::getSelectedInteractiveItems() const

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -466,16 +466,14 @@ void Scene::showContextMenu(QGraphicsSceneMouseEvent* event)
     auto pos = event->scenePos();
     auto [atoms, bonds, secondary_connections, sgroups, non_molecular_objects] =
         getModelObjects(SceneSubset::HOVERED, &pos);
-    // The atom under the cursor at right-click time, for menus that act
-    // on the clicked atom rather than the whole selection (e.g. NA sugar
-    // toggle). Null when the cursor isn't on an atom/monomer item.
+    // The monomer atom under the cursor at right-click time, for menus
+    // that act on the clicked monomer (e.g. NA sugar toggle). Null when
+    // the cursor isn't on a monomer item.
     const RDKit::Atom* primary_atom = nullptr;
     if (auto* top_item =
-            getTopInteractiveItemAt(pos, InteractiveItemFlag::ALL)) {
-        if (auto* atom_item =
-                dynamic_cast<AbstractAtomOrMonomerItem*>(top_item)) {
-            primary_atom = atom_item->getAtom();
-        }
+            getTopInteractiveItemAt(pos, InteractiveItemFlag::MONOMER)) {
+        primary_atom =
+            static_cast<AbstractAtomOrMonomerItem*>(top_item)->getAtom();
     }
     emit showContextMenuRequested(event, atoms, bonds, secondary_connections,
                                   sgroups, non_molecular_objects, primary_atom);

--- a/src/schrodinger/sketcher/molviewer/scene.h
+++ b/src/schrodinger/sketcher/molviewer/scene.h
@@ -212,7 +212,8 @@ class SKETCHER_API Scene : public QGraphicsScene
         const std::unordered_set<const RDKit::Bond*>& secondary_connections,
         const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
         const std::unordered_set<const NonMolecularObject*>&
-            non_molecular_objects);
+            non_molecular_objects,
+        const RDKit::Atom* primary_atom);
 
     void viewportTranslationRequested(const QPointF& start_screen_position,
                                       const QPointF& end_screen_position);

--- a/src/schrodinger/sketcher/rdkit/monomer_analog.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomer_analog.cpp
@@ -1,0 +1,218 @@
+#include "schrodinger/sketcher/rdkit/monomer_analog.h"
+
+#include <algorithm>
+
+#include <rdkit/GraphMol/Atom.h>
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+// dR has NATURAL_ANALOG=R, so it's not a key in the analog map. Pull R's
+// analogs (and R itself) into dR's popup for symmetry with R.
+static const std::unordered_map<std::string, std::string>
+    NA_ANALOG_LOOKUP_OVERRIDES = {{"dR", "R"}};
+
+static rdkit_extensions::opt_string_t
+get_peptide_natural_analog(std::string_view sym)
+{
+    return rdkit_extensions::MonomerDatabase::instance().getNaturalAnalog(
+        std::string(sym), rdkit_extensions::ChainType::PEPTIDE);
+}
+
+// Default DB tags sugars as RNA, but custom DBs may register them under
+// DNA — try RNA first, then fall back to DNA so either works.
+static rdkit_extensions::opt_string_t
+get_na_natural_analog(std::string_view sym)
+{
+    auto& db = rdkit_extensions::MonomerDatabase::instance();
+    if (auto rna = db.getNaturalAnalog(std::string(sym),
+                                       rdkit_extensions::ChainType::RNA);
+        rna && !rna->empty()) {
+        return rna;
+    }
+    return db.getNaturalAnalog(std::string(sym),
+                               rdkit_extensions::ChainType::DNA);
+}
+
+bool all_monomers_have_type(const std::unordered_set<const RDKit::Atom*>& atoms,
+                            MonomerType type)
+{
+    if (atoms.empty()) {
+        return false;
+    }
+    return std::ranges::all_of(
+        atoms, [type](const auto* a) { return get_monomer_type(a) == type; });
+}
+
+bool is_d_form(std::string_view sym)
+{
+    if (sym.size() < 2 || sym.front() != 'd') {
+        return false;
+    }
+    auto sym_analog = get_peptide_natural_analog(sym);
+    auto stripped_analog = get_peptide_natural_analog(sym.substr(1));
+    return sym_analog && stripped_analog && !sym_analog->empty() &&
+           *sym_analog == *stripped_analog;
+}
+
+bool is_deoxy_sugar(std::string_view sym)
+{
+    if (sym.size() < 2 || sym.front() != 'd') {
+        return false;
+    }
+    auto sym_analog = get_na_natural_analog(sym);
+    auto stripped_analog = get_na_natural_analog(sym.substr(1));
+    return sym_analog && stripped_analog && !sym_analog->empty() &&
+           *sym_analog == *stripped_analog;
+}
+
+std::optional<std::string> toggle_d_form_symbol(std::string_view sym)
+{
+    if (is_d_form(sym)) {
+        // Stripping the prefix is safe: is_d_form only succeeds when the
+        // L-form counterpart exists with a matching analog.
+        return std::string(sym.substr(1));
+    }
+    auto candidate = std::string("d") + std::string(sym);
+    auto candidate_analog = get_peptide_natural_analog(candidate);
+    auto sym_analog = get_peptide_natural_analog(sym);
+    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
+        *candidate_analog == *sym_analog) {
+        return candidate;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> toggle_sugar_symbol(std::string_view sym)
+{
+    if (is_deoxy_sugar(sym)) {
+        return std::string(sym.substr(1));
+    }
+    auto candidate = std::string("d") + std::string(sym);
+    auto candidate_analog = get_na_natural_analog(candidate);
+    auto sym_analog = get_na_natural_analog(sym);
+    if (candidate_analog && sym_analog && !candidate_analog->empty() &&
+        *candidate_analog == *sym_analog) {
+        return candidate;
+    }
+    return std::nullopt;
+}
+
+bool all_residues_are_d_form(
+    const std::unordered_set<const RDKit::Atom*>& atoms)
+{
+    return std::ranges::all_of(atoms, [](const auto* a) {
+        return is_d_form(get_monomer_res_name(a));
+    });
+}
+
+std::vector<MonomerMutation>
+build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                   bool target_d_form)
+{
+    std::unordered_map<std::string, std::unordered_set<const RDKit::Atom*>>
+        by_target;
+    for (const auto* a : atoms) {
+        const auto current = get_monomer_res_name(a);
+        if (is_d_form(current) == target_d_form) {
+            continue;
+        }
+        if (auto next = toggle_d_form_symbol(current)) {
+            by_target[*next].insert(a);
+        }
+    }
+    std::vector<MonomerMutation> batch;
+    batch.reserve(by_target.size());
+    for (auto& [sym, group] : by_target) {
+        batch.push_back({std::move(group), sym});
+    }
+    return batch;
+}
+
+std::vector<MonomerMutation>
+build_sugar_toggle_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                         const std::string& target_sym)
+{
+    std::unordered_set<const RDKit::Atom*> group;
+    for (const auto* a : atoms) {
+        if (get_monomer_res_name(a) == target_sym) {
+            continue;
+        }
+        if (auto next = toggle_sugar_symbol(get_monomer_res_name(a));
+            next && *next == target_sym) {
+            group.insert(a);
+        }
+    }
+    if (group.empty()) {
+        return {};
+    }
+    return {{std::move(group), target_sym}};
+}
+
+std::unordered_set<const RDKit::Atom*>
+atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
+                       std::string_view target)
+{
+    std::unordered_set<const RDKit::Atom*> out;
+    for (const auto* a : atoms) {
+        if (get_monomer_res_name(a) != target) {
+            out.insert(a);
+        }
+    }
+    return out;
+}
+
+AnalogMap get_merged_na_analogs()
+{
+    auto& db = rdkit_extensions::MonomerDatabase::instance();
+    auto base = db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::RNA);
+    auto other =
+        db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::DNA);
+    for (const auto& [key, other_list] : other) {
+        auto& merged = base[key];
+        std::unordered_set<std::string> seen;
+        for (const auto& m : merged) {
+            seen.insert(m.symbol.value_or(""));
+        }
+        for (const auto& m : other_list) {
+            if (seen.insert(m.symbol.value_or("")).second) {
+                merged.push_back(m);
+            }
+        }
+    }
+    return base;
+}
+
+std::vector<rdkit_extensions::MonomerInfo> get_analogs_for_na_button(
+    const std::string& symbol, const AnalogMap& analogs_by_na,
+    const std::unordered_map<std::string, std::string>& standard_names)
+{
+    std::vector<rdkit_extensions::MonomerInfo> analogs;
+    auto override_it = NA_ANALOG_LOOKUP_OVERRIDES.find(symbol);
+    const auto& lookup_key = override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()
+                                 ? override_it->second
+                                 : symbol;
+    if (override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()) {
+        auto parent_name_it = standard_names.find(lookup_key);
+        rdkit_extensions::MonomerInfo parent_entry;
+        parent_entry.symbol = lookup_key;
+        parent_entry.name = parent_name_it != standard_names.end()
+                                ? parent_name_it->second
+                                : lookup_key;
+        analogs.push_back(std::move(parent_entry));
+    }
+    auto analog_it = analogs_by_na.find(lookup_key);
+    if (analog_it != analogs_by_na.end()) {
+        for (const auto& m : analog_it->second) {
+            if (m.symbol.value_or("") != symbol) {
+                analogs.push_back(m);
+            }
+        }
+    }
+    return analogs;
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/rdkit/monomer_analog.h
+++ b/src/schrodinger/sketcher/rdkit/monomer_analog.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
+namespace RDKit
+{
+class Atom;
+} // namespace RDKit
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+using AnalogMap =
+    std::unordered_map<std::string, std::vector<rdkit_extensions::MonomerInfo>>;
+
+/**
+ * One unit of work for `MolModel::mutateMonomers`: a set of atoms that
+ * should all be mutated to the same target HELM symbol.
+ */
+struct MonomerMutation {
+    std::unordered_set<const RDKit::Atom*> atoms;
+    std::string helm_symbol;
+};
+
+/**
+ * True iff `atoms` is non-empty and every atom has the given monomer type.
+ * Empty returns false (gates menu actions: nothing-to-act-on must be false).
+ */
+SKETCHER_API bool
+all_monomers_have_type(const std::unordered_set<const RDKit::Atom*>& atoms,
+                       MonomerType type);
+
+/**
+ * True iff every atom in `atoms` is currently a D-form residue.
+ */
+SKETCHER_API bool
+all_residues_are_d_form(const std::unordered_set<const RDKit::Atom*>& atoms);
+
+/**
+ * `dFoo` is the D-form of `Foo` iff both exist as PEPTIDEs and share the
+ * same NATURAL_ANALOG. Prefix alone is unsafe — a custom DB could name
+ * an entry `dXyz` with no semantic link to `Xyz`.
+ */
+SKETCHER_API bool is_d_form(std::string_view sym);
+
+/**
+ * Sugar parallel of `is_d_form`: `dX` is the deoxy form of `X` iff both
+ * exist in the DB and share the same NATURAL_ANALOG.
+ */
+SKETCHER_API bool is_deoxy_sugar(std::string_view sym);
+
+/**
+ * The L↔D toggle target for `sym`, or nullopt when no DB-corroborated
+ * counterpart exists (would silently change chemistry otherwise).
+ */
+SKETCHER_API std::optional<std::string>
+toggle_d_form_symbol(std::string_view sym);
+
+/**
+ * The R↔dR toggle target for `sym`, or nullopt when the candidate is
+ * missing or has a different NATURAL_ANALOG.
+ */
+SKETCHER_API std::optional<std::string>
+toggle_sugar_symbol(std::string_view sym);
+
+/**
+ * Build the per-target-symbol mutation batch for the D-form toggle.
+ * Atoms already at the target form are skipped; atoms whose toggle has
+ * no DB counterpart are dropped. One MonomerMutation per distinct target
+ * symbol.
+ */
+SKETCHER_API std::vector<MonomerMutation>
+build_d_form_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                   bool target_d_form);
+
+/**
+ * Sugar-toggle batch with direction fixed by the caller. Skips atoms
+ * already at `target_sym` and atoms whose toggle leads elsewhere.
+ */
+SKETCHER_API std::vector<MonomerMutation>
+build_sugar_toggle_batch(const std::unordered_set<const RDKit::Atom*>& atoms,
+                         const std::string& target_sym);
+
+/**
+ * Filter to the atoms whose current symbol differs from `target` — avoids
+ * pushing a no-op mutation (and a useless undo entry).
+ */
+SKETCHER_API std::unordered_set<const RDKit::Atom*>
+atoms_needing_mutation(const std::unordered_set<const RDKit::Atom*>& atoms,
+                       std::string_view target);
+
+/**
+ * NA analogs keyed by natural-analog symbol, merged across RNA and DNA
+ * chain types and deduped by analog symbol — custom DBs may register
+ * variants under either polymer type.
+ */
+SKETCHER_API AnalogMap get_merged_na_analogs();
+
+/**
+ * Build the analog list for an NA button: optionally prepend a parent
+ * standard (e.g. R for the dR button) sourced from `standard_names`,
+ * then append the natural-analog list keyed by the override target (or
+ * `symbol` itself if no override applies), filtering out entries whose
+ * symbol matches `symbol` (the button's own standard).
+ */
+SKETCHER_API std::vector<rdkit_extensions::MonomerInfo>
+get_analogs_for_na_button(
+    const std::string& symbol, const AnalogMap& analogs_by_na,
+    const std::unordered_map<std::string, std::string>& standard_names);
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -882,14 +882,22 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
                     description.isEmpty() ? QStringLiteral("Mutate Monomers")
                                           : description);
                 for (auto& [idxs, sym] : indexed) {
+                    if (idxs.empty()) {
+                        continue;
+                    }
                     std::unordered_set<const RDKit::Atom*> resolved;
                     resolved.reserve(idxs.size());
                     const auto* mol = m_mol_model->getMol();
                     for (auto i : idxs) {
                         resolved.insert(mol->getAtomWithIdx(i));
                     }
-                    m_mol_model->mutateMonomers(resolved, sym,
-                                                MonomerType::PEPTIDE);
+                    // Menu only emits uniform-type batches (peptide / NA
+                    // base / NA sugar); sampling the first atom is enough.
+                    // A wrong guess silently no-ops via mutateMonomers'
+                    // type filter — which was the original PEPTIDE bug.
+                    const auto target_type =
+                        get_monomer_type(*resolved.begin());
+                    m_mol_model->mutateMonomers(resolved, sym, target_type);
                 }
             });
 }
@@ -1033,13 +1041,55 @@ void SketcherWidget::connectContextMenu(const BackgroundContextMenu& menu)
             &MolModel::clear);
 }
 
+AbstractContextMenu* SketcherWidget::chooseContextMenu(
+    const std::unordered_set<const RDKit::Atom*>& filtered_atoms,
+    const std::unordered_set<const RDKit::Bond*>& filtered_bonds,
+    const std::unordered_set<const RDKit::Bond*>& secondary_connections,
+    const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
+    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects,
+    bool only_attachment_points)
+{
+    if (!sgroups.empty()) {
+        return m_sgroup_context_menu;
+    }
+    if (only_attachment_points) {
+        return m_attachment_point_context_menu;
+    }
+    const bool bond_selected =
+        !filtered_bonds.empty() || !secondary_connections.empty();
+    if (!filtered_atoms.empty()) {
+        // All-monomeric short-circuits any atom+bond routing — selecting
+        // R and A together in R(A)P (which auto-includes the R-A bond)
+        // belongs to the monomer menu, not the atomistic selection menu.
+        const bool all_monomeric =
+            std::ranges::all_of(filtered_atoms, [](const auto* atom) {
+                return is_atom_monomeric(atom);
+            });
+        if (all_monomeric) {
+            return m_monomer_context_menu;
+        }
+        if (bond_selected) {
+            return m_selection_context_menu;
+        }
+        return m_atom_context_menu;
+    }
+    if (bond_selected) {
+        return m_bond_context_menu;
+    }
+    if (!non_molecular_objects.empty()) {
+        return nullptr;
+    }
+    return m_background_context_menu;
+}
+
 void SketcherWidget::showContextMenu(
     QGraphicsSceneMouseEvent* event,
     const std::unordered_set<const RDKit::Atom*>& atoms,
     const std::unordered_set<const RDKit::Bond*>& bonds,
     const std::unordered_set<const RDKit::Bond*>& secondary_connections,
     const std::unordered_set<const RDKit::SubstanceGroup*>& sgroups,
-    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects)
+    const std::unordered_set<const NonMolecularObject*>& non_molecular_objects,
+    const RDKit::Atom* primary_atom)
 {
     if (m_sketcher_model && m_sketcher_model->isSelectOnlyModeActive()) {
         // context menus are disabled when select-only mode is active to prevent
@@ -1067,46 +1117,23 @@ void SketcherWidget::showContextMenu(
         sgroups.empty() && (!atoms.empty() || !bonds.empty()) &&
         filtered_atoms.empty() && filtered_bonds.empty();
 
-    AbstractContextMenu* menu = nullptr;
-    bool bond_selected = bonds.size() || secondary_connections.size();
-    if (sgroups.size()) {
-        menu = m_sgroup_context_menu;
-    } else if (only_attachment_points) {
-        menu = m_attachment_point_context_menu;
-    } else if (atoms.size() && bond_selected) {
-        menu = m_selection_context_menu;
-    } else if (atoms.size()) {
-        bool all_monomeric =
-            !filtered_atoms.empty() &&
-            std::ranges::all_of(filtered_atoms, [](const auto* atom) {
-                return is_atom_monomeric(atom);
-            });
-        if (all_monomeric) {
-            menu = m_monomer_context_menu;
-        } else {
-            menu = m_atom_context_menu;
-        }
-    } else if (bond_selected) {
-        menu = m_bond_context_menu;
-    } else if (non_molecular_objects.size()) {
-        /** a non molecular object is clicked, do nothing as there's no context
-         * menu for it.
-         * */
+    AbstractContextMenu* menu = chooseContextMenu(
+        filtered_atoms, filtered_bonds, secondary_connections, sgroups,
+        non_molecular_objects, only_attachment_points);
+    if (menu == nullptr) {
+        // Non-molecular object clicked — no menu to show.
         return;
-    } else {
-        // show the background context menu
-        menu = m_background_context_menu;
     }
 
     // Pass unfiltered sets to the attachment point menu; pass filtered sets
     // (attachment points excluded) to all other chemical modification menus.
     if (menu == m_attachment_point_context_menu) {
         menu->setContextItems(atoms, bonds, secondary_connections, sgroups,
-                              non_molecular_objects);
+                              non_molecular_objects, primary_atom);
     } else {
         menu->setContextItems(filtered_atoms, filtered_bonds,
                               secondary_connections, sgroups,
-                              non_molecular_objects);
+                              non_molecular_objects, primary_atom);
     }
 
     menu->move(event->screenPos());

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -871,7 +871,7 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
     connect(&menu, &MonomerContextMenu::deleteRequested, this,
             [this](auto atoms) { m_mol_model->remove(atoms, {}, {}, {}, {}); });
 
-    connect(&menu, &MonomerContextMenu::mutateResidueRequested, this,
+    connect(&menu, &MonomerContextMenu::mutateMonomerRequested, this,
             [this](auto mutations, const QString& description) {
                 if (mutations.empty()) {
                     return;
@@ -891,10 +891,8 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
                     for (auto i : idxs) {
                         resolved.insert(mol->getAtomWithIdx(i));
                     }
-                    // Menu only emits uniform-type batches (peptide / NA
-                    // base / NA sugar); sampling the first atom is enough.
-                    // A wrong guess silently no-ops via mutateMonomers'
-                    // type filter — which was the original PEPTIDE bug.
+                    // Menu emits uniform-type batches; first-atom sample
+                    // gives the right type.
                     const auto target_type =
                         get_monomer_type(*resolved.begin());
                     m_mol_model->mutateMonomers(resolved, sym, target_type);

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -9,6 +9,7 @@
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h" // ChainType
 #include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/rdkit/monomer_analog.h"
 #include "schrodinger/sketcher/sketcher_css_style.h"
 #include "schrodinger/sketcher/ui/ui_monomer_tool_widget.h"
 #include "schrodinger/sketcher/widget/amino_acid_symbol_popup.h"
@@ -23,76 +24,6 @@ namespace schrodinger
 {
 namespace sketcher
 {
-
-using AnalogMap =
-    std::unordered_map<std::string, std::vector<rdkit_extensions::MonomerInfo>>;
-
-// dR has NATURAL_ANALOG=R, so it's not a key in the analog map. Pull
-// R's analogs (and R itself) into dR's popup for symmetry with R, which
-// already shows dR.
-static const std::unordered_map<std::string, std::string>
-    NA_ANALOG_LOOKUP_OVERRIDES = {{"dR", "R"}};
-
-/**
- * Build the analog list for an NA button: optionally prepend a parent
- * standard (e.g. R for the dR button) sourced from `standard_names`,
- * then append the natural-analog list keyed by the override target (or
- * `symbol` itself if no override applies), filtering out entries whose
- * symbol matches `symbol` (the button's own standard).
- */
-static std::vector<rdkit_extensions::MonomerInfo> get_analogs_for_na_button(
-    const std::string& symbol, const AnalogMap& analogs_by_na,
-    const std::unordered_map<std::string, std::string>& standard_names)
-{
-    std::vector<rdkit_extensions::MonomerInfo> analogs;
-    auto override_it = NA_ANALOG_LOOKUP_OVERRIDES.find(symbol);
-    const auto& lookup_key = override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()
-                                 ? override_it->second
-                                 : symbol;
-    if (override_it != NA_ANALOG_LOOKUP_OVERRIDES.end()) {
-        auto parent_name_it = standard_names.find(lookup_key);
-        rdkit_extensions::MonomerInfo parent_entry;
-        parent_entry.symbol = lookup_key;
-        parent_entry.name = parent_name_it != standard_names.end()
-                                ? parent_name_it->second
-                                : lookup_key;
-        analogs.push_back(std::move(parent_entry));
-    }
-    auto analog_it = analogs_by_na.find(lookup_key);
-    if (analog_it != analogs_by_na.end()) {
-        for (const auto& m : analog_it->second) {
-            if (m.symbol.value_or("") != symbol) {
-                analogs.push_back(m);
-            }
-        }
-    }
-    return analogs;
-}
-
-/**
- * Return analogs for nucleic acid bases keyed by their natural analog symbol,
- * pulled from both RNA and DNA chain types and deduped by analog symbol.
- */
-static AnalogMap get_merged_na_analogs()
-{
-    auto& db = rdkit_extensions::MonomerDatabase::instance();
-    auto base = db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::RNA);
-    auto other =
-        db.getMonomersByNaturalAnalog(rdkit_extensions::ChainType::DNA);
-    for (const auto& [key, other_list] : other) {
-        auto& merged = base[key];
-        std::unordered_set<std::string> seen;
-        for (const auto& m : merged) {
-            seen.insert(m.symbol.value_or(""));
-        }
-        for (const auto& m : other_list) {
-            if (seen.insert(m.symbol.value_or("")).second) {
-                merged.push_back(m);
-            }
-        }
-    }
-    return base;
-}
 
 MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
     AbstractDrawToolWidget(parent)

--- a/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
@@ -63,7 +63,7 @@ atoms_from(const RDKit::ROMol& mol, std::initializer_list<unsigned int> idxs)
     return out;
 }
 
-// Captures the most recent `mutateResidueRequested` emission.
+// Captures the most recent `mutateMonomerRequested` emission.
 struct MutateRequestCapture {
     std::vector<MonomerMutation> last_mutations;
     QString last_description;
@@ -71,7 +71,7 @@ struct MutateRequestCapture {
 
     void connectTo(MonomerContextMenu& menu)
     {
-        QObject::connect(&menu, &MonomerContextMenu::mutateResidueRequested,
+        QObject::connect(&menu, &MonomerContextMenu::mutateMonomerRequested,
                          &menu,
                          [this](auto mutations, const QString& description) {
                              last_mutations = std::move(mutations);

--- a/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
@@ -22,6 +22,7 @@
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/sketcher/menu/monomer_context_menu.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
 
@@ -539,6 +540,361 @@ BOOST_AUTO_TEST_CASE(test_custom_paired_with_different_analogs_is_not_d_form)
     auto* d_form = find_action(menu, "Set D-Form");
     BOOST_REQUIRE(d_form != nullptr);
     BOOST_TEST(!d_form->isEnabled());
+}
+
+/**
+ * Base selection shows Mutate Base; AA and sugar actions hide. Sanity
+ * check on the dispatcher in updateActions().
+ */
+BOOST_AUTO_TEST_CASE(test_na_base_selection_shows_mutate_base_only)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    // R = atom 0, A (base) = atom 1, P = atom 2 in this molecule.
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {1}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(1));
+    menu.updateActions();
+
+    BOOST_TEST(find_action(menu, "Mutate Base")->isVisible());
+    BOOST_TEST(!find_action(menu, "Mutate Residue")->isVisible());
+    BOOST_TEST(!find_action(menu, "Set D-Form")->isVisible());
+    auto* sugar = find_action(menu, "Change R to dR");
+    BOOST_REQUIRE(sugar != nullptr);
+    BOOST_TEST(!sugar->isVisible());
+    BOOST_TEST(find_action(menu, "Delete")->isVisible());
+}
+
+/**
+ * Sugar (R) selection: the toggle reads "Change R to dR" and is enabled
+ * when the right-clicked atom is the only sugar in the selection.
+ */
+BOOST_AUTO_TEST_CASE(test_sugar_toggle_label_R_to_dR)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change R to dR");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isVisible());
+    BOOST_TEST(toggle->isEnabled());
+    BOOST_TEST(find_action(menu, "Mutate Base") != nullptr);
+    BOOST_TEST(!find_action(menu, "Mutate Base")->isVisible());
+}
+
+/**
+ * Sugar (dR) selection: the toggle reads "Change dR to R".
+ */
+BOOST_AUTO_TEST_CASE(test_sugar_toggle_label_dR_to_R)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{[dR](T)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change dR to R");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isVisible());
+    BOOST_TEST(toggle->isEnabled());
+}
+
+/**
+ * Mixed {R, dR} selection: direction comes from m_primary_atom. With
+ * primary = R, all sugars become dR. The atom already at dR is excluded
+ * from the emitted batch (no no-op).
+ */
+BOOST_AUTO_TEST_CASE(test_sugar_toggle_mixed_selection_primary_R)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P.[dR](T)P}$$$$V2.0");
+    // R = atom 0, A = atom 1, P = atom 2, dR = atom 3, T = atom 4, P = atom 5.
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0, 3}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change R to dR");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isEnabled());
+    toggle->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description == "Change R to dR");
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "dR");
+    BOOST_REQUIRE(capture.last_mutations[0].atoms.size() == 1u);
+    BOOST_TEST(*capture.last_mutations[0].atoms.begin() ==
+               mol->getAtomWithIdx(0));
+}
+
+/**
+ * Same selection but primary = dR: direction reverses, all sugars become R.
+ */
+BOOST_AUTO_TEST_CASE(test_sugar_toggle_mixed_selection_primary_dR)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P.[dR](T)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0, 3}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(3));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change dR to R");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isEnabled());
+    toggle->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description == "Change dR to R");
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "R");
+    BOOST_REQUIRE(capture.last_mutations[0].atoms.size() == 1u);
+    BOOST_TEST(*capture.last_mutations[0].atoms.begin() ==
+               mol->getAtomWithIdx(3));
+}
+
+/**
+ * No primary atom (e.g. menu shown via API outside the right-click flow):
+ * direction is ambiguous, action disabled.
+ */
+BOOST_AUTO_TEST_CASE(test_sugar_toggle_disabled_when_no_primary_atom)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change R to dR");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isVisible());
+    BOOST_TEST(!toggle->isEnabled());
+}
+
+/**
+ * The Mutate Base submenu has one top-level entry per natural base
+ * (A/C/G/U/T) in display order; each contains at least the natural
+ * symbol leaf.
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_base_submenu_structure)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {1}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(1));
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Base");
+    BOOST_REQUIRE(mutate != nullptr);
+    BOOST_REQUIRE(mutate->menu() != nullptr);
+    BOOST_TEST(mutate->menu()->actions().size() == 5u);
+
+    for (auto* expected : {"Adenine (A)", "Cytosine (C)", "Guanine (G)",
+                           "Uracil (U)", "Thymine (T)"}) {
+        auto* sub = find_action(*mutate->menu(), expected);
+        BOOST_REQUIRE(sub != nullptr);
+        BOOST_REQUIRE(sub->menu() != nullptr);
+        BOOST_TEST(sub->menu()->actions().size() >= 1u);
+    }
+}
+
+/**
+ * Picking a different base emits a single-pair batch with empty
+ * description (per the same convention as Mutate Residue leaves).
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_base_emits_single_pair_batch)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {1}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(1));
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Base");
+    auto* thy = find_action(*mutate->menu(), "Thymine (T)");
+    BOOST_REQUIRE(thy != nullptr);
+    auto* t_leaf = find_action(*thy->menu(), "T");
+    BOOST_REQUIRE(t_leaf != nullptr);
+    t_leaf->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_TEST(capture.last_description.isEmpty());
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "T");
+    BOOST_REQUIRE(capture.last_mutations[0].atoms.size() == 1u);
+    BOOST_TEST(*capture.last_mutations[0].atoms.begin() ==
+               mol->getAtomWithIdx(1));
+}
+
+/**
+ * Mutate Base → X on a base already at X must NOT emit, mirroring the
+ * Mutate Residue no-op guard.
+ */
+BOOST_AUTO_TEST_CASE(test_mutate_base_to_current_symbol_is_noop)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {1}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(1));
+    menu.updateActions();
+
+    auto* mutate = find_action(menu, "Mutate Base");
+    auto* ade = find_action(*mutate->menu(), "Adenine (A)");
+    BOOST_REQUIRE(ade != nullptr);
+    auto* a_leaf = find_action(*ade->menu(), "A");
+    BOOST_REQUIRE(a_leaf != nullptr);
+    a_leaf->trigger();
+
+    BOOST_TEST(capture.call_count == 0);
+}
+
+/**
+ * Custom sugar with mismatched NATURAL_ANALOG must not be classified as
+ * the deoxy form — toggle stays disabled. Parallel of the AA case.
+ */
+BOOST_AUTO_TEST_CASE(
+    test_custom_d_prefix_sugar_with_mismatched_analog_is_not_deoxy)
+{
+    constexpr std::string_view json = R"([{
+        "symbol": "dXur",
+        "polymer_type": "RNA",
+        "natural_analog": "K",
+        "smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+        "core_smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+        "name": "Custom dXur",
+        "monomer_type": "Backbone",
+        "author": "test",
+        "pdbcode": "DXR"
+    }])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("RNA1{[dXur]}$$$$V2.0");
+    // Classifier precondition — name must end in 'r' to be NA_SUGAR.
+    BOOST_REQUIRE(get_monomer_type(mol->getAtomWithIdx(0)) ==
+                  MonomerType::NA_SUGAR);
+
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    // No DB counterpart → falls back to default label, disabled.
+    auto* toggle = find_action(menu, "Change R to dR");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(!toggle->isEnabled());
+}
+
+/**
+ * Custom sugar pair "Xur"/"dXur" with matching NATURAL_ANALOG: toggle
+ * enables and emits the deoxy symbol on click.
+ */
+BOOST_AUTO_TEST_CASE(test_custom_well_formed_sugar_pair_enables_toggle)
+{
+    constexpr std::string_view json = R"([
+        {
+            "symbol": "Xur",
+            "polymer_type": "RNA",
+            "natural_analog": "Xur",
+            "smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+            "core_smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+            "name": "Custom Xur",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "XUR"
+        },
+        {
+            "symbol": "dXur",
+            "polymer_type": "RNA",
+            "natural_analog": "Xur",
+            "smiles": "OC[C@H]1O[C@H]([H:1])C[C@@H]1[OH:2]",
+            "core_smiles": "OC[C@H]1O[C@H]([H:1])C[C@@H]1[OH:2]",
+            "name": "Custom dXur",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "DXR"
+        }
+    ])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("RNA1{[Xur]}$$$$V2.0");
+    // Classifier precondition — name must end in 'r' to be NA_SUGAR.
+    BOOST_REQUIRE(get_monomer_type(mol->getAtomWithIdx(0)) ==
+                  MonomerType::NA_SUGAR);
+
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change Xur to dXur");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isEnabled());
+    toggle->trigger();
+
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "dXur");
+}
+
+/**
+ * Sugar pair registered under POLYMER_TYPE: "DNA" must be recognised
+ * via the DNA fallback in `get_na_natural_analog`.
+ */
+BOOST_AUTO_TEST_CASE(test_custom_dna_registered_sugar_pair_enables_toggle)
+{
+    constexpr std::string_view json = R"([
+        {
+            "symbol": "Yur",
+            "polymer_type": "DNA",
+            "natural_analog": "Yur",
+            "smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+            "core_smiles": "OC[C@H]1O[C@H]([H:1])[C@@H]([OH:2])[C@@H]1O",
+            "name": "Custom Yur",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "YUR"
+        },
+        {
+            "symbol": "dYur",
+            "polymer_type": "DNA",
+            "natural_analog": "Yur",
+            "smiles": "OC[C@H]1O[C@H]([H:1])C[C@@H]1[OH:2]",
+            "core_smiles": "OC[C@H]1O[C@H]([H:1])C[C@@H]1[OH:2]",
+            "name": "Custom dYur",
+            "monomer_type": "Backbone",
+            "author": "test",
+            "pdbcode": "DYR"
+        }
+    ])";
+    CustomDbScope scope(json);
+
+    auto mol = rdkit_extensions::to_rdkit("RNA1{[Yur]}$$$$V2.0");
+    BOOST_REQUIRE(get_monomer_type(mol->getAtomWithIdx(0)) ==
+                  MonomerType::NA_SUGAR);
+
+    TestMonomerContextMenu menu;
+    MutateRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {},
+                         mol->getAtomWithIdx(0));
+    menu.updateActions();
+
+    auto* toggle = find_action(menu, "Change Yur to dYur");
+    BOOST_REQUIRE(toggle != nullptr);
+    BOOST_TEST(toggle->isEnabled());
+    toggle->trigger();
+
+    BOOST_REQUIRE(capture.last_mutations.size() == 1u);
+    BOOST_TEST(capture.last_mutations[0].helm_symbol == "dYur");
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/menu/test_selection_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_selection_context_menu.cpp
@@ -52,27 +52,28 @@ BOOST_AUTO_TEST_CASE(test_updateActions)
     // Variable bond will be disabled if fewer than 2 atoms are selected
 
     // Select nothing
-    menu.setContextItems({}, {}, {}, {}, {});
+    menu.setContextItems({}, {}, {}, {}, {}, nullptr);
     // Use updateActions() as a placeholder for showEvent()
     menu.updateActions();
     BOOST_TEST(!menu.m_variable_bond_action->isEnabled());
 
     // Select 1 atom
-    menu.setContextItems({*c_atoms.begin()}, {}, {}, {}, {});
+    menu.setContextItems({*c_atoms.begin()}, {}, {}, {}, {}, nullptr);
     menu.updateActions();
     BOOST_TEST(!menu.m_variable_bond_action->isEnabled());
 
     // Select all atoms on the same molecule
-    menu.setContextItems(n_atoms, {}, {}, {}, {});
+    menu.setContextItems(n_atoms, {}, {}, {}, {}, nullptr);
     menu.updateActions();
     BOOST_TEST(menu.m_variable_bond_action->isEnabled());
 
-    menu.setContextItems(c_atoms, {}, {}, {}, {});
+    menu.setContextItems(c_atoms, {}, {}, {}, {}, nullptr);
     menu.updateActions();
     BOOST_TEST(menu.m_variable_bond_action->isEnabled());
 
     // Select atoms from different molecules
-    menu.setContextItems({*c_atoms.begin(), *n_atoms.begin()}, {}, {}, {}, {});
+    menu.setContextItems({*c_atoms.begin(), *n_atoms.begin()}, {}, {}, {}, {},
+                         nullptr);
     menu.updateActions();
     BOOST_TEST(!menu.m_variable_bond_action->isEnabled());
 
@@ -81,14 +82,14 @@ BOOST_AUTO_TEST_CASE(test_updateActions)
     menu.setContextItems(c_atoms,
                          {mol_model.getMol()->getBondWithIdx(1),
                           mol_model.getMol()->getBondWithIdx(2)},
-                         {}, {}, {});
+                         {}, {}, {}, nullptr);
     menu.updateActions();
     BOOST_TEST(menu.m_clean_up_region_action->isEnabled());
 
     // clean up region action should be disabled if there is no contiguous
     // region of atoms and bonds
     menu.setContextItems(c_atoms, {mol_model.getMol()->getBondWithIdx(0)}, {},
-                         {}, {});
+                         {}, {}, nullptr);
     menu.updateActions();
     BOOST_TEST(!menu.m_clean_up_region_action->isEnabled());
 }

--- a/test/schrodinger/sketcher/test_common.h
+++ b/test/schrodinger/sketcher/test_common.h
@@ -73,11 +73,15 @@ class TestSketcherWidget : public SketcherWidget
     TestSketcherWidget() : SketcherWidget(){};
     using SketcherWidget::addFromString;
     using SketcherWidget::addTextToMolModel;
+    using SketcherWidget::chooseContextMenu;
     using SketcherWidget::copy;
     using SketcherWidget::cut;
     using SketcherWidget::importText;
+    using SketcherWidget::m_atom_context_menu;
     using SketcherWidget::m_mol_model;
+    using SketcherWidget::m_monomer_context_menu;
     using SketcherWidget::m_scene;
+    using SketcherWidget::m_selection_context_menu;
     using SketcherWidget::m_sketcher_model;
     using SketcherWidget::m_ui;
     using SketcherWidget::m_undo_stack;

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -15,6 +15,9 @@
 
 #include "schrodinger/rdkit_extensions/convert.h"
 #include "schrodinger/rdkit_extensions/monomer_database.h"
+#include "schrodinger/sketcher/menu/monomer_context_menu.h"
+#include "schrodinger/sketcher/menu/selection_context_menu.h"
+#include "schrodinger/sketcher/menu/atom_context_menu.h"
 #include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/rdkit/monomeric.h"
 #include "schrodinger/sketcher/rdkit/coord_utils.h"
@@ -620,6 +623,136 @@ BOOST_AUTO_TEST_CASE(test_pingMutateMonomersNucleicAcidAnalog)
     BOOST_TEST(base_count == 2);
 
     monomer_db.resetMonomerDefinitions();
+}
+
+static const RDKit::Atom* find_atom_by_res_name(const RDKit::ROMol& mol,
+                                                std::string_view res_name)
+{
+    for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+        const auto* atom = mol.getAtomWithIdx(i);
+        if (get_monomer_res_name(atom) == res_name) {
+            return atom;
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * `mutateResidueRequested` from the menu must reach `mutateMonomers`
+ * with the right MonomerType — else the type filter silently no-ops.
+ * AA path covered here; NA paths in the next two cases.
+ */
+BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_peptide)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("PEPTIDE1{A}$$$$V2.0");
+
+    const auto* mol = sk.m_mol_model->getMol();
+    BOOST_REQUIRE(mol->getNumAtoms() == 1u);
+    const auto* a_atom = mol->getAtomWithIdx(0);
+    BOOST_REQUIRE(get_monomer_res_name(a_atom) == "A");
+
+    emit sk.m_monomer_context_menu->mutateResidueRequested({{{a_atom}, "C"}},
+                                                           QString());
+
+    const auto* mol_after = sk.m_mol_model->getMol();
+    BOOST_TEST(get_monomer_res_name(mol_after->getAtomWithIdx(0)) == "C");
+}
+
+/**
+ * NA base mutation — regression guard against the handler hard-coding
+ * MonomerType::PEPTIDE.
+ */
+BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_base)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("RNA1{R(A)P}$$$$V2.0");
+
+    const auto* mol = sk.m_mol_model->getMol();
+    const auto* base_atom = find_atom_by_res_name(*mol, "A");
+    BOOST_REQUIRE(base_atom != nullptr);
+    BOOST_REQUIRE(get_monomer_type(base_atom) == MonomerType::NA_BASE);
+
+    emit sk.m_monomer_context_menu->mutateResidueRequested({{{base_atom}, "T"}},
+                                                           QString());
+
+    const auto* mol_after = sk.m_mol_model->getMol();
+    // Base must now be T; sugar and phosphate untouched.
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "T") != nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "A") == nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "R") != nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "P") != nullptr);
+}
+
+/**
+ * NA sugar R→dR mutation — third branch of the dispatch matrix.
+ */
+BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_sugar)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("RNA1{R(A)P}$$$$V2.0");
+
+    const auto* mol = sk.m_mol_model->getMol();
+    const auto* sugar_atom = find_atom_by_res_name(*mol, "R");
+    BOOST_REQUIRE(sugar_atom != nullptr);
+    BOOST_REQUIRE(get_monomer_type(sugar_atom) == MonomerType::NA_SUGAR);
+
+    emit sk.m_monomer_context_menu->mutateResidueRequested(
+        {{{sugar_atom}, "dR"}}, "Change R to dR");
+
+    const auto* mol_after = sk.m_mol_model->getMol();
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "dR") != nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "R") == nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "A") != nullptr);
+    BOOST_TEST(find_atom_by_res_name(*mol_after, "P") != nullptr);
+}
+
+/**
+ * Selecting two monomers and the bond between them (e.g. R + A + R-A bond
+ * in R(A)P) must route to the monomer menu, not the atomistic selection
+ * menu. Regression for the atoms+bonds short-circuit bug.
+ */
+BOOST_AUTO_TEST_CASE(test_chooseContextMenu_monomer_atoms_with_bond)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("RNA1{R(A)P}$$$$V2.0");
+
+    const auto* mol = sk.m_mol_model->getMol();
+    const auto* r_atom = find_atom_by_res_name(*mol, "R");
+    const auto* a_atom = find_atom_by_res_name(*mol, "A");
+    BOOST_REQUIRE(r_atom != nullptr);
+    BOOST_REQUIRE(a_atom != nullptr);
+    const auto* r_a_bond =
+        mol->getBondBetweenAtoms(r_atom->getIdx(), a_atom->getIdx());
+    BOOST_REQUIRE(r_a_bond != nullptr);
+
+    auto* menu = sk.chooseContextMenu({r_atom, a_atom}, {r_a_bond}, {}, {}, {},
+                                      /*only_attachment_points=*/false);
+    BOOST_TEST(menu == sk.m_monomer_context_menu);
+}
+
+/**
+ * Atomistic atoms+bond stays on the selection menu (no regression).
+ */
+BOOST_AUTO_TEST_CASE(test_chooseContextMenu_atomistic_atoms_with_bond)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.addFromString("CCO");
+
+    const auto* mol = sk.m_mol_model->getMol();
+    BOOST_REQUIRE(mol->getNumAtoms() >= 2u);
+    const auto* a0 = mol->getAtomWithIdx(0);
+    const auto* a1 = mol->getAtomWithIdx(1);
+    const auto* bond = mol->getBondBetweenAtoms(0, 1);
+    BOOST_REQUIRE(bond != nullptr);
+
+    auto* menu = sk.chooseContextMenu({a0, a1}, {bond}, {}, {}, {}, false);
+    BOOST_TEST(menu == sk.m_selection_context_menu);
 }
 
 /**

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -638,11 +638,11 @@ static const RDKit::Atom* find_atom_by_res_name(const RDKit::ROMol& mol,
 }
 
 /**
- * `mutateResidueRequested` from the menu must reach `mutateMonomers`
+ * `mutateMonomerRequested` from the menu must reach `mutateMonomers`
  * with the right MonomerType — else the type filter silently no-ops.
  * AA path covered here; NA paths in the next two cases.
  */
-BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_peptide)
+BOOST_AUTO_TEST_CASE(test_mutateMonomerRequested_signal_mutates_peptide)
 {
     TestSketcherWidget& sk = *TestWidgetFixture::get();
     sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_peptide)
     const auto* a_atom = mol->getAtomWithIdx(0);
     BOOST_REQUIRE(get_monomer_res_name(a_atom) == "A");
 
-    emit sk.m_monomer_context_menu->mutateResidueRequested({{{a_atom}, "C"}},
+    emit sk.m_monomer_context_menu->mutateMonomerRequested({{{a_atom}, "C"}},
                                                            QString());
 
     const auto* mol_after = sk.m_mol_model->getMol();
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_peptide)
  * NA base mutation — regression guard against the handler hard-coding
  * MonomerType::PEPTIDE.
  */
-BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_base)
+BOOST_AUTO_TEST_CASE(test_mutateMonomerRequested_signal_mutates_na_base)
 {
     TestSketcherWidget& sk = *TestWidgetFixture::get();
     sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_base)
     BOOST_REQUIRE(base_atom != nullptr);
     BOOST_REQUIRE(get_monomer_type(base_atom) == MonomerType::NA_BASE);
 
-    emit sk.m_monomer_context_menu->mutateResidueRequested({{{base_atom}, "T"}},
+    emit sk.m_monomer_context_menu->mutateMonomerRequested({{{base_atom}, "T"}},
                                                            QString());
 
     const auto* mol_after = sk.m_mol_model->getMol();
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_base)
 /**
  * NA sugar R→dR mutation — third branch of the dispatch matrix.
  */
-BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_sugar)
+BOOST_AUTO_TEST_CASE(test_mutateMonomerRequested_signal_mutates_na_sugar)
 {
     TestSketcherWidget& sk = *TestWidgetFixture::get();
     sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE(test_mutateResidueRequested_signal_mutates_na_sugar)
     BOOST_REQUIRE(sugar_atom != nullptr);
     BOOST_REQUIRE(get_monomer_type(sugar_atom) == MonomerType::NA_SUGAR);
 
-    emit sk.m_monomer_context_menu->mutateResidueRequested(
+    emit sk.m_monomer_context_menu->mutateMonomerRequested(
         {{{sugar_atom}, "dR"}}, "Change R to dR");
 
     const auto* mol_after = sk.m_mol_model->getMol();


### PR DESCRIPTION
- Linked Case: SKETCH-2762

### Description
Supports nucleic acid sugar (R <-> dR) and base mutation via right-click context menu. For cases where we have mixed selections including `dR` and `R` sugars, the right clicked bead will become "primary" and drive the menu/action.

Also added a `chooseContextMenu` to help organize the selection of correct context menu a bit.

### Testing Done
Added various tests to 1) verify mutations; 2) verify expected menu behavior.