### PR TITLE
SKETCH-2757: Improving attachment point label placement and colors

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
@@ -8,6 +8,7 @@
 #include <rdkit/GraphMol/MonomerInfo.h>
 
 #include "schrodinger/sketcher/image_constants.h"
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
 #include "schrodinger/rdkit_extensions/helm.h"
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
@@ -39,6 +40,24 @@ void AbstractMonomerItem::paint(QPainter* painter,
     painter->setFont(m_main_label_font);
     painter->drawText(m_main_label_left_baseline, m_main_label_text);
     painter->restore();
+}
+
+QPointF AbstractMonomerItem::getLabelOffsetPastShape(qreal angle) const
+{
+    auto rect = boundingRect();
+    // start with a non-null unit line
+    QLineF line({0.0, 0.0}, {1.0, 0.0});
+    line.setAngle(angle);
+    // make the line clearly longer than any side of the rect so the bounded
+    // intersection test will find an exit point
+    line.setLength(2 * (rect.width() + rect.height()));
+
+    QPointF intersection;
+    intersection_of_line_and_rect(line, rect, intersection);
+
+    line.setLength(QLineF({0.0, 0.0}, intersection).length() +
+                   MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING);
+    return line.p2();
 }
 
 void AbstractMonomerItem::setMonomerColors(const QColor& background_color,

--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.h
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.h
@@ -56,6 +56,17 @@ class SKETCHER_API AbstractMonomerItem : public AbstractAtomOrMonomerItem
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget = nullptr) override;
 
+    /**
+     * Return a point at the specified angle that's just outside of this
+     * monomer's shape. This is normally used for placing an attachment point
+     * label.
+     * @note The default implementation assumes that the bounding rect is an
+     * acceptable estimate for the monomer's shape, which is only true for
+     * monomers that use a rectangle or rounded rectangle. Monomers that use
+     * other shapes should reimplement this method.
+     */
+    virtual QPointF getLabelOffsetPastShape(qreal angle) const;
+
   protected:
     const Fonts& m_fonts;
     QPen m_border_pen;

--- a/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
+++ b/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
@@ -1,7 +1,11 @@
 #include "schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h"
 
+// #include <cmath>
+
+#include <QGraphicsItem>
 #include <QGraphicsSimpleTextItem>
 
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/coord_utils.h"
 #include "schrodinger/sketcher/molviewer/fonts.h"
 #include "schrodinger/sketcher/molviewer/monomer_constants.h"
@@ -15,6 +19,7 @@ namespace sketcher
 {
 
 void position_ap_label_rect(QRectF& ap_label_rect,
+                            const AbstractMonomerItem* const monomer_item,
                             const QPointF& monomer_coords,
                             const QPointF& bound_coords)
 {
@@ -27,11 +32,7 @@ void position_ap_label_rect(QRectF& ap_label_rect,
 
     // Qt measures angles in [0, 360) degrees, counter-clockwise from a point on
     // the x-axis to the right of the origin.
-    if (angle == 0 || angle >= 315) {
-        rotate_ccw = true;
-        left_aligned = true;
-        bottom_aligned = true;
-    } else if (angle < 45) {
+    if (angle < 45) {
         rotate_ccw = false;
         left_aligned = true;
         bottom_aligned = false;
@@ -39,7 +40,7 @@ void position_ap_label_rect(QRectF& ap_label_rect,
         rotate_ccw = true;
         left_aligned = false;
         bottom_aligned = true;
-    } else if (angle <= 135) {
+    } else if (angle < 135) {
         rotate_ccw = false;
         left_aligned = true;
         bottom_aligned = true;
@@ -47,18 +48,22 @@ void position_ap_label_rect(QRectF& ap_label_rect,
         rotate_ccw = true;
         left_aligned = false;
         bottom_aligned = false;
-    } else if (angle <= 225) {
+    } else if (angle < 225) {
         rotate_ccw = false;
         left_aligned = false;
         bottom_aligned = true;
-    } else if (angle <= 270) {
+    } else if (angle < 270) {
         rotate_ccw = true;
         left_aligned = true;
         bottom_aligned = false;
-    } else {
+    } else if (angle < 315) {
         rotate_ccw = false;
         left_aligned = false;
         bottom_aligned = false;
+    } else {
+        rotate_ccw = true;
+        left_aligned = true;
+        bottom_aligned = true;
     }
 
     if (rotate_ccw) {
@@ -77,21 +82,57 @@ void position_ap_label_rect(QRectF& ap_label_rect,
         ap_label_rect.moveTop(0.0);
     }
 
-    qline.setAngle(angle);
-    // TODO: explicitly account for monomer size
-    qline.setLength(MONOMERIC_ATTACHMENT_POINT_LABEL_DIST);
-    ap_label_rect.translate(qline.p2());
+    auto label_offset = monomer_item->getLabelOffsetPastShape(angle);
+    ap_label_rect.translate(monomer_item->mapToScene(label_offset));
 }
 
 /**
  * @overload Accepts RDKit coordinates instead of Scene coordinates
  */
-static void position_ap_label_rect(QRectF& ap_label_rect,
-                                   const RDGeom::Point3D& monomer_coords,
-                                   const RDGeom::Point3D& bound_coords)
+static void position_ap_label_rect(
+    QRectF& ap_label_rect, const AbstractMonomerItem* const monomer_item,
+    const RDGeom::Point3D& monomer_coords, const RDGeom::Point3D& bound_coords)
 {
-    position_ap_label_rect(ap_label_rect, to_scene_xy(monomer_coords),
+    position_ap_label_rect(ap_label_rect, monomer_item,
+                           to_scene_xy(monomer_coords),
                            to_scene_xy(bound_coords));
+}
+
+/**
+ * Position the given rectangle to label a monomer's attachment point, assuming
+ * that the attachment point connection is drawn either above or below the
+ * monomer using an arrowhead. See `prep_attachment_point_name` for parameter
+ * documentation.
+ */
+static void position_ap_label_rect_next_to_arrowhead(
+    QRectF& ap_label_rect, const QGraphicsItem* monomer_item,
+    const RDGeom::Point3D& monomer_coords, const RDGeom::Point3D& bound_coords)
+{
+    auto monomer_qcoords = to_scene_xy(monomer_coords);
+    auto bound_qcoords = to_scene_xy(bound_coords);
+
+    auto arrowhead_offset =
+        get_monomer_arrowhead_offset(*monomer_item, bound_qcoords);
+    auto label_vertical_offset =
+        monomer_item->boundingRect().height() / 2 +
+        MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_VERTICAL;
+    if (arrowhead_offset > 0) {
+        ap_label_rect.moveBottom(-label_vertical_offset);
+    } else {
+        ap_label_rect.moveTop(label_vertical_offset);
+    }
+
+    auto label_horizontal_offset =
+        MONOMER_CONNECTOR_ARROWHEAD_RADIUS +
+        MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_HORIZONTAL;
+    auto angle = QLineF(monomer_qcoords, bound_qcoords).angle();
+    if (angle < 90 || angle >= 270) {
+        ap_label_rect.moveRight(-label_horizontal_offset);
+    } else {
+        ap_label_rect.moveLeft(label_horizontal_offset);
+    }
+
+    ap_label_rect.translate(monomer_item->pos());
 }
 
 /**
@@ -136,12 +177,24 @@ static QGraphicsItem* create_attachment_point_label(const QString& label,
     return label_item;
 }
 
+static const AbstractMonomerItem*
+get_monomer_item(const RDKit::Atom* const monomer, const Scene* const scene)
+{
+    const auto* graphics_item = scene->getGraphicsItemForAtom(monomer);
+    const auto* monomer_item =
+        dynamic_cast<const AbstractMonomerItem*>(graphics_item);
+    if (monomer_item == nullptr) {
+        throw std::runtime_error("Atom is not a monomer");
+    }
+    return monomer_item;
+}
+
 QGraphicsItem* create_label_for_bound_attachment_point(
     const RDKit::Atom* const monomer, const RDKit::Atom* const bound_monomer,
     const bool is_secondary_connection, const std::string& ap_name,
     const QColor& color, const Fonts& fonts, const Scene* const scene)
 {
-    const auto* monomer_item = scene->getGraphicsItemForAtom(monomer);
+    const auto* monomer_item = get_monomer_item(monomer, scene);
     return create_label_for_bound_attachment_point(
         monomer, bound_monomer, is_secondary_connection, ap_name, color, fonts,
         monomer_item);
@@ -151,7 +204,7 @@ QGraphicsItem* create_label_for_bound_attachment_point(
     const RDKit::Atom* const monomer, const RDKit::Atom* const bound_monomer,
     const bool is_secondary_connection, const std::string& ap_name,
     const QColor& color, const Fonts& fonts,
-    const QGraphicsItem* const monomer_item)
+    const AbstractMonomerItem* const monomer_item)
 {
     // nothing to do if there's no label (e.g. phosphate attachment points)
     if (ap_name.empty()) {
@@ -165,15 +218,15 @@ QGraphicsItem* create_label_for_bound_attachment_point(
     auto ap_qname = prep_attachment_point_name(ap_name);
     auto ap_label_rect =
         fonts.m_monomeric_attachment_point_label_fm.boundingRect(ap_qname);
-    position_ap_label_rect(ap_label_rect, monomer_coords, bound_coords);
-    // if the bond is drawn with an arrowhead at this attachment point (e.g.
-    // disulfide bonds or branching monomers), offset the label to account for
-    // the arrowhead
-    if (attachment_point_is_drawn_with_arrowhead(monomer, bound_monomer,
-                                                 is_secondary_connection)) {
-        auto arrowhead_offset = get_monomer_arrowhead_offset(
-            *monomer_item, to_scene_xy(bound_coords));
-        ap_label_rect.translate(0, -arrowhead_offset);
+    if (!attachment_point_is_drawn_with_arrowhead(monomer, bound_monomer,
+                                                  is_secondary_connection)) {
+        position_ap_label_rect(ap_label_rect, monomer_item, monomer_coords,
+                               bound_coords);
+    } else {
+        // this connection is drawn with an arrowhead, so position the label
+        // next to the arrowhead
+        position_ap_label_rect_next_to_arrowhead(ap_label_rect, monomer_item,
+                                                 monomer_coords, bound_coords);
     }
     return create_attachment_point_label(ap_qname, ap_label_rect, fonts, color);
 }
@@ -237,9 +290,9 @@ std::vector<QGraphicsItem*> create_attachment_point_labels_for_connector(
     const QColor& color, const Fonts& fonts, const Scene* const scene)
 {
     const auto* begin_monomer_item =
-        scene->getGraphicsItemForAtom(connector->getBeginAtom());
+        get_monomer_item(connector->getBeginAtom(), scene);
     const auto* end_monomer_item =
-        scene->getGraphicsItemForAtom(connector->getEndAtom());
+        get_monomer_item(connector->getEndAtom(), scene);
     return create_attachment_point_labels_for_connector(
         connector, is_secondary_connection, color, fonts, begin_monomer_item,
         end_monomer_item);
@@ -248,8 +301,8 @@ std::vector<QGraphicsItem*> create_attachment_point_labels_for_connector(
 std::vector<QGraphicsItem*> create_attachment_point_labels_for_connector(
     const RDKit::Bond* const connector, const bool is_secondary_connection,
     const QColor& color, const Fonts& fonts,
-    const QGraphicsItem* const begin_monomer_item,
-    const QGraphicsItem* const end_monomer_item)
+    const AbstractMonomerItem* const begin_monomer_item,
+    const AbstractMonomerItem* const end_monomer_item)
 {
     auto begin_monomer = connector->getBeginAtom();
     auto end_monomer = connector->getEndAtom();

--- a/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h
@@ -9,6 +9,7 @@
 #include "schrodinger/sketcher/molviewer/fonts.h"
 #include "schrodinger/sketcher/tool/standard_scene_tool_base.h"
 
+class QGraphicsItem;
 class QPointF;
 class QRectF;
 
@@ -24,6 +25,8 @@ namespace schrodinger
 namespace sketcher
 {
 
+class AbstractMonomerItem;
+
 /**
  * @return the attachment point name to a QString after converting apostrophes
  * to Unicode primes.
@@ -31,15 +34,20 @@ namespace sketcher
 SKETCHER_API QString prep_attachment_point_name(const std::string& name);
 
 /**
- * Position the given rectangle to label a monomer's attachment point
+ * Position the given rectangle to label a monomer's attachment point. Note that
+ * this function doesn't take connector arrowheads into account.
  * @param ap_label_rect The rectangle to position. It should already be sized
- * correctly for the attachment point label.
+ * correctly for the attachment point label. On return, its position will be in
+ * scene coordinates (via monomer_item->mapToScene).
+ * @param monomer_item The graphics item for the monomer being labeled. Its
+ * shape (assumed to contain the origin in item-local coordinates) is used to
+ * place the label just outside the monomer's edge.
  * @param monomer_coords The coordinates of the monomer being labeled
  * @param bound_coords The coordinates of the other monomer involved in the bond
  */
-SKETCHER_API void position_ap_label_rect(QRectF& ap_label_rect,
-                                         const QPointF& monomer_coords,
-                                         const QPointF& bound_coords);
+SKETCHER_API void position_ap_label_rect(
+    QRectF& ap_label_rect, const AbstractMonomerItem* const monomer_item,
+    const QPointF& monomer_coords, const QPointF& bound_coords);
 
 /**
  * Create and return a label for monomer's attachment point where it's connected
@@ -59,7 +67,7 @@ SKETCHER_API QGraphicsItem* create_label_for_bound_attachment_point(
     const RDKit::Atom* const monomer, const RDKit::Atom* const bound_monomer,
     const bool is_secondary_connection, const std::string& ap_name,
     const QColor& color, const Fonts& fonts,
-    const QGraphicsItem* const monomer_item);
+    const AbstractMonomerItem* const monomer_item);
 
 /**
  * Create and return labels for the attachment points on both ends of the
@@ -82,8 +90,8 @@ SKETCHER_API std::vector<QGraphicsItem*>
 create_attachment_point_labels_for_connector(
     const RDKit::Bond* const connector, const bool is_secondary_connection,
     const QColor& color, const Fonts& fonts,
-    const QGraphicsItem* const begin_monomer_item,
-    const QGraphicsItem* const end_monomer_item);
+    const AbstractMonomerItem* const begin_monomer_item,
+    const AbstractMonomerItem* const end_monomer_item);
 
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/molviewer/monomer_constants.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_constants.h
@@ -187,11 +187,16 @@ const QColor CHEM_MONOMER_RECT_COLOR =
 // the angle between a monomeric connector, the center of the bound monomer, and
 // the attachment point label. Raising this number will move the label further
 // from the bond line.
-const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ANGLE_OFFSET = 10;
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ANGLE_OFFSET = 7.5;
 
-// the distance between the center of a monomer and its attachment point labels
-const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_DIST = 16;
 const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_FONT_RATIO = 0.7;
+
+// the distance between the edge of the monomer and its attachment point labels
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING = 2.5;
+
+// positioning for attachment point labels relative to connector arrowheads
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_VERTICAL = -2;
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_HORIZONTAL = 4.5;
 
 // the distance between the "pair" label and the relevant connector, as measured
 // perpendicular to the connector
@@ -214,8 +219,8 @@ const qreal UNBOUND_AP_CIRCLE_DIAMETER = 5.0;
 const qreal UNBOUND_AP_MIN_HOVER_HALF_WIDTH = 12;
 const QColor UNBOUND_AP_LABEL_COLOR = QColor("#AAAAAA");
 const QColor UNBOUND_AP_LABEL_COLOR_DARK_BG = QColor("#999999");
-const QColor BOUND_AP_LABEL_COLOR = QColor("#000000");
-const QColor BOUND_AP_LABEL_COLOR_DARK_BG = QColor("#AAAAAA");
+const QColor BOUND_AP_LABEL_COLOR = QColor("#AAAAAA");
+const QColor BOUND_AP_LABEL_COLOR_DARK_BG = QColor("#999999");
 const qreal MONOMER_FRAGMENT_HINT_CONNECTOR_WIDTH = 3;
 
 const QColor AA_LINEAR_CONNECTOR_COLOR =

--- a/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.cpp
@@ -53,11 +53,20 @@ void MonomerHintFragmentItem::createGraphicsItems()
         m_bond_items.append(kv.second);
     }
 
+    auto get_monomer_item = [&atom_to_atom_item](RDKit::Atom* monomer) {
+        auto* graphics_item = atom_to_atom_item.at(monomer);
+        auto* monomer_item = dynamic_cast<AbstractMonomerItem*>(graphics_item);
+        if (monomer_item == nullptr) {
+            throw std::runtime_error("Atom is not a monomer");
+        }
+        return monomer_item;
+    };
+
     // label the attachment points
     if (m_bond_index_to_label >= 0) {
         auto* bond = m_frag->getBondWithIdx(m_bond_index_to_label);
-        auto* begin_monomer_item = atom_to_atom_item.at(bond->getBeginAtom());
-        auto* end_monomer_item = atom_to_atom_item.at(bond->getEndAtom());
+        auto* begin_monomer_item = get_monomer_item(bond->getBeginAtom());
+        auto* end_monomer_item = get_monomer_item(bond->getEndAtom());
         auto items = create_attachment_point_labels_for_connector(
             bond, false, STRUCTURE_HINT_COLOR, *m_fonts, begin_monomer_item,
             end_monomer_item);

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.cpp
@@ -111,5 +111,23 @@ void NucleicAcidBaseItem::updateCachedData()
     m_border_brush.setColor(rect_color);
 }
 
+QPointF NucleicAcidBaseItem::getLabelOffsetPastShape(qreal angle) const
+{
+    // For a diamond centered at the origin with vertices (+/- half_w, 0) and
+    // (0, +/- half_h), points on the border satisfy
+    // |x|/half_w + |y|/half_h = 1. So for a unit-length direction (dx, dy)
+    // from the origin, the ray exits the diamond at distance
+    // t = 1 / (|dx|/half_w + |dy|/half_h).
+    QLineF line({0.0, 0.0}, {1.0, 0.0});
+    line.setAngle(angle);
+    auto rect = m_border_path.boundingRect();
+    auto half_width = rect.width() / 2.0;
+    auto half_height = rect.height() / 2.0;
+    auto t = 1.0 / (std::abs(line.dx()) / half_width +
+                    std::abs(line.dy()) / half_height);
+    line.setLength(t + MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING);
+    return line.p2();
+}
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.h
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.h
@@ -28,6 +28,9 @@ class SKETCHER_API NucleicAcidBaseItem : public AbstractMonomerItem
 
     // Overridden AbstractGraphicsItem method
     void updateCachedData() override;
+
+    // Overridden AbstractMonomerItem method
+    QPointF getLabelOffsetPastShape(qreal angle) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.cpp
@@ -1,6 +1,11 @@
 #include "schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.h"
 
+#include <cmath>
+
+#include <QLineF>
+
 #include "schrodinger/sketcher/molviewer/constants.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
 
 namespace schrodinger
 {
@@ -74,6 +79,25 @@ void NucleicAcidPhosphateItem::updateCachedData()
     m_bounding_rect =
         rect_expanded_by_half_pen_width(border_rect, border_pen_width);
     set_path_to_rect(m_shape, border_rect, border_pen_width / 2.0);
+}
+
+QPointF NucleicAcidPhosphateItem::getLabelOffsetPastShape(qreal angle) const
+{
+    // For an ellipse centered at the origin with semi-axes half_w and
+    // half_h, points on the border satisfy (x/half_w)^2 + (y/half_h)^2 = 1.
+    // So for a unit-length direction (dx, dy) from the origin, the ray
+    // exits the ellipse at distance
+    // t = 1 / sqrt((dx/half_w)^2 + (dy/half_h)^2).
+    QLineF line({0.0, 0.0}, {1.0, 0.0});
+    line.setAngle(angle);
+    auto rect = m_border_path.boundingRect();
+    auto half_width = rect.width() / 2.0;
+    auto half_height = rect.height() / 2.0;
+    auto dx_term = line.dx() / half_width;
+    auto dy_term = line.dy() / half_height;
+    auto t = 1.0 / std::sqrt(dx_term * dx_term + dy_term * dy_term);
+    line.setLength(t + MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING);
+    return line.p2();
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.h
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.h
@@ -25,6 +25,9 @@ class SKETCHER_API NucleicAcidPhosphateItem : public AbstractMonomerItem
 
     // Overridden AbstractGraphicsItem method
     void updateCachedData() override;
+
+    // Overridden AbstractMonomerItem method
+    QPointF getLabelOffsetPastShape(qreal angle) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
@@ -116,7 +116,10 @@ calculate_geometry(const UnboundAttachmentPoint& attachment_point,
     auto label_text = prep_attachment_point_name(attachment_point.display_name);
     auto label_rect =
         fonts.m_monomeric_attachment_point_label_fm.boundingRect(label_text);
-    position_ap_label_rect(label_rect, {0.0, 0.0}, dir);
+    position_ap_label_rect(label_rect, parent_monomer, {0.0, 0.0}, dir);
+    // position_ap_label_rect returns the rect in scene coords, but we want it
+    // in parent_monomer's local coords so paint() can draw it directly
+    label_rect.moveTopLeft(parent_monomer->mapFromScene(label_rect.topLeft()));
 
     qreal half_line_width = UNBOUND_AP_LINE_THICKNESS / 2.0;
     QRectF line_bounds = QRectF(QPointF(0, 0), line_end).normalized();


### PR DESCRIPTION
- Linked Case: SKETCH-2757, SKETCH-2756

### Description

This tweaks the attachment point labels based on Laura's comments in SKETCH-2746.  The main changes here are:

- The two labels for a connection (i.e. the labels for the start and end monomer) are now on opposite sides of the connection so there's more space for each
- Label positioning does a better job of accounting for the arrowheads
- Label positioning now takes into account the size and shape of the monomer's graphics item.  Previously, labels were positioned a constant distance away from the center of the monomer.
- The labels for bound attachment points are now light gray instead of black so they don’t distract from the structure hint

Here's a comparison:

| Old| New|
|--------|--------|
| <img width="234" height="108" alt="image" src="https://github.com/user-attachments/assets/0ba530a7-af89-4c8a-a596-6b5b48d58531" />| <img width="243" height="122" alt="image" src="https://github.com/user-attachments/assets/dacdf98d-c4ff-4fbb-9cda-0cfea519362a" />|
| <img width="209" height="173" alt="image" src="https://github.com/user-attachments/assets/6c68d251-020a-4548-8da9-d7b1c4e25b10" />| <img width="211" height="170" alt="image" src="https://github.com/user-attachments/assets/5b7e4825-616a-425e-9c04-02ec91ad2a3c" />|
| <img width="237" height="309" alt="image" src="https://github.com/user-attachments/assets/614ced3e-73b7-455b-a5d4-7bce264219bc" />| <img width="249" height="337" alt="image" src="https://github.com/user-attachments/assets/32d4c338-481e-4376-8412-a06380b89d6f" />|
| <img width="270" height="100" alt="image" src="https://github.com/user-attachments/assets/f9ea64a9-b25f-4956-a301-e16c32973712" />| <img width="277" height="111" alt="image" src="https://github.com/user-attachments/assets/15bf9e72-20db-41b6-b48d-5af3dfe42b79" />|

### Testing Done

Tested via the Windows desktop app.  I've pinged Laura on the Jira case to see if she has any additional feedback.
