### PR TITLE
SKETCH-2667: Using JavaScript's readText API to access the browser clipboard when Qt's clipboard access fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ if(EMSCRIPTEN)
   set(EXTRA_SKETCHER_APP_LINK_FLAGS
       -sEXPORT_NAME=schrodinger_sketcher_entry
       -sMODULARIZE=1
-      -sEXPORTED_RUNTIME_METHODS=[callMain,FS,JSEvents,specialHTMLTargets,stringToUTF16,UTF16ToString,getExceptionMessage]
+      -sEXPORTED_RUNTIME_METHODS=[callMain,FS,JSEvents,specialHTMLTargets,stringToUTF8,stringToUTF16,UTF16ToString,lengthBytesUTF8,getExceptionMessage]
       -sASYNCIFY
       -lembind
       -fexceptions

--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -17,6 +17,12 @@ class QGraphicsSvgItem;
 class QGraphicsSceneMouseEvent;
 class QUndoStack;
 
+#ifdef __EMSCRIPTEN__
+// Callback invoked by JavaScript after navigator.clipboard.readText() resolves;
+// see SketcherWidget::pasteAt() for context.
+extern "C" void sketcher_finish_browser_paste(const char* text);
+#endif
+
 namespace RDGeom
 {
 class Point3D;
@@ -278,6 +284,9 @@ class SKETCHER_API SketcherWidget : public QWidget
     /**
      * Paste clipboard content into the scene.
      * @param position The position to paste the content at
+     * @note In WASM builds, this function may return before the paste is
+     * completed. If that occurs, completePaste will be automatically called
+     * once the user approves clipboard access.
      */
     void pasteAt(std::optional<QPointF> position);
 
@@ -391,6 +400,22 @@ class SKETCHER_API SketcherWidget : public QWidget
      */
     virtual std::string getClipboardContents() const;
     virtual void setClipboardContents(std::string text) const;
+
+    /**
+     * Perform the actual paste of clipboard text into the scene at the given
+     * position. This is normally called from pasteAt(), but may be called
+     * separately in WASM builds if the user needs to approve the clipboard
+     * access, in which case it will be called automatically from a JavaScript
+     * callback.
+     */
+    void completePaste(std::string text, std::optional<QPointF> position);
+
+#ifdef __EMSCRIPTEN__
+    // pasteAt() stashes paste state in a translation-unit-local pointer and
+    // kicks off navigator.clipboard.readText(); this friend completes the
+    // paste from the Promise's .then() callback on a fresh wasm stack.
+    friend void ::sketcher_finish_browser_paste(const char* text);
+#endif
 
     /**
      *  Connects slots to the model and various widget tool bars

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -534,6 +534,10 @@ void SketcherWidget::setInterfaceType(InterfaceTypeType interface_type)
 std::string SketcherWidget::getClipboardContents() const
 {
     auto data = QApplication::clipboard()->mimeData();
+    if (data == nullptr) {
+        // mimeData can return a nullptr in WASM builds
+        return "";
+    }
     if (data->hasText()) {
         return data->text().toStdString();
     }
@@ -545,6 +549,13 @@ void SketcherWidget::setClipboardContents(std::string text) const
     auto data = new QMimeData;
     data->setText(QString::fromStdString(text));
     QApplication::clipboard()->setMimeData(data);
+
+#ifdef __EMSCRIPTEN__
+    // Use the browser's aync clipboard api to enable copy for the wasm build
+    emscripten::val navigator = emscripten::val::global("navigator");
+    navigator["clipboard"].call<emscripten::val>("writeText",
+                                                 emscripten::val(text));
+#endif
 }
 
 void SketcherWidget::cut(Format format)
@@ -570,13 +581,6 @@ void SketcherWidget::copy(Format format, SceneSubset subset)
     }
     setClipboardContents(text);
     // SKETCH-2091: Add image content to the clipboard; blocked by SKETCH-1975
-
-#ifdef __EMSCRIPTEN__
-    // Use the browser's aync clipboard api to enable copy for the wasm build
-    emscripten::val navigator = emscripten::val::global("navigator");
-    navigator["clipboard"].call<emscripten::val>("writeText",
-                                                 emscripten::val(text));
-#endif
 }
 
 void SketcherWidget::copyAsImage()
@@ -589,6 +593,48 @@ void SketcherWidget::copyAsImage()
     QApplication::clipboard()->setImage(image);
 }
 
+#ifdef __EMSCRIPTEN__
+namespace
+{
+// State for the in-flight browser clipboard read kicked off by pasteAt(). The
+// .then() callback in sketcher_start_browser_clipboard_read re-enters via
+// sketcher_finish_browser_paste(), which uses these to complete the paste.
+SketcherWidget* g_pending_paste_widget = nullptr;
+std::optional<QPointF> g_pending_paste_position;
+} // namespace
+
+// Non-suspending: starts readText() and attaches a .then() that calls back
+// into C++. We must NOT await here -- ASYNCIFY cannot suspend through the JS
+// trampoline Qt uses for slot dispatch, so the read has to complete on a
+// fresh wasm stack (see sketcher_finish_browser_paste below).
+EM_JS(void, sketcher_start_browser_clipboard_read, (), {
+    navigator.clipboard.readText()
+        .then(function(text) {
+            const byteLength = lengthBytesUTF8(text) + 1;
+            const ptr = _malloc(byteLength);
+            stringToUTF8(text, ptr, byteLength);
+            _sketcher_finish_browser_paste(ptr);
+            _free(ptr);
+        })
+        .catch(function(err) {
+            // No text, permission denied, document not focused, etc.
+            _sketcher_finish_browser_paste(0);
+        });
+});
+
+extern "C" EMSCRIPTEN_KEEPALIVE void
+sketcher_finish_browser_paste(const char* text)
+{
+    auto* widget = g_pending_paste_widget;
+    auto position = g_pending_paste_position;
+    g_pending_paste_widget = nullptr;
+    g_pending_paste_position.reset();
+    if (widget && text && *text) {
+        widget->completePaste(text, position);
+    }
+}
+#endif
+
 /**
  * @internal
  * paste is agnostic of NEW_STRUCTURES_REPLACE_CONTENT
@@ -596,9 +642,24 @@ void SketcherWidget::copyAsImage()
 void SketcherWidget::pasteAt(std::optional<QPointF> position)
 {
     auto text = getClipboardContents();
-    if (text.empty()) {
+    if (!text.empty()) {
+        completePaste(std::move(text), position);
         return;
     }
+#ifdef __EMSCRIPTEN__
+    // The browser may not not allow us to access the clipboard via Qt. In that
+    // case, use the JavaScript readText API to request permission from the
+    // user. JavaScript will automatically call completePaste once the user has
+    // granted permission.
+    g_pending_paste_widget = this;
+    g_pending_paste_position = position;
+    sketcher_start_browser_clipboard_read();
+#endif
+}
+
+void SketcherWidget::completePaste(std::string text,
+                                   std::optional<QPointF> position)
+{
     // On WASM builds, RDKit doesn't like Windows newline characters, so we
     // explicitly remove the /r's, which converts Windows-style newlines to
     // Unix-style


### PR DESCRIPTION
- Linked Case: SKETCH-2667

### Description

When Qt's clipboard access fails due to browser security, this PR allows the Sketcher to request access the clipboard via JavaScript's `readText` API, which should prompt the browser to request permission from the user.  I thought this was going to be straight-forward, but ran into a complication: When using asyncify, `await`ing a JavaScript promise in a Qt slot or event handler causes an immediate crash.  In other words `pasteAt` can't wait for the user to approve the clipboard access.  Instead, `pasteAt` has to return before waiting for the user, and there's now a JavaScript callback that will call C++ to complete the paste once Sketcher is given clipboard access.

With this change, pasting via the Sketcher menu bar should now work even if the user hasn't pasted via a keyboard shortcut first.  However, this won't work if the user tries to paste via the context menu in the Paste in Text... dialog.  The logic for that paste is buried pretty deep in a Qt private class (QWidgetTextControl), so there's no real ways to replace that code with the `readText` API.  The user can still paste into that dialog using Ctrl+V if they want, after which the dialog's context menu will work.

This change also works with Jarrett's changes for SKETCH-2751 (#341). I actually included his PR in my branch when I was working on this, but then backed it out at the end so that this PR wouldn't depend on that one.  I think there'll be a fairly trivial merge conflict in `SketcherWidget::getClipboardContents` (the `data == nullptr` check added here should, not surprisingly, go before the `data->hasFormat(SKETCHER_MIME_TYPE)` check) but the two changes work nicely together.

According to Claude (which wrote much of the code here), the `await`/Qt-slot-or-event-handler limitation doesn't exist in JSPI (which is basically asyncify version 2), but that's not even an option until we upgrade to Qt 6.10, which requires a fix or workaround for [QTBUG-145012](https://qt-project.atlassian.net/browse/QTBUG-145012).  Eventually, we may be able to remove some of this logic, though (or possibly all of it if Qt switches their WASM clipboard access to use the new API).

### Testing Done

Tested WASM builds using both Firefox and Chrome on Windows.  Since the build was hosted as localhost, which is allowed clipboard access by default, I didn't get any permission prompt, but pasting via the menu worked correctly even if I had pasted via a keyboard shortcut.  On Firefox, I get a weird additional button that needs to be clicked before the paste happens, but I don't think there's anything we can do about that.  (I think that's down to Firefox's implementation of `readText`.  I've seen that button on Firefox with other websites before.)

<img width="1341" height="981" alt="image" src="https://github.com/user-attachments/assets/9da824b6-b1c7-4210-89a5-fdfe902f9610" />
