### PR TITLE
SKETCH-2758: Move button now enabled when monomers are selected

### DIFF
--- a/src/schrodinger/sketcher/model/sketcher_model.cpp
+++ b/src/schrodinger/sketcher/model/sketcher_model.cpp
@@ -467,6 +467,11 @@ bool SketcherModel::hasNAPhosphateSelection() const
     return contains_item<NucleicAcidPhosphateItem>(*this);
 }
 
+bool SketcherModel::hasMonomerSelection() const
+{
+    return contains_item<AbstractMonomerItem>(*this);
+}
+
 QList<QGraphicsItem*> SketcherModel::getInteractiveItems() const
 {
     return emit interactiveItemsRequested();

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -602,6 +602,7 @@ class SKETCHER_API SketcherModel : public QObject
     virtual bool hasNABaseSelection() const;
     virtual bool hasNASugarSelection() const;
     virtual bool hasNAPhosphateSelection() const;
+    virtual bool hasMonomerSelection() const;
 
     /**
      * getter and setter for select-only mode.

--- a/src/schrodinger/sketcher/widget/select_options_widget.cpp
+++ b/src/schrodinger/sketcher/widget/select_options_widget.cpp
@@ -67,6 +67,7 @@ void SelectOptionsWidget::updateWidgetsEnabled()
     // Move tool should only be enabled if there are atoms or non-molecular
     // objects selected
     bool movable_selection = !has_selection || model->hasAtomSelection() ||
+                             model->hasMonomerSelection() ||
                              model->hasNonMolecularObjectSelection();
     ui->move_rotate_btn->setEnabled(has_contents && movable_selection);
 

--- a/test/schrodinger/sketcher/widget/test_select_options_widget.cpp
+++ b/test/schrodinger/sketcher/widget/test_select_options_widget.cpp
@@ -147,22 +147,32 @@ BOOST_AUTO_TEST_CASE(updateWidgetsEnabled)
         BOOST_TEST(!btn->isEnabled());
     }
 
+    auto test_widget_state = [&mol_model, &ui, &requires_contents_btns,
+                              &requires_selection_btns]() {
+        for (bool has_selection : {true, false}) {
+            if (has_selection) {
+                mol_model->selectAll();
+            } else {
+                mol_model->clearSelection();
+            }
+            // select all is disabled when everything is selected
+            BOOST_TEST(ui->select_all_btn->isEnabled() == !has_selection);
+            for (auto btn : requires_contents_btns) {
+                BOOST_TEST(btn->isEnabled());
+            }
+            for (auto btn : requires_selection_btns) {
+                BOOST_TEST(btn->isEnabled() == has_selection);
+            }
+        }
+    };
+
+    // test with an atomistic model
     import_mol_text(mol_model, "CC");
-    for (bool has_selection : {true, false}) {
-        if (has_selection) {
-            mol_model->selectAll();
-        } else {
-            mol_model->clearSelection();
-        }
-        // select all is disabled when everything is selected
-        BOOST_TEST(ui->select_all_btn->isEnabled() == !has_selection);
-        for (auto btn : requires_contents_btns) {
-            BOOST_TEST(btn->isEnabled());
-        }
-        for (auto btn : requires_selection_btns) {
-            BOOST_TEST(btn->isEnabled() == has_selection);
-        }
-    }
+    test_widget_state();
+    // test with a monomeric model
+    mol_model->clear();
+    import_mol_text(mol_model, "PEPTIDE1{A.G.L}$$$$V2.0");
+    test_widget_state();
 
     // SKETCH-2219: Ensure that clicking any of these mutually exclusive buttons
     // twice doesn't deselect it


### PR DESCRIPTION
- Linked Case: SKETCH-2758

### Description

The logic for enabling the move button looked for atoms, but not monomers.

### Testing Done

Confirmed with Windows desktop app.
