### PR TITLE
SKETCH-2772: Anchor wheel zoom at the cursor

### DIFF
--- a/src/schrodinger/sketcher/molviewer/view.cpp
+++ b/src/schrodinger/sketcher/molviewer/view.cpp
@@ -168,11 +168,12 @@ void View::scaleAnchoredAtCursor(qreal scale_factor, const QPoint& anchor)
     // do it manually via sceneRect (the mechanism this view uses for
     // panning). Iterate so any sub-pixel residual from setSceneRect's
     // snapping converges to zero.
+    constexpr qreal SCENE_COORD_EPSILON = 0.001;
     auto scene_pos_before = mapToScene(anchor);
     scaleSafely(scale_factor);
     for (int i = 0; i < 4; ++i) {
         auto delta = scene_pos_before - mapToScene(anchor);
-        if (delta.manhattanLength() < 0.001) {
+        if (delta.manhattanLength() < SCENE_COORD_EPSILON) {
             break;
         }
         translateViewport(delta);

--- a/src/schrodinger/sketcher/molviewer/view.cpp
+++ b/src/schrodinger/sketcher/molviewer/view.cpp
@@ -113,9 +113,13 @@ void View::pinchTriggered(QPinchGesture* gesture)
     if (state == Qt::GestureStarted) {
         m_currently_pinching_trackpad = true;
     } else {
-        // zoom
+        // zoom anchored at the pinch center (the mouse cursor on a macOS
+        // trackpad pinch). Anchoring at the view center would push the
+        // structure away from where the user is pinching.
         auto scale_factor = gesture->scaleFactor();
-        scaleSafely(scale_factor);
+        auto pinch_anchor =
+            viewport()->mapFromGlobal(QCursor::pos());
+        scaleAnchoredAtCursor(scale_factor, pinch_anchor);
 
         auto angle = gesture->rotationAngle() - gesture->lastRotationAngle();
 
@@ -153,17 +157,22 @@ void View::wheelEvent(QWheelEvent* event)
     // K * 2^x, where K is an empirical constant to make the zooming feel
     // natural
     qreal scal = pow(2.0, event->angleDelta().y() / 2400.0);
-    // Capture the scene point under the cursor before the scale, then shift
-    // the viewport after so the same scene point is back under the cursor.
-    // Qt's setTransformationAnchor(AnchorUnderMouse) compensates via scroll
-    // bars, which this view has disabled, so do it via sceneRect (the
-    // mechanism this view already uses for panning) instead. Iterate so any
-    // sub-pixel residual from setSceneRect's snapping converges to zero.
-    auto cursor = event->position().toPoint();
-    auto cursor_scene_before = mapToScene(cursor);
-    scaleSafely(scal);
+    scaleAnchoredAtCursor(scal, event->position().toPoint());
+}
+
+void View::scaleAnchoredAtCursor(qreal scale_factor, const QPoint& anchor)
+{
+    // Capture the scene point under the anchor (cursor / pinch center) before
+    // scaling and shift the view afterwards so the same scene point is back
+    // under the anchor. Qt's setTransformationAnchor(AnchorUnderMouse)
+    // compensates through the scroll bars, which this view has disabled, so
+    // do it manually via sceneRect (the mechanism this view uses for
+    // panning). Iterate so any sub-pixel residual from setSceneRect's
+    // snapping converges to zero.
+    auto scene_pos_before = mapToScene(anchor);
+    scaleSafely(scale_factor);
     for (int i = 0; i < 4; ++i) {
-        auto delta = cursor_scene_before - mapToScene(cursor);
+        auto delta = scene_pos_before - mapToScene(anchor);
         if (delta.manhattanLength() < 0.001) {
             break;
         }

--- a/src/schrodinger/sketcher/molviewer/view.cpp
+++ b/src/schrodinger/sketcher/molviewer/view.cpp
@@ -117,8 +117,7 @@ void View::pinchTriggered(QPinchGesture* gesture)
         // trackpad pinch). Anchoring at the view center would push the
         // structure away from where the user is pinching.
         auto scale_factor = gesture->scaleFactor();
-        auto pinch_anchor =
-            viewport()->mapFromGlobal(QCursor::pos());
+        auto pinch_anchor = viewport()->mapFromGlobal(QCursor::pos());
         scaleAnchoredAtCursor(scale_factor, pinch_anchor);
 
         auto angle = gesture->rotationAngle() - gesture->lastRotationAngle();

--- a/src/schrodinger/sketcher/molviewer/view.cpp
+++ b/src/schrodinger/sketcher/molviewer/view.cpp
@@ -153,7 +153,22 @@ void View::wheelEvent(QWheelEvent* event)
     // K * 2^x, where K is an empirical constant to make the zooming feel
     // natural
     qreal scal = pow(2.0, event->angleDelta().y() / 2400.0);
+    // Capture the scene point under the cursor before the scale, then shift
+    // the viewport after so the same scene point is back under the cursor.
+    // Qt's setTransformationAnchor(AnchorUnderMouse) compensates via scroll
+    // bars, which this view has disabled, so do it via sceneRect (the
+    // mechanism this view already uses for panning) instead. Iterate so any
+    // sub-pixel residual from setSceneRect's snapping converges to zero.
+    auto cursor = event->position().toPoint();
+    auto cursor_scene_before = mapToScene(cursor);
     scaleSafely(scal);
+    for (int i = 0; i < 4; ++i) {
+        auto delta = cursor_scene_before - mapToScene(cursor);
+        if (delta.manhattanLength() < 0.001) {
+            break;
+        }
+        translateViewport(delta);
+    }
 }
 
 void View::fitToScreen(bool selection_only)

--- a/src/schrodinger/sketcher/molviewer/view.h
+++ b/src/schrodinger/sketcher/molviewer/view.h
@@ -131,6 +131,14 @@ class SKETCHER_API View : public QGraphicsView
     void scaleSafely(qreal scale_factor);
 
     /**
+     * Scale the matrix and shift the viewport so the scene point currently
+     * under @p anchor (in viewport coordinates) stays under @p anchor after
+     * the scale. Use this for wheel and pinch zooms so the user can focus a
+     * region by zooming with the cursor over it.
+     */
+    void scaleAnchoredAtCursor(qreal scale_factor, const QPoint& anchor);
+
+    /**
      * Utility function to fit given rectangle to the screen.
      */
     void fitRecToScreen(const QRectF& rec);

--- a/test/schrodinger/sketcher/molviewer/test_view.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_view.cpp
@@ -4,6 +4,8 @@
 
 #include <QUndoStack>
 #include <QShowEvent>
+#include <QTest>
+#include <QWheelEvent>
 
 #include "../test_common.h"
 #include "schrodinger/sketcher/molviewer/view.h"
@@ -28,6 +30,7 @@ class TestView : public View
     using View::m_delayed_fit_to_screen;
     using View::m_initial_geometry_set;
     using View::showEvent;
+    using View::wheelEvent;
 };
 
 /**
@@ -49,6 +52,37 @@ BOOST_AUTO_TEST_CASE(test_delayed_fit_to_screen)
     view.showEvent(&show_event);
     BOOST_TEST(!view.m_delayed_fit_to_screen);
     BOOST_TEST(view.m_initial_geometry_set);
+}
+
+/**
+ * SKETCH-2772: a wheel zoom must keep the scene point under the cursor fixed,
+ * so users can focus on a region by zooming while pointing at it.
+ */
+BOOST_AUTO_TEST_CASE(test_wheel_zoom_keeps_cursor_point_fixed)
+{
+    auto scene = TestScene::getScene();
+    TestView view(scene.get());
+    view.resize(400, 400);
+    view.show();
+    [[maybe_unused]] auto exposed = QTest::qWaitForWindowExposed(&view);
+    // The View defaults to an empty sceneRect (real usage sets one via
+    // fitToScreen). Cursor-anchored zoom uses sceneRect to position the
+    // viewport, so prime a non-empty one for the test.
+    view.setSceneRect(QRectF(-200, -200, 400, 400));
+
+    auto cursor = QPointF(300, 100); // offset from the view center (200, 200)
+    auto scene_pos_before = view.mapToScene(cursor.toPoint());
+
+    // Negative deltaY = wheel down = zoom out, which avoids the zoom-in cap.
+    auto global_cursor = view.viewport()->mapToGlobal(cursor.toPoint());
+    QWheelEvent wheel_event(cursor, global_cursor, QPoint(0, -120),
+                            QPoint(0, -120), Qt::NoButton, Qt::NoModifier,
+                            Qt::NoScrollPhase, false);
+    view.wheelEvent(&wheel_event);
+
+    auto scene_pos_after = view.mapToScene(cursor.toPoint());
+    BOOST_CHECK_CLOSE(scene_pos_after.x(), scene_pos_before.x(), 0.5);
+    BOOST_CHECK_CLOSE(scene_pos_after.y(), scene_pos_before.y(), 0.5);
 }
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2772

### Description

Updates the zoom behavior (both pinch and wheel-zoom) to be focused at the cursor point.

### Testing Done

Added a test; manually tested with the trackpad on my mac