### PR TITLE
SKETCH-2757: Now using tightBoundingRect for attachment point labels

### DIFF
--- a/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
+++ b/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
@@ -171,7 +171,13 @@ static QGraphicsItem* create_attachment_point_label(const QString& label,
     auto* label_item = new QGraphicsSimpleTextItem(label);
     label_item->setFont(fonts.m_monomeric_attachment_point_label_font);
     label_item->setBrush({color});
-    label_item->setPos(label_rect.topLeft());
+    auto pos = label_rect.bottomLeft();
+    // label_rect.top() would give us the top of the pixels actually covered by
+    // the label text. However, QGraphicsSimpleTextItem::setPos wants the top of
+    // a "typical" line of text (i.e. the top of the font's ascent). As such, we
+    // use label_rect.bottom() + fm.ascent() for the vertical positioning here.
+    pos.ry() -= fonts.m_monomeric_attachment_point_label_fm.ascent();
+    label_item->setPos(pos);
     return label_item;
 }
 
@@ -215,7 +221,7 @@ QGraphicsItem* create_label_for_bound_attachment_point(
 
     auto ap_qname = prep_attachment_point_name(ap_name);
     auto ap_label_rect =
-        fonts.m_monomeric_attachment_point_label_fm.boundingRect(ap_qname);
+        fonts.m_monomeric_attachment_point_label_fm.tightBoundingRect(ap_qname);
     if (!attachment_point_is_drawn_with_arrowhead(monomer, bound_monomer,
                                                   is_secondary_connection)) {
         position_ap_label_rect(ap_label_rect, monomer_item, monomer_coords,

--- a/src/schrodinger/sketcher/molviewer/monomer_constants.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_constants.h
@@ -187,15 +187,15 @@ const QColor CHEM_MONOMER_RECT_COLOR =
 // the angle between a monomeric connector, the center of the bound monomer, and
 // the attachment point label. Raising this number will move the label further
 // from the bond line.
-const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ANGLE_OFFSET = 7.5;
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ANGLE_OFFSET = 12.5;
 
 const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_FONT_RATIO = 0.7;
 
 // the distance between the edge of the monomer and its attachment point labels
-const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING = 2.5;
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_MONOMER_SPACING = 2.0;
 
 // positioning for attachment point labels relative to connector arrowheads
-const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_VERTICAL = -2;
+const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_VERTICAL = 1;
 const qreal MONOMERIC_ATTACHMENT_POINT_LABEL_ARROWHEAD_SPACING_HORIZONTAL = 4.5;
 
 // the distance between the "pair" label and the relevant connector, as measured

--- a/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
@@ -115,7 +115,8 @@ calculate_geometry(const UnboundAttachmentPoint& attachment_point,
 
     auto label_text = prep_attachment_point_name(attachment_point.display_name);
     auto label_rect =
-        fonts.m_monomeric_attachment_point_label_fm.boundingRect(label_text);
+        fonts.m_monomeric_attachment_point_label_fm.tightBoundingRect(
+            label_text);
     position_ap_label_rect(label_rect, parent_monomer, {0.0, 0.0}, dir);
     // position_ap_label_rect returns the rect in scene coords, but we want it
     // in parent_monomer's local coords so paint() can draw it directly


### PR DESCRIPTION
- Linked Case: SKETCH-2757

### Description

This PR tweaks the attachment point label positioning to use `QFontMetricsF::tightBoundingRect` instead of `QFontMetricsF::boundingRect`.  This improves the label positioning, especially when a strand is laid out vertically.

| Before | After |
|--------|--------|
| <img width="75" height="146" alt="image" src="https://github.com/user-attachments/assets/1e65eb25-69b5-4d8e-835f-f1441d60dd32" />| <img width="71" height="142" alt="image" src="https://github.com/user-attachments/assets/3ee70015-6b3f-44ef-b75b-fb797234b53e" />|

### Testing Done

Tested on Windows desktop app and ran all existing unit tests.
