### PR TITLE
SKETCH-2375: Migrate to RDKit native attachment point handling

### DIFF
--- a/include/schrodinger/rdkit_extensions/rgroup.h
+++ b/include/schrodinger/rdkit_extensions/rgroup.h
@@ -23,12 +23,6 @@ namespace rdkit_extensions
 {
 
 /**
- * @param atom rdkit atom
- * @return whether the atom is an attachment point
- */
-RDKIT_EXTENSIONS_API bool is_attachment_point_dummy(const RDKit::Atom& atom);
-
-/**
  * @return The R-group number of the specified atom.  If the atom is not an
  * R-group, an empty `r_group_num_t` object will be returned.
  */

--- a/include/schrodinger/rdkit_extensions/rgroup.h
+++ b/include/schrodinger/rdkit_extensions/rgroup.h
@@ -23,6 +23,16 @@ namespace rdkit_extensions
 {
 
 /**
+ * @return whether the specified atom is an attachment point dummy.
+ *
+ * Unlike RDKit::MolOps::details::isAttachmentPoint(), this tests attachment
+ * point identity rather than whether the atom is currently eligible to be
+ * collapsed. In particular, wedged attachment points are still recognized.
+ */
+[[nodiscard]] RDKIT_EXTENSIONS_API bool
+is_attachment_point_dummy(const RDKit::Atom& atom);
+
+/**
  * @return The R-group number of the specified atom.  If the atom is not an
  * R-group, an empty `r_group_num_t` object will be returned.
  */

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -7,7 +7,6 @@
 #include "schrodinger/rdkit_extensions/convert.h"
 
 #include <functional>
-#include <map>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/beast/core/detail/base64.hpp>
@@ -109,25 +108,6 @@ template <typename T> boost::shared_ptr<T> auto_detect(
 void collapse_attachment_point_dummies(RDKit::RWMol& rdk_mol)
 {
     rdk_mol.updatePropertyCache(false);
-
-    std::map<unsigned int, std::vector<RDKit::Atom*>> parent_to_aps;
-    for (auto atom : rdk_mol.atoms()) {
-        if (!is_attachment_point_dummy(*atom)) {
-            continue;
-        }
-        for (auto parent : rdk_mol.atomNeighbors(atom)) {
-            parent_to_aps[parent->getIdx()].push_back(atom);
-            parent->setNoImplicit(false);
-        }
-    }
-
-    for (auto& [parent_idx, aps] : parent_to_aps) {
-        for (size_t i = 0; i < aps.size(); ++i) {
-            aps[i]->setProp(RDKit::common_properties::_fromAttachPoint,
-                            static_cast<int>(i + 1));
-        }
-    }
-
     RDKit::MolOps::collapseAttachmentPoints(rdk_mol, true);
     rdk_mol.updatePropertyCache(false);
 }

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -105,7 +105,8 @@ template <typename T> boost::shared_ptr<T> auto_detect(
     throw std::invalid_argument("Unable to determine format");
 }
 
-bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
+bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol,
+                                      const unsigned int first_expanded_atom)
 {
     bool found_any = false;
     unsigned int ap_num = 1;
@@ -124,11 +125,12 @@ bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
             atom->setProp(RDKit::common_properties::atomLabel,
                           ATTACHMENT_POINT_LABEL_PREFIX +
                               std::to_string(ap_num++));
-
-            for (auto parent : rdk_mol.atomNeighbors(atom)) {
-                auto explicit_h_count = parent->getNumExplicitHs();
-                if (explicit_h_count != 0) {
-                    parent->setNumExplicitHs(explicit_h_count - 1);
+            if (j >= first_expanded_atom) {
+                for (auto parent : rdk_mol.atomNeighbors(atom)) {
+                    auto explicit_h_count = parent->getNumExplicitHs();
+                    if (explicit_h_count != 0) {
+                        parent->setNumExplicitHs(explicit_h_count - 1);
+                    }
                 }
             }
             continue;
@@ -149,6 +151,16 @@ bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
         rdk_mol.updatePropertyCache(false);
     }
     return found_any;
+}
+
+void mark_legacy_attachment_points(RDKit::RWMol& mol)
+{
+    for (auto atom : mol.atoms()) {
+        if (is_attachment_point_dummy(*atom) &&
+            !atom->hasProp(RDKit::common_properties::_fromAttachPoint)) {
+            atom->setProp(RDKit::common_properties::_fromAttachPoint, 1);
+        }
+    }
 }
 
 void preserve_wiggly_bonds(RDKit::RWMol& mol)
@@ -656,8 +668,10 @@ boost::shared_ptr<RDKit::RWMol> to_rdkit(const std::string& text,
         mol->updatePropertyCache(false);
     }
 
+    const auto first_expanded_atom = mol->getNumAtoms();
     RDKit::MolOps::expandAttachmentPoints(*mol);
-    bool has_attchpt = label_expanded_attachment_points(*mol);
+    bool has_attchpt =
+        label_expanded_attachment_points(*mol, first_expanded_atom);
     if (!has_attchpt) {
         preserve_wiggly_bonds(*mol);
         fix_r0_rgroup(*mol);
@@ -801,6 +815,7 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
             // single/double bonds to avoid sanitization errors, but for
             // atomistic inputs we'll keep whatever the caller gave us.
             kekulize = is_monomeric;
+            mark_legacy_attachment_points(*mol);
             RDKit::MolOps::collapseAttachmentPoints(*mol, true);
             if (format == Format::MDL_MOLV2000) {
                 adjust_for_mdl_v2k_format(*mol);

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -105,13 +105,6 @@ template <typename T> boost::shared_ptr<T> auto_detect(
     throw std::invalid_argument("Unable to determine format");
 }
 
-void collapse_attachment_point_dummies(RDKit::RWMol& rdk_mol)
-{
-    rdk_mol.updatePropertyCache(false);
-    RDKit::MolOps::collapseAttachmentPoints(rdk_mol, true);
-    rdk_mol.updatePropertyCache(false);
-}
-
 bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
 {
     bool found_any = false;
@@ -809,7 +802,7 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
             // single/double bonds to avoid sanitization errors, but for
             // atomistic inputs we'll keep whatever the caller gave us.
             kekulize = is_monomeric;
-            collapse_attachment_point_dummies(*mol);
+            RDKit::MolOps::collapseAttachmentPoints(*mol, true);
             if (format == Format::MDL_MOLV2000) {
                 adjust_for_mdl_v2k_format(*mol);
             }

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -523,9 +523,8 @@ boost::shared_ptr<RDKit::RWMol> to_rdkit(const std::string& text,
     switch (format) {
         case Format::RDMOL_BINARY_BASE64:
             mol = base64_to_mol<RDKit::RWMol, RDKit::ROMol>(
-                text,
-                (void (*)(const std::string&,
-                          RDKit::ROMol*))&RDKit::MolPickler::molFromPickle);
+                text, (void (*)(const std::string&, RDKit::ROMol*)) &
+                          RDKit::MolPickler::molFromPickle);
             break;
         case Format::SMILES:
         case Format::EXTENDED_SMILES: {
@@ -695,9 +694,9 @@ to_rdkit_reaction(const std::string& text, const Format format)
         case Format::RDMOL_BINARY_BASE64:
             rxn =
                 base64_to_mol<RDKit::ChemicalReaction, RDKit::ChemicalReaction>(
-                    text, (void (*)(const std::string&,
-                                    RDKit::ChemicalReaction*))&RDKit::
-                              ReactionPickler::reactionFromPickle);
+                    text,
+                    (void (*)(const std::string&, RDKit::ChemicalReaction*)) &
+                        RDKit::ReactionPickler::reactionFromPickle);
             break;
         case Format::SMILES:
         case Format::EXTENDED_SMILES:
@@ -784,8 +783,8 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
         case Format::RDMOL_BINARY_BASE64:
             return mol_to_base64<RDKit::ROMol>(
                 mol.get(),
-                (void (*)(const RDKit::ROMol*, std::string&,
-                          unsigned int))&RDKit::MolPickler::pickleMol);
+                (void (*)(const RDKit::ROMol*, std::string&, unsigned int)) &
+                    RDKit::MolPickler::pickleMol);
         case Format::SMILES:
             return RDKit::MolToSmiles(*mol, include_stereo, kekulize);
         case Format::EXTENDED_SMILES:
@@ -854,10 +853,9 @@ std::string to_string(const RDKit::ChemicalReaction& rxn, const Format format)
     switch (format) {
         case Format::RDMOL_BINARY_BASE64:
             return mol_to_base64<RDKit::ChemicalReaction>(
-                &rxn,
-                (void (*)(
-                    const RDKit::ChemicalReaction*, std::string&,
-                    unsigned int))&RDKit::ReactionPickler::pickleReaction);
+                &rxn, (void (*)(const RDKit::ChemicalReaction*, std::string&,
+                                unsigned int)) &
+                          RDKit::ReactionPickler::pickleReaction);
         case Format::SMILES:
             return RDKit::ChemicalReactionToRxnSmiles(rxn);
         case Format::EXTENDED_SMILES:

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -140,20 +140,33 @@ bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
     const auto num_atoms = rdk_mol.getNumAtoms();
     for (auto j = 0u; j < num_atoms; ++j) {
         auto atom = rdk_mol.getAtomWithIdx(j);
-        int from_ap{0};
-        if (!atom->getPropIfPresent(RDKit::common_properties::_fromAttachPoint,
-                                    from_ap)) {
+        if (atom->getAtomicNum() != 0 || atom->getDegree() != 1) {
             continue;
         }
-        found_any = true;
-        atom->setProp(RDKit::common_properties::atomLabel,
-                      ATTACHMENT_POINT_LABEL_PREFIX + std::to_string(ap_num++));
 
-        for (auto parent : rdk_mol.atomNeighbors(atom)) {
-            auto explicit_h_count = parent->getNumExplicitHs();
-            if (explicit_h_count != 0) {
-                parent->setNumExplicitHs(explicit_h_count - 1);
+        int from_ap{0};
+        if (atom->getPropIfPresent(RDKit::common_properties::_fromAttachPoint,
+                                   from_ap)) {
+            found_any = true;
+            atom->setProp(RDKit::common_properties::atomLabel,
+                          ATTACHMENT_POINT_LABEL_PREFIX +
+                              std::to_string(ap_num++));
+
+            for (auto parent : rdk_mol.atomNeighbors(atom)) {
+                auto explicit_h_count = parent->getNumExplicitHs();
+                if (explicit_h_count != 0) {
+                    parent->setNumExplicitHs(explicit_h_count - 1);
+                }
             }
+            continue;
+        }
+
+        std::string label;
+        if (atom->getPropIfPresent(RDKit::common_properties::atomLabel,
+                                   label) &&
+            label.find(ATTACHMENT_POINT_LABEL_PREFIX) == 0) {
+            found_any = true;
+            atom->setProp(RDKit::common_properties::_fromAttachPoint, 1);
         }
     }
 
@@ -537,8 +550,9 @@ boost::shared_ptr<RDKit::RWMol> to_rdkit(const std::string& text,
     switch (format) {
         case Format::RDMOL_BINARY_BASE64:
             mol = base64_to_mol<RDKit::RWMol, RDKit::ROMol>(
-                text, (void (*)(const std::string&, RDKit::ROMol*)) &
-                          RDKit::MolPickler::molFromPickle);
+                text,
+                (void (*)(const std::string&,
+                          RDKit::ROMol*))&RDKit::MolPickler::molFromPickle);
             break;
         case Format::SMILES:
         case Format::EXTENDED_SMILES: {
@@ -708,9 +722,9 @@ to_rdkit_reaction(const std::string& text, const Format format)
         case Format::RDMOL_BINARY_BASE64:
             rxn =
                 base64_to_mol<RDKit::ChemicalReaction, RDKit::ChemicalReaction>(
-                    text,
-                    (void (*)(const std::string&, RDKit::ChemicalReaction*)) &
-                        RDKit::ReactionPickler::reactionFromPickle);
+                    text, (void (*)(const std::string&,
+                                    RDKit::ChemicalReaction*))&RDKit::
+                              ReactionPickler::reactionFromPickle);
             break;
         case Format::SMILES:
         case Format::EXTENDED_SMILES:
@@ -797,8 +811,8 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
         case Format::RDMOL_BINARY_BASE64:
             return mol_to_base64<RDKit::ROMol>(
                 mol.get(),
-                (void (*)(const RDKit::ROMol*, std::string&, unsigned int)) &
-                    RDKit::MolPickler::pickleMol);
+                (void (*)(const RDKit::ROMol*, std::string&,
+                          unsigned int))&RDKit::MolPickler::pickleMol);
         case Format::SMILES:
             return RDKit::MolToSmiles(*mol, include_stereo, kekulize);
         case Format::EXTENDED_SMILES:
@@ -867,9 +881,10 @@ std::string to_string(const RDKit::ChemicalReaction& rxn, const Format format)
     switch (format) {
         case Format::RDMOL_BINARY_BASE64:
             return mol_to_base64<RDKit::ChemicalReaction>(
-                &rxn, (void (*)(const RDKit::ChemicalReaction*, std::string&,
-                                unsigned int)) &
-                          RDKit::ReactionPickler::pickleReaction);
+                &rxn,
+                (void (*)(
+                    const RDKit::ChemicalReaction*, std::string&,
+                    unsigned int))&RDKit::ReactionPickler::pickleReaction);
         case Format::SMILES:
             return RDKit::ChemicalReactionToRxnSmiles(rxn);
         case Format::EXTENDED_SMILES:

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -7,6 +7,7 @@
 #include "schrodinger/rdkit_extensions/convert.h"
 
 #include <functional>
+#include <map>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/beast/core/detail/base64.hpp>
@@ -105,84 +106,63 @@ template <typename T> boost::shared_ptr<T> auto_detect(
     throw std::invalid_argument("Unable to determine format");
 }
 
-void attachment_point_dummies_to_molattachpt_property(RDKit::RWMol& rdk_mol)
+void collapse_attachment_point_dummies(RDKit::RWMol& rdk_mol)
 {
     rdk_mol.updatePropertyCache(false);
-    std::vector<RDKit::Atom*> dummies_to_remove;
-    for (auto atom : rdk_mol.atoms()) {
-        if (is_attachment_point_dummy(*atom)) {
-            dummies_to_remove.push_back(atom);
 
-            // This should find only one neighbor
-            for (auto parent : rdk_mol.atomNeighbors(atom)) {
-                int attachment_point_type{1};
-                if (parent->hasProp(RDKit::common_properties::molAttachPoint)) {
-                    attachment_point_type = -1;
-                }
-                parent->setNoImplicit(false);
-                parent->setProp(RDKit::common_properties::molAttachPoint,
-                                attachment_point_type);
-            }
+    std::map<unsigned int, std::vector<RDKit::Atom*>> parent_to_aps;
+    for (auto atom : rdk_mol.atoms()) {
+        if (!is_attachment_point_dummy(*atom)) {
+            continue;
+        }
+        for (auto parent : rdk_mol.atomNeighbors(atom)) {
+            parent_to_aps[parent->getIdx()].push_back(atom);
+            parent->setNoImplicit(false);
         }
     }
-    rdk_mol.beginBatchEdit();
-    for (auto atom : dummies_to_remove) {
-        rdk_mol.removeAtom(atom);
-    }
-    rdk_mol.commitBatchEdit();
 
+    for (auto& [parent_idx, aps] : parent_to_aps) {
+        for (size_t i = 0; i < aps.size(); ++i) {
+            aps[i]->setProp(RDKit::common_properties::_fromAttachPoint,
+                            static_cast<int>(i + 1));
+        }
+    }
+
+    RDKit::MolOps::collapseAttachmentPoints(rdk_mol, true);
     rdk_mol.updatePropertyCache(false);
 }
 
-bool molattachpt_property_to_attachment_point_dummies(RDKit::RWMol& rdk_mol)
+bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol)
 {
-    std::unordered_set<int> new_attachment_dummies;
-    // We can't use rdk_mol.atoms() because adding new atoms below
-    // will invalidate the iterators. Using num_atoms in the loop
-    // prevents us from checking rdk_mol.size() in each iteration
-    // and potentially checking atoms we just added.
+    bool found_any = false;
+    unsigned int ap_num = 1;
+
     const auto num_atoms = rdk_mol.getNumAtoms();
     for (auto j = 0u; j < num_atoms; ++j) {
         auto atom = rdk_mol.getAtomWithIdx(j);
-        int attach_point_type{0};
-        if (atom->getPropIfPresent(RDKit::common_properties::molAttachPoint,
-                                   attach_point_type)) {
-            auto num_dummies = (attach_point_type == -1 ? 2 : 1);
-            auto explicit_h_count = atom->getNumExplicitHs();
-            for (auto i = 1; i <= num_dummies; ++i) {
+        int from_ap{0};
+        if (!atom->getPropIfPresent(RDKit::common_properties::_fromAttachPoint,
+                                    from_ap)) {
+            continue;
+        }
+        found_any = true;
+        atom->setProp(RDKit::common_properties::atomLabel,
+                      ATTACHMENT_POINT_LABEL_PREFIX + std::to_string(ap_num++));
 
-                auto dummy_atom = new RDKit::QueryAtom(0);
-                dummy_atom->setQuery(RDKit::makeAtomNullQuery());
-
-                dummy_atom->setProp(RDKit::common_properties::atomLabel,
-                                    ATTACHMENT_POINT_LABEL_PREFIX +
-                                        std::to_string(i));
-
-                bool update_label = false;
-                bool take_ownership = true;
-                auto dummy_idx =
-                    rdk_mol.addAtom(dummy_atom, update_label, take_ownership);
-                rdk_mol.addBond(atom, dummy_atom, RDKit::Bond::SINGLE);
-
-                new_attachment_dummies.insert(dummy_idx);
-
-                RDKit::MolOps::setTerminalAtomCoords(rdk_mol, dummy_idx,
-                                                     atom->getIdx());
-            }
+        for (auto parent : rdk_mol.atomNeighbors(atom)) {
+            auto explicit_h_count = parent->getNumExplicitHs();
             if (explicit_h_count != 0) {
-                atom->setNumExplicitHs(explicit_h_count - num_dummies);
+                parent->setNumExplicitHs(explicit_h_count - 1);
             }
-            atom->clearProp(RDKit::common_properties::molAttachPoint);
         }
     }
 
-    if (!new_attachment_dummies.empty()) {
+    if (found_any) {
         RDKit::Chirality::reapplyMolBlockWedging(rdk_mol);
         RDKit::MolOps::assignChiralTypesFromBondDirs(rdk_mol);
         rdk_mol.updatePropertyCache(false);
-        return true;
     }
-    return false;
+    return found_any;
 }
 
 void preserve_wiggly_bonds(RDKit::RWMol& mol)
@@ -586,7 +566,6 @@ boost::shared_ptr<RDKit::RWMol> to_rdkit(const std::string& text,
             break;
         case Format::MDL_MOLV2000:
         case Format::MDL_MOLV3000: {
-            // SDMolSupplier will preserve structure level properties
             RDKit::SDMolSupplier reader;
             bool strict_parsing = false;
             reader.setData(text, sanitize, removeHs, strict_parsing);
@@ -691,7 +670,8 @@ boost::shared_ptr<RDKit::RWMol> to_rdkit(const std::string& text,
         mol->updatePropertyCache(false);
     }
 
-    bool has_attchpt = molattachpt_property_to_attachment_point_dummies(*mol);
+    RDKit::MolOps::expandAttachmentPoints(*mol);
+    bool has_attchpt = label_expanded_attachment_points(*mol);
     if (!has_attchpt) {
         preserve_wiggly_bonds(*mol);
         fix_r0_rgroup(*mol);
@@ -835,7 +815,7 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
             // single/double bonds to avoid sanitization errors, but for
             // atomistic inputs we'll keep whatever the caller gave us.
             kekulize = is_monomeric;
-            attachment_point_dummies_to_molattachpt_property(*mol);
+            collapse_attachment_point_dummies(*mol);
             if (format == Format::MDL_MOLV2000) {
                 adjust_for_mdl_v2k_format(*mol);
             }

--- a/src/schrodinger/rdkit_extensions/convert.cpp
+++ b/src/schrodinger/rdkit_extensions/convert.cpp
@@ -153,12 +153,39 @@ bool label_expanded_attachment_points(RDKit::RWMol& rdk_mol,
     return found_any;
 }
 
-void mark_legacy_attachment_points(RDKit::RWMol& mol)
+/**
+ * @internal Make every attachment point dummy in the mol collapsible by
+ * RDKit::MolOps::collapseAttachmentPoints(), which is about to be called on
+ * this (already copied) mol.
+ *
+ * Two things stop RDKit from collapsing an attachment point that Sketcher
+ * considers one:
+ *
+ * - a legacy `_AP<n>` labelled dummy carries no _fromAttachPoint property, so
+ *   RDKit doesn't recognize it as marked.
+ * - RDKit refuses to collapse an attachment point whose bond is wedged, since
+ *   ATTCHPT is an atom property and has nowhere to record the wedging.
+ *
+ * The wedge is dropped rather than preserved because the alternative is worse:
+ * an uncollapsed attachment point is written as a bare `*` atom, losing the
+ * attachment point marker entirely, so it reads back as an ordinary dummy
+ * rather than an attachment point.
+ */
+void prepare_attachment_points_for_collapse(RDKit::RWMol& mol)
 {
     for (auto atom : mol.atoms()) {
-        if (is_attachment_point_dummy(*atom) &&
-            !atom->hasProp(RDKit::common_properties::_fromAttachPoint)) {
+        if (!is_attachment_point_dummy(*atom)) {
+            continue;
+        }
+        if (!atom->hasProp(RDKit::common_properties::_fromAttachPoint)) {
             atom->setProp(RDKit::common_properties::_fromAttachPoint, 1);
+        }
+        // is_attachment_point_dummy() requires degree 1, so there's exactly
+        // one bond to dereference here
+        auto bond = *mol.atomBonds(atom).begin();
+        if (bond->getBondType() == RDKit::Bond::BondType::SINGLE ||
+            bond->getBondType() == RDKit::Bond::BondType::UNSPECIFIED) {
+            bond->setBondDir(RDKit::Bond::BondDir::NONE);
         }
     }
 }
@@ -815,7 +842,7 @@ std::string to_string(const RDKit::ROMol& input_mol, const Format format)
             // single/double bonds to avoid sanitization errors, but for
             // atomistic inputs we'll keep whatever the caller gave us.
             kekulize = is_monomeric;
-            mark_legacy_attachment_points(*mol);
+            prepare_attachment_points_for_collapse(*mol);
             RDKit::MolOps::collapseAttachmentPoints(*mol, true);
             if (format == Format::MDL_MOLV2000) {
                 adjust_for_mdl_v2k_format(*mol);

--- a/src/schrodinger/rdkit_extensions/rgroup.cpp
+++ b/src/schrodinger/rdkit_extensions/rgroup.cpp
@@ -11,7 +11,6 @@
 #include <stdexcept>
 
 #include <rdkit/GraphMol/Atom.h>
-#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 
 #include "schrodinger/rdkit_extensions/constants.h"
@@ -21,11 +20,6 @@ namespace schrodinger
 {
 namespace rdkit_extensions
 {
-
-bool is_attachment_point_dummy(const RDKit::Atom& atom)
-{
-    return RDKit::MolOps::details::isAttachmentPoint(&atom);
-}
 
 [[nodiscard]] std::shared_ptr<RDKit::Atom>
 make_new_r_group(const unsigned int r_group_num)

--- a/src/schrodinger/rdkit_extensions/rgroup.cpp
+++ b/src/schrodinger/rdkit_extensions/rgroup.cpp
@@ -23,9 +23,16 @@ namespace rdkit_extensions
 
 bool is_attachment_point_dummy(const RDKit::Atom& atom)
 {
+    if (atom.getAtomicNum() != 0 || atom.getTotalDegree() != 1) {
+        return false;
+    }
+    int from_ap{0};
+    if (atom.getPropIfPresent(RDKit::common_properties::_fromAttachPoint,
+                              from_ap)) {
+        return from_ap == 1 || from_ap == 2;
+    }
     std::string label;
-    return atom.getAtomicNum() == 0 && atom.getTotalDegree() == 1 &&
-           atom.getPropIfPresent(RDKit::common_properties::atomLabel, label) &&
+    return atom.getPropIfPresent(RDKit::common_properties::atomLabel, label) &&
            label.find(ATTACHMENT_POINT_LABEL_PREFIX) == 0;
 }
 

--- a/src/schrodinger/rdkit_extensions/rgroup.cpp
+++ b/src/schrodinger/rdkit_extensions/rgroup.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include <rdkit/GraphMol/Atom.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 
 #include "schrodinger/rdkit_extensions/constants.h"
@@ -23,17 +24,7 @@ namespace rdkit_extensions
 
 bool is_attachment_point_dummy(const RDKit::Atom& atom)
 {
-    if (atom.getAtomicNum() != 0 || atom.getTotalDegree() != 1) {
-        return false;
-    }
-    int from_ap{0};
-    if (atom.getPropIfPresent(RDKit::common_properties::_fromAttachPoint,
-                              from_ap)) {
-        return from_ap == 1 || from_ap == 2;
-    }
-    std::string label;
-    return atom.getPropIfPresent(RDKit::common_properties::atomLabel, label) &&
-           label.find(ATTACHMENT_POINT_LABEL_PREFIX) == 0;
+    return RDKit::MolOps::details::isAttachmentPoint(&atom);
 }
 
 [[nodiscard]] std::shared_ptr<RDKit::Atom>

--- a/src/schrodinger/rdkit_extensions/rgroup.cpp
+++ b/src/schrodinger/rdkit_extensions/rgroup.cpp
@@ -21,6 +21,20 @@ namespace schrodinger
 namespace rdkit_extensions
 {
 
+[[nodiscard]] bool is_attachment_point_dummy(const RDKit::Atom& atom)
+{
+    if (atom.getAtomicNum() != DUMMY_ATOMIC_NUMBER || atom.getDegree() != 1) {
+        return false;
+    }
+    if (atom.hasProp(RDKit::common_properties::_fromAttachPoint)) {
+        return true;
+    }
+
+    std::string label;
+    return atom.getPropIfPresent(RDKit::common_properties::atomLabel, label) &&
+           label.starts_with(ATTACHMENT_POINT_LABEL_PREFIX);
+}
+
 [[nodiscard]] std::shared_ptr<RDKit::Atom>
 make_new_r_group(const unsigned int r_group_num)
 {

--- a/src/schrodinger/rdkit_extensions/stereochemistry.cpp
+++ b/src/schrodinger/rdkit_extensions/stereochemistry.cpp
@@ -2,11 +2,11 @@
 
 #include <rdkit/GraphMol/GraphMol.h>
 #include <rdkit/GraphMol/Chirality.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/StereoGroup.h>
 #include <rdkit/GraphMol/FileParsers/MolFileStereochem.h>
 
 #include "schrodinger/rdkit_extensions/molops.h"
-#include "schrodinger/rdkit_extensions/rgroup.h"
 
 namespace schrodinger
 {
@@ -62,7 +62,7 @@ void wedgeMolBonds(RDKit::ROMol& mol, const RDKit::Conformer* conf)
 {
     std::vector<RDKit::Bond*> attachment_dummy_bonds;
     for (auto atom : mol.atoms()) {
-        if (is_attachment_point_dummy(*atom)) {
+        if (RDKit::MolOps::details::isAttachmentPoint(atom)) {
             auto bonds = mol.atomBonds(atom);
             auto bond = *bonds.begin();
             if (bond->getBondType() == RDKit::Bond::SINGLE) {

--- a/src/schrodinger/rdkit_extensions/stereochemistry.cpp
+++ b/src/schrodinger/rdkit_extensions/stereochemistry.cpp
@@ -2,11 +2,11 @@
 
 #include <rdkit/GraphMol/GraphMol.h>
 #include <rdkit/GraphMol/Chirality.h>
-#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/StereoGroup.h>
 #include <rdkit/GraphMol/FileParsers/MolFileStereochem.h>
 
 #include "schrodinger/rdkit_extensions/molops.h"
+#include "schrodinger/rdkit_extensions/rgroup.h"
 
 namespace schrodinger
 {
@@ -62,7 +62,7 @@ void wedgeMolBonds(RDKit::ROMol& mol, const RDKit::Conformer* conf)
 {
     std::vector<RDKit::Bond*> attachment_dummy_bonds;
     for (auto atom : mol.atoms()) {
-        if (RDKit::MolOps::details::isAttachmentPoint(atom)) {
+        if (is_attachment_point_dummy(*atom)) {
             auto bonds = mol.atomBonds(atom);
             auto bond = *bonds.begin();
             if (bond->getBondType() == RDKit::Bond::SINGLE) {

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -654,10 +654,7 @@ void MolModel::addAttachmentPoint(const RDGeom::Point3D& coords,
     unsigned int ap_num = get_next_attachment_point_number(&m_mol);
 
     auto cmd_func = [this, coords, bound_to_atom_tag, ap_num]() {
-        auto create_atom = std::bind(make_new_attachment_point, ap_num);
-        auto create_bond = make_new_single_bond;
-        addAtomChainCommandFunc(create_atom, {coords}, create_bond,
-                                bound_to_atom_tag);
+        addAttachmentPointCommandFunc(coords, bound_to_atom_tag, ap_num);
     };
     doCommandUsingSnapshots(cmd_func, "Add attachment point",
                             WhatChanged::MOLECULE);
@@ -2668,6 +2665,25 @@ MolModel::addDummyAtomsFromInvalidatedVariableAttachmentBonds(
         }
     }
     return updated_atoms_to_be_deleted;
+}
+
+void MolModel::addAttachmentPointCommandFunc(const RDGeom::Point3D& coords,
+                                             const AtomTag bound_to_atom_tag,
+                                             const unsigned int ap_num)
+{
+    Q_ASSERT(m_allow_edits);
+    auto* parent = m_mol.getUniqueAtomWithBookmark(bound_to_atom_tag);
+    auto parent_idx = parent->getIdx();
+    auto ap_idx = RDKit::MolOps::details::addExplicitAttachmentPoint(
+        m_mol, parent_idx, 1, /*addAsQuery=*/true, /*addCoords=*/false);
+    auto* ap_atom = m_mol.getAtomWithIdx(ap_idx);
+    ap_atom->setProp(RDKit::common_properties::atomLabel,
+                     rdkit_extensions::ATTACHMENT_POINT_LABEL_PREFIX +
+                         std::to_string(ap_num));
+    setTagForAtom(ap_atom, m_next_atom_tag++);
+    m_mol.getConformer().setAtomPos(ap_idx, coords);
+    auto* bond = m_mol.getBondBetweenAtoms(parent_idx, ap_idx);
+    setTagForBond(bond, m_next_bond_tag++);
 }
 
 void MolModel::addAtomChainCommandFunc(

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -653,10 +653,7 @@ void MolModel::addAttachmentPoint(const RDGeom::Point3D& coords,
     unsigned int ap_num = get_next_attachment_point_number(&m_mol);
 
     auto cmd_func = [this, coords, bound_to_atom_tag, ap_num]() {
-        auto create_atom = std::bind(make_new_attachment_point, ap_num);
-        auto create_bond = make_new_single_bond;
-        addAtomChainCommandFunc(create_atom, {coords}, create_bond,
-                                bound_to_atom_tag);
+        addAttachmentPointCommandFunc(coords, bound_to_atom_tag, ap_num);
     };
     doCommandUsingSnapshots(cmd_func, "Add attachment point",
                             WhatChanged::MOLECULE);
@@ -2667,6 +2664,25 @@ MolModel::addDummyAtomsFromInvalidatedVariableAttachmentBonds(
         }
     }
     return updated_atoms_to_be_deleted;
+}
+
+void MolModel::addAttachmentPointCommandFunc(const RDGeom::Point3D& coords,
+                                             const AtomTag bound_to_atom_tag,
+                                             const unsigned int ap_num)
+{
+    Q_ASSERT(m_allow_edits);
+    auto* parent = m_mol.getUniqueAtomWithBookmark(bound_to_atom_tag);
+    auto parent_idx = parent->getIdx();
+    auto ap_idx = RDKit::MolOps::details::addExplicitAttachmentPoint(
+        m_mol, parent_idx, 1, /*addAsQuery=*/true, /*addCoords=*/false);
+    auto* ap_atom = m_mol.getAtomWithIdx(ap_idx);
+    ap_atom->setProp(RDKit::common_properties::atomLabel,
+                     rdkit_extensions::ATTACHMENT_POINT_LABEL_PREFIX +
+                         std::to_string(ap_num));
+    setTagForAtom(ap_atom, m_next_atom_tag++);
+    m_mol.getConformer().setAtomPos(ap_idx, coords);
+    auto* bond = m_mol.getBondBetweenAtoms(parent_idx, ap_idx);
+    setTagForBond(bond, m_next_bond_tag++);
 }
 
 void MolModel::addAtomChainCommandFunc(

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -95,7 +95,7 @@ struct HighlightingInfo {
                      const QColor& color) :
         atom_tags(atom_tags),
         bond_tags(bond_tags),
-        color(color) {};
+        color(color){};
     std::unordered_set<AtomTag> atom_tags;
     std::unordered_set<BondTag> bond_tags;
     QColor color;

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -95,7 +95,7 @@ struct HighlightingInfo {
                      const QColor& color) :
         atom_tags(atom_tags),
         bond_tags(bond_tags),
-        color(color){};
+        color(color) {};
     std::unordered_set<AtomTag> atom_tags;
     std::unordered_set<BondTag> bond_tags;
     QColor color;
@@ -1349,6 +1349,10 @@ class SKETCHER_API MolModel : public AbstractUndoableModel
     addDummyAtomsFromInvalidatedVariableAttachmentBonds(
         const std::unordered_set<const RDKit::Atom*>& atoms_to_be_deleted,
         const std::unordered_set<const RDKit::Bond*>& bonds_to_be_deleted);
+
+    void addAttachmentPointCommandFunc(const RDGeom::Point3D& coords,
+                                       const AtomTag bound_to_atom_tag,
+                                       const unsigned int ap_num);
 
     /**
      * Add a chain of atoms, where each atom is bound to the previous and next

--- a/src/schrodinger/sketcher/rdkit/rgroup.cpp
+++ b/src/schrodinger/sketcher/rdkit/rgroup.cpp
@@ -5,6 +5,7 @@
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/Bond.h>
 #include <rdkit/GraphMol/Conformer.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <rdkit/RDGeneral/types.h>
@@ -54,6 +55,7 @@ make_new_attachment_point(const unsigned int ap_num)
     auto atom = rdkit_extensions::create_dummy_atom();
     atom->setProp(RDKit::common_properties::atomLabel,
                   ATTACHMENT_POINT_LABEL_PREFIX + std::to_string(ap_num));
+    atom->setProp(RDKit::common_properties::_fromAttachPoint, 1);
     return atom;
 }
 

--- a/src/schrodinger/sketcher/rdkit/rgroup.cpp
+++ b/src/schrodinger/sketcher/rdkit/rgroup.cpp
@@ -5,12 +5,12 @@
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/Bond.h>
 #include <rdkit/GraphMol/Conformer.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <rdkit/RDGeneral/types.h>
 
 #include "schrodinger/rdkit_extensions/constants.h"
 #include "schrodinger/rdkit_extensions/convert.h"
-#include "schrodinger/rdkit_extensions/molops.h"
 #include "schrodinger/rdkit_extensions/rgroup.h"
 #include "schrodinger/sketcher/molviewer/constants.h"
 
@@ -48,19 +48,19 @@ unsigned int get_numerical_suffix(const std::string& label,
 
 bool is_attachment_point(const RDKit::Atom* const atom)
 {
-    // rdkit_extensions::is_attachment_point_dummy doesn't require digits after
-    // "_AP", but we do since we need to use those numbers when we renumber the
-    // attachment points after an atom deletion
+    // RDKit's isAttachmentPoint doesn't require digits after "_AP", but we do
+    // since we need to use those numbers when we renumber the attachment points
+    // after an atom deletion
     return get_attachment_point_number(atom);
 }
 
 unsigned int get_attachment_point_number(const RDKit::Atom* const atom)
 {
-    if (!rdkit_extensions::is_attachment_point_dummy(*atom)) {
+    if (!RDKit::MolOps::details::isAttachmentPoint(atom)) {
         return 0;
     }
     // We know that the atomLabel property must be present, because
-    // is_attachment_point_dummy will return false without it
+    // isAttachmentPoint will return false without it
     std::string label =
         atom->getProp<std::string>(RDKit::common_properties::atomLabel);
     return get_numerical_suffix(label, ATTACHMENT_POINT_LABEL_PREFIX);

--- a/src/schrodinger/sketcher/rdkit/rgroup.cpp
+++ b/src/schrodinger/sketcher/rdkit/rgroup.cpp
@@ -5,14 +5,11 @@
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/Bond.h>
 #include <rdkit/GraphMol/Conformer.h>
-#include <rdkit/GraphMol/MolOps.h>
-#include <rdkit/GraphMol/QueryAtom.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <rdkit/RDGeneral/types.h>
 
 #include "schrodinger/rdkit_extensions/constants.h"
 #include "schrodinger/rdkit_extensions/convert.h"
-#include "schrodinger/rdkit_extensions/dummy_atom.h"
 #include "schrodinger/rdkit_extensions/molops.h"
 #include "schrodinger/rdkit_extensions/rgroup.h"
 #include "schrodinger/sketcher/molviewer/constants.h"
@@ -48,16 +45,6 @@ unsigned int get_numerical_suffix(const std::string& label,
     }
 }
 } // namespace
-
-std::shared_ptr<RDKit::Atom>
-make_new_attachment_point(const unsigned int ap_num)
-{
-    auto atom = rdkit_extensions::create_dummy_atom();
-    atom->setProp(RDKit::common_properties::atomLabel,
-                  ATTACHMENT_POINT_LABEL_PREFIX + std::to_string(ap_num));
-    atom->setProp(RDKit::common_properties::_fromAttachPoint, 1);
-    return atom;
-}
 
 bool is_attachment_point(const RDKit::Atom* const atom)
 {

--- a/src/schrodinger/sketcher/rdkit/rgroup.cpp
+++ b/src/schrodinger/sketcher/rdkit/rgroup.cpp
@@ -5,7 +5,6 @@
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/Bond.h>
 #include <rdkit/GraphMol/Conformer.h>
-#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <rdkit/RDGeneral/types.h>
 
@@ -56,13 +55,13 @@ bool is_attachment_point(const RDKit::Atom* const atom)
 
 unsigned int get_attachment_point_number(const RDKit::Atom* const atom)
 {
-    if (!RDKit::MolOps::details::isAttachmentPoint(atom)) {
+    if (!rdkit_extensions::is_attachment_point_dummy(*atom)) {
         return 0;
     }
-    // We know that the atomLabel property must be present, because
-    // isAttachmentPoint will return false without it
-    std::string label =
-        atom->getProp<std::string>(RDKit::common_properties::atomLabel);
+    std::string label;
+    if (!atom->getPropIfPresent(RDKit::common_properties::atomLabel, label)) {
+        return 0;
+    }
     return get_numerical_suffix(label, ATTACHMENT_POINT_LABEL_PREFIX);
 }
 

--- a/src/schrodinger/sketcher/rdkit/rgroup.h
+++ b/src/schrodinger/sketcher/rdkit/rgroup.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -19,13 +18,6 @@ namespace schrodinger
 {
 namespace sketcher
 {
-
-/**
- * @return a new attachment point atom using the specified attachment point
- * number
- */
-std::shared_ptr<RDKit::Atom>
-make_new_attachment_point(const unsigned int ap_num);
 
 /**
  * @return whether the specified atom is an attachment point.  Note that we

--- a/src/schrodinger/sketcher/rdkit/stereochemistry.cpp
+++ b/src/schrodinger/sketcher/rdkit/stereochemistry.cpp
@@ -2,9 +2,8 @@
 
 #include <rdkit/GraphMol/GraphMol.h>
 #include <rdkit/GraphMol/Chirality.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/StereoGroup.h>
-
-#include "schrodinger/rdkit_extensions/rgroup.h"
 #include "schrodinger/sketcher/rdkit/atom_properties.h"
 
 namespace schrodinger
@@ -26,7 +25,7 @@ template <typename T> bool has_non_CIP_neighbor(const T& obj)
         }
         auto controlling_atom = mol.getAtomWithIdx(atom_idx);
         if (RDKit::getAtomRLabel(controlling_atom) != 0 ||
-            rdkit_extensions::is_attachment_point_dummy(*controlling_atom)) {
+            RDKit::MolOps::details::isAttachmentPoint(controlling_atom)) {
             return true;
         }
     }

--- a/src/schrodinger/sketcher/rdkit/stereochemistry.cpp
+++ b/src/schrodinger/sketcher/rdkit/stereochemistry.cpp
@@ -2,8 +2,8 @@
 
 #include <rdkit/GraphMol/GraphMol.h>
 #include <rdkit/GraphMol/Chirality.h>
-#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/StereoGroup.h>
+#include "schrodinger/rdkit_extensions/rgroup.h"
 #include "schrodinger/sketcher/rdkit/atom_properties.h"
 
 namespace schrodinger
@@ -25,7 +25,7 @@ template <typename T> bool has_non_CIP_neighbor(const T& obj)
         }
         auto controlling_atom = mol.getAtomWithIdx(atom_idx);
         if (RDKit::getAtomRLabel(controlling_atom) != 0 ||
-            RDKit::MolOps::details::isAttachmentPoint(controlling_atom)) {
+            rdkit_extensions::is_attachment_point_dummy(*controlling_atom)) {
             return true;
         }
     }

--- a/test/schrodinger/rdkit_extensions/test_convert.cpp
+++ b/test/schrodinger/rdkit_extensions/test_convert.cpp
@@ -8,6 +8,7 @@
 #define BOOST_TEST_MODULE rdkit_extensions_convert
 
 #include <map>
+#include <memory>
 
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
@@ -687,6 +688,26 @@ M  END)MDL";
     Eigen::Vector3d c(a2.x, a2.y, a2.z);
     // *C* is linear, the cross product is the zero vector
     BOOST_TEST((a - b).cross(a - c).norm() != 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(test_cxsmiles_attachment_point_preserves_explicit_hs)
+{
+    auto mol = to_rdkit("*[NH2+]C |$_AP1;;$|", Format::EXTENDED_SMILES);
+
+    BOOST_REQUIRE(mol);
+    BOOST_TEST(mol->getAtomWithIdx(1)->getNumExplicitHs() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_legacy_attachment_point_mdl_export)
+{
+    std::unique_ptr<RDKit::RWMol> mol{
+        RDKit::SmilesToMol("*C |$_AP3;$|", 0, false)};
+    BOOST_REQUIRE(mol);
+    BOOST_REQUIRE(!mol->getAtomWithIdx(0)->hasProp(
+        RDKit::common_properties::_fromAttachPoint));
+
+    auto molblock = to_string(*mol, Format::MDL_MOLV3000);
+    BOOST_TEST(molblock.find("ATTCHPT=1") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(test_atom_ring_queries)

--- a/test/schrodinger/rdkit_extensions/test_convert.cpp
+++ b/test/schrodinger/rdkit_extensions/test_convert.cpp
@@ -710,6 +710,34 @@ BOOST_AUTO_TEST_CASE(test_legacy_attachment_point_mdl_export)
     BOOST_TEST(molblock.find("ATTCHPT=1") != std::string::npos);
 }
 
+BOOST_AUTO_TEST_CASE(test_wedged_attachment_point_mdl_export)
+{
+    // RDKit won't collapse an attachment point whose bond is wedged, since
+    // ATTCHPT is an atom property with nowhere to record the wedging. We drop
+    // the wedge so that the attachment point still collapses, because an
+    // uncollapsed attachment point is written as a bare "*" and reads back as
+    // an ordinary dummy atom rather than an attachment point.
+    for (auto bond_dir :
+         {RDKit::Bond::BondDir::NONE, RDKit::Bond::BondDir::BEGINWEDGE,
+          RDKit::Bond::BondDir::BEGINDASH}) {
+        BOOST_TEST_CONTEXT("bond direction " << static_cast<int>(bond_dir))
+        {
+            std::unique_ptr<RDKit::RWMol> mol{
+                RDKit::SmilesToMol("*C |$_AP1;$|", 0, false)};
+            BOOST_REQUIRE(mol);
+            mol->getBondWithIdx(0)->setBondDir(bond_dir);
+
+            auto molblock = to_string(*mol, Format::MDL_MOLV3000);
+            BOOST_TEST(molblock.find("ATTCHPT=1") != std::string::npos);
+
+            auto roundtripped = to_rdkit(molblock, Format::MDL_MOLV3000);
+            BOOST_REQUIRE(roundtripped->getNumAtoms() == 2);
+            BOOST_TEST(
+                is_attachment_point_dummy(*roundtripped->getAtomWithIdx(1)));
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(test_atom_ring_queries)
 {
     auto molblock = R""""(

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -27,6 +27,7 @@
 #include <rdkit/GraphMol/FileParsers/MolSupplier.h>
 #include <rdkit/GraphMol/MolTransforms/MolTransforms.h>
 #include <rdkit/GraphMol/MonomerInfo.h>
+#include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 #include <rdkit/GraphMol/QueryBond.h>
 #include <rdkit/GraphMol/ROMol.h>
@@ -654,6 +655,34 @@ BOOST_AUTO_TEST_CASE(test_addAtom_attachment_point)
     BOOST_TEST(get_next_attachment_point_number(mol) == 4);
     BOOST_TEST(mol->getNumAtoms() == 5);
     BOOST_TEST(mol->getNumBonds() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(test_wedged_attachment_point_identity)
+{
+    auto mol = rdkit_extensions::to_rdkit(
+        "*C |$_AP1;$|", rdkit_extensions::Format::EXTENDED_SMILES);
+    auto* attachment_atom = mol->getAtomWithIdx(0);
+    auto* attachment_bond = mol->getBondWithIdx(0);
+    attachment_bond->setBondDir(RDKit::Bond::BondDir::BEGINWEDGE);
+
+    // A wedged attachment point cannot be collapsed by RDKit, but it remains
+    // an attachment point for Sketcher selection, numbering, and editing.
+    BOOST_TEST(is_attachment_point(attachment_atom));
+    BOOST_TEST(get_attachment_point_number(attachment_atom) == 1);
+    BOOST_TEST(get_attachment_point_bond(attachment_atom) == attachment_bond);
+}
+
+BOOST_AUTO_TEST_CASE(test_unlabelled_native_attachment_point)
+{
+    RDKit::RWMol mol;
+    auto parent_idx = mol.addAtom(new RDKit::Atom(6), false, true);
+    auto attachment_idx = RDKit::MolOps::details::addExplicitAttachmentPoint(
+        mol, parent_idx, 1, true, false);
+    auto* attachment_atom = mol.getAtomWithIdx(attachment_idx);
+
+    BOOST_TEST(rdkit_extensions::is_attachment_point_dummy(*attachment_atom));
+    BOOST_TEST(!is_attachment_point(attachment_atom));
+    BOOST_TEST(get_attachment_point_number(attachment_atom) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_removeAtom)

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -672,6 +672,28 @@ BOOST_AUTO_TEST_CASE(test_wedged_attachment_point_identity)
     BOOST_TEST(get_attachment_point_bond(attachment_atom) == attachment_bond);
 }
 
+BOOST_AUTO_TEST_CASE(test_wedged_attachment_point_is_reachable_and_exports)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    const RDKit::ROMol* mol = model.getMol();
+
+    model.addAtom(Element::C, RDGeom::Point3D(1.0, 2.0, 0.0));
+    model.addAttachmentPoint(RDGeom::Point3D(3.0, 4.0, 0.0),
+                             mol->getAtomWithIdx(0));
+    BOOST_REQUIRE(mol->getNumBonds() == 1);
+
+    // Nothing stops the wedge bond tool from being applied to an attachment
+    // point bond, so this state is reachable from the UI
+    model.mutateBonds({mol->getBondWithIdx(0)}, BondTool::SINGLE_UP);
+    BOOST_TEST(mol->getBondWithIdx(0)->getBondDir() ==
+               RDKit::Bond::BondDir::BEGINWEDGE);
+
+    // ...and the attachment point must still survive an MDL round trip
+    auto molblock = rdkit_extensions::to_string(*mol, Format::MDL_MOLV3000);
+    BOOST_TEST(molblock.find("ATTCHPT=1") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(test_unlabelled_native_attachment_point)
 {
     RDKit::RWMol mol;


### PR DESCRIPTION
- Linked Case: SKETCH-2375

### RDKit APIs used

- `MolOps::expandAttachmentPoints()` replaces `molattachpt_property_to_attachment_point_dummies()`.
- `MolOps::collapseAttachmentPoints()` replaces `attachment_point_dummies_to_molattachpt_property()`.
- `MolOps::details::addExplicitAttachmentPoint()` replaces `make_new_attachment_point()`.

### Functions kept for Sketcher behavior

- `is_attachment_point_dummy()` cannot use RDKit's `isAttachmentPoint()` because RDKit tests whether an AP can be collapsed and therefore rejects wedged APs. Sketcher must still recognize those as attachment points and support legacy `_AP<n>` labels.
- `compute2DCoords()` additionally handles HELM structures, frozen atoms, ring templates, and removal of stale molfile wedging.
- `wedgeMolBonds()` prevents RDKit from choosing attachment-point bonds for wedging by temporarily making those bonds ineligible.
- The Sketcher R-group helpers for AP numbering, renumbering, bond/atom lookup, and counting implement Sketcher's global `_AP<n>` UI numbering. RDKit's `_fromAttachPoint` values only describe the first or second attachment on an individual parent atom.
- MDL export clears the bond direction on attachment-point bonds before collapsing, since RDKit won't collapse a wedged AP and the uncollapsed dummy would otherwise be written as a bare `*` that reads back as an ordinary dummy atom.

### Testing Done

Added new tests; all existing tests pass
