### PR TITLE
SKETCH-2667: Copy and paste in WASM builds no longer uses QClipboard and preserves binary RDMol

### DIFF
--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -399,6 +399,9 @@ class SKETCHER_API SketcherWidget : public QWidget
      * overriden in the unit test since using the real clipboard can lead to
      * intermittent failures on buildbot. The optional `binary` payload is
      * stashed under a sketcher-private MIME type and preferred on paste.
+     *
+     * @note getClipboardContents() always return an empty string on WASM
+     * builds. Use sketcher_start_browser_clipboard_read() instead.
      */
     virtual std::string getClipboardContents() const;
     virtual void setClipboardContents(std::string text,

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -577,8 +577,8 @@ EM_JS(void, sketcher_write_clipboard,
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
-        const html = '<div data-' + appName + '="' + binary + '"></div>' +
-                     escapeHtml(text);
+        const html = '<div style="display: none;" data-' + appName + '="' +
+                    binary + '"></div>' + escapeHtml(text);
         items['text/html'] = new Blob([html], {type: 'text/html'});
         if (sketcher_browser_supports_web_mime(web_mime_ptr)) {
             items[webMime] = new Blob([binary], {type: webMime});

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -19,7 +19,6 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#include <emscripten/val.h>
 #endif
 
 #include "schrodinger/rdkit_extensions/helm.h"
@@ -533,40 +532,98 @@ void SketcherWidget::setInterfaceType(InterfaceTypeType interface_type)
 
 // Sketcher-private MIME for a lossless RDKit pickle stashed alongside the
 // text payload; intra-sketcher pastes prefer it, other apps don't see it.
+const std::string SKETCHER_MIME_APP_NAME = "x-schrodinger-sketcher";
 const QString SKETCHER_MIME_TYPE =
-    QStringLiteral("application/x-schrodinger-sketcher");
+    QStringLiteral("application/") +
+    QString::fromStdString(SKETCHER_MIME_APP_NAME);
+
+#ifdef __EMSCRIPTEN__
+const std::string SKETCHER_WEB_MIME_TYPE =
+    "web " + SKETCHER_MIME_TYPE.toStdString();
+
+// prevent clang from breaking JavaScript by trying to reformat it
+// clang-format off
+
+// Returns whether the browser supports the given MIME type.  Supporting
+// SKETCHER_WEB_MIME_TYPE requires that the browser support the Web Custom
+// Formats extension to the async clipboard API (which is currently only recent
+// versions of Chromium-based browsers).
+EM_JS(int, sketcher_browser_supports_web_mime, (const char* web_mime_ptr), {
+    if (typeof ClipboardItem == 'undefined')
+        return 0;
+    if (typeof ClipboardItem.supports != 'function')
+        return 0;
+    return ClipboardItem.supports(UTF8ToString(web_mime_ptr)) ? 1 : 0;
+});
+
+// Write `text` and the lossless `binary` pickle to the system clipboard in a
+// single ClipboardItem. The binary is stored in the text/html MIME type using a
+// data property of an empty <div> block. The binary is additionally written to
+// the SKETCHER_WEB_MIME_TYPE if the source browser supports web custom MIMEs,
+// which allows intra-Chromium pastes to skip the HTML round-trip (and the
+// reformatting and security checks that text/html data is subjected to).
+EM_JS(void, sketcher_write_clipboard,
+      (const char* text_ptr, const char* binary_ptr,
+       const char* web_mime_ptr, const char* app_name_ptr), {
+    const text = UTF8ToString(text_ptr);
+    const binary = UTF8ToString(binary_ptr);
+    const webMime = UTF8ToString(web_mime_ptr);
+    const appName = UTF8ToString(app_name_ptr);
+    const items = {
+        'text/plain': new Blob([text], {type: 'text/plain'}),
+    };
+    if (binary.length > 0) {
+        const escapeHtml = (s) => s
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        const html = '<div data-' + appName + '="' + binary + '"></div>' +
+                     escapeHtml(text);
+        items['text/html'] = new Blob([html], {type: 'text/html'});
+        if (sketcher_browser_supports_web_mime(web_mime_ptr)) {
+            items[webMime] = new Blob([binary], {type: webMime});
+        }
+    }
+    navigator.clipboard.write([new ClipboardItem(items)]).catch((err) => {
+        // Best-effort; user may have denied clipboard permission.
+    });
+});
+// clang-format on
+#endif
 
 std::string SketcherWidget::getClipboardContents() const
 {
+#ifndef __EMSCRIPTEN__
     auto data = QApplication::clipboard()->mimeData();
-    if (data == nullptr) {
-        // mimeData can return a nullptr in WASM builds
-        return "";
-    }
     if (data->hasFormat(SKETCHER_MIME_TYPE)) {
         return data->data(SKETCHER_MIME_TYPE).toStdString();
     }
     if (data->hasText()) {
         return data->text().toStdString();
     }
+#endif
     return "";
 }
 
 void SketcherWidget::setClipboardContents(std::string text,
                                           std::string binary) const
 {
+#ifdef __EMSCRIPTEN__
+    // QClipboard doesn't interact with the system clipboard on WASM builds, so
+    // we write everything directly to the system clipboard instead. The writer
+    // always embeds the binary in a text/html sidecar (so Chrome -> Firefox
+    // round-trips through HTML) and additionally adds a custom web MIME when
+    // the browser supports the Web Custom Formats extension.
+    sketcher_write_clipboard(text.c_str(), binary.c_str(),
+                             SKETCHER_WEB_MIME_TYPE.c_str(),
+                             SKETCHER_MIME_APP_NAME.c_str());
+#else
     auto data = new QMimeData;
     data->setText(QString::fromStdString(text));
     if (!binary.empty()) {
         data->setData(SKETCHER_MIME_TYPE, QByteArray::fromStdString(binary));
     }
     QApplication::clipboard()->setMimeData(data);
-
-#ifdef __EMSCRIPTEN__
-    // Use the browser's aync clipboard api to enable copy for the wasm build
-    emscripten::val navigator = emscripten::val::global("navigator");
-    navigator["clipboard"].call<emscripten::val>("writeText",
-                                                 emscripten::val(text));
 #endif
 }
 
@@ -620,24 +677,71 @@ SketcherWidget* g_pending_paste_widget = nullptr;
 std::optional<QPointF> g_pending_paste_position;
 } // namespace
 
-// Non-suspending: starts readText() and attaches a .then() that calls back
-// into C++. We must NOT await here -- ASYNCIFY cannot suspend through the JS
-// trampoline Qt uses for slot dispatch, so the read has to complete on a
-// fresh wasm stack (see sketcher_finish_browser_paste below).
-EM_JS(void, sketcher_start_browser_clipboard_read, (), {
-    navigator.clipboard.readText()
-        .then(function(text) {
-            const byteLength = lengthBytesUTF8(text) + 1;
-            const ptr = _malloc(byteLength);
-            stringToUTF8(text, ptr, byteLength);
-            _sketcher_finish_browser_paste(ptr);
-            _free(ptr);
-        })
-        .catch(function(err) {
-            // No text, permission denied, document not focused, etc.
-            _sketcher_finish_browser_paste(0);
-        });
-});
+// Reads the system clipboard via the async API and re-enters C++ with whatever
+// payload should be pasted. Priority: the SKETCHER_WEB_MIME_TYPE custom MIME
+// (only present when the writer browser supported it), then the text/html
+// sidecar (a `<div data-${app}="${binary}">` written by the fallback path --
+// found via DOMParser since browsers may wrap clipboard HTML on read-back),
+// then plain text.
+//
+// Non-suspending: we must NOT await in the EM_JS body itself -- ASYNCIFY
+// cannot suspend through the JS trampoline Qt uses for slot dispatch, so the
+// read has to complete on a fresh wasm stack inside the .then() callback (see
+// sketcher_finish_browser_paste below).
+EM_JS(void, sketcher_start_browser_clipboard_read,
+      (const char* web_mime_ptr, const char* app_name_ptr), {
+          const webMime = UTF8ToString(web_mime_ptr);
+          const appName = UTF8ToString(app_name_ptr);
+
+          const sendString = function(s)
+          {
+              const byteLength = lengthBytesUTF8(s) + 1;
+              const ptr = _malloc(byteLength);
+              stringToUTF8(s, ptr, byteLength);
+              _sketcher_finish_browser_paste(ptr);
+              _free(ptr);
+          };
+
+          const findItem = function(items, mime)
+          {
+              for (const it of items) {
+                  if (it.types.includes(mime))
+                      return it;
+              }
+              return null;
+          };
+
+          navigator.clipboard.read()
+              .then(async function(items) {
+                  const webItem = findItem(items, webMime);
+                  if (webItem) {
+                      const blob = await webItem.getType(webMime);
+                      sendString(await blob.text());
+                      return;
+                  }
+                  const htmlItem = findItem(items, 'text/html');
+                  if (htmlItem) {
+                      const blob = await htmlItem.getType('text/html');
+                      const html = await blob.text();
+                      const doc =
+                          new DOMParser().parseFromString(html, 'text/html');
+                      const div =
+                          doc.querySelector('div[data-' + appName + ']');
+                      if (div) {
+                          sendString(div.getAttribute('data-' + appName));
+                          return;
+                      }
+                  }
+                  const textItem = findItem(items, 'text/plain');
+                  if (textItem) {
+                      const blob = await textItem.getType('text/plain');
+                      sendString(await blob.text());
+                      return;
+                  }
+                  _sketcher_finish_browser_paste(0);
+              })
+              .catch(function(err) { _sketcher_finish_browser_paste(0); });
+      });
 
 extern "C" EMSCRIPTEN_KEEPALIVE void
 sketcher_finish_browser_paste(const char* text)
@@ -658,19 +762,22 @@ sketcher_finish_browser_paste(const char* text)
  */
 void SketcherWidget::pasteAt(std::optional<QPointF> position)
 {
+#ifdef __EMSCRIPTEN__
+    // QClipboard doesn't interact with  the system clipboard on WASM, so always
+    // read the system clipboard via the async API and let the .then() callback
+    // re-enter through sketcher_finish_browser_paste(). The read function
+    // checks all three possible payload locations (web custom MIME, text/html
+    // sidecar, plain text) so the caller doesn't need to branch on browser
+    // support.
+    g_pending_paste_widget = this;
+    g_pending_paste_position = position;
+    sketcher_start_browser_clipboard_read(SKETCHER_WEB_MIME_TYPE.c_str(),
+                                          SKETCHER_MIME_APP_NAME.c_str());
+#else
     auto text = getClipboardContents();
     if (!text.empty()) {
         completePaste(std::move(text), position);
-        return;
     }
-#ifdef __EMSCRIPTEN__
-    // The browser may not not allow us to access the clipboard via Qt. In that
-    // case, use the JavaScript readText API to request permission from the
-    // user. JavaScript will automatically call completePaste once the user has
-    // granted permission.
-    g_pending_paste_widget = this;
-    g_pending_paste_position = position;
-    sketcher_start_browser_clipboard_read();
 #endif
 }
 


### PR DESCRIPTION
- Linked Case: SKETCH-2667
 
### Description

I think I finally have a good solution for copying and pasting in WASM builds.  With this PR, desktop app copying is unchanged, but we no longer use QClipboard at all in WASM.  Instead, we only use the system clipboard, so we shouldn't have to worry about anything getting out of sync.  To accomplish this, web copying now uses either 2 or 3 different MIME types, depending on the browser:

| MIME type | Browser | Example data |
|-----------|---------|--------------|
| text/plain | all |  PEPTIDE1{A.A}$$$$V2.0 |
| text/html  | all | &lt;div data-x-schrodinger-sketcher="KLUv/WDcAc0KAPZSQjswxTiNATDkH0rVAE8KY4FSAwMTNhAIMt01v3sCMmw1G06KeKidinkL9NCbrfhPSKwT6F1UN/kbjITIFCwANQAwAAfW/vvA+QI0YAoPNiJ5ZFj2Xzz/WoT+lbjzI6t/L5y35N/f+vo1/wFQVAQEktuoBGVFebGrn6xUpV0DoYqCGYisIqpJN037M1v+kwQL1ACg/md8IkxWKlYpFgTDvwLCZQ/S62b4Y+SMHL8l5MlULE1a418wwe/HZ7NXCRt1mDRTCdv4Dfb6d0UZSaT9GPnR0QwLmz2nzsTpFzisX0ez+snJbbFqHDA2IV88TVpDXgQ7bltU2F2gnPSjJm77IqgRdn+GpiYJKgweAF9LhAi5BuUyCkhrAGxShe8CZJc3SOA8APUGsmnMUa7GoLz1tWQp5I0mGwl5XQaYejdsEgDMDdWwF928gTe4CeyrFU19JcacWRyAEg=="> &lt;/div>PEPTIDE1{A.A}$$$$V2.0 |
| web&nbsp;application&#8725;x&#8209;schrodinger&#8209;sketcher | recent Chromium-based | KLUv/WDcAc0KAPZSQjswxTiNATDkH0rVAE8KY4FSAwMTNhAIMt01v3sCMmw1G06KeKidinkL9NCbrfhPSKwT6F1UN/kbjITIFCwANQAwAAfW/vvA+QI0YAoPNiJ5ZFj2Xzz/WoT+lbjzI6t/L5y35N/f+vo1/wFQVAQEktuoBGVFebGrn6xUpV0DoYqCGYisIqpJN037M1v+kwQL1ACg/md8IkxWKlYpFgTDvwLCZQ/S62b4Y+SMHL8l5MlULE1a418wwe/HZ7NXCRt1mDRTCdv4Dfb6d0UZSaT9GPnR0QwLmz2nzsTpFzisX0ez+snJbbFqHDA2IV88TVpDXgQ7bltU2F2gnPSjJm77IqgRdn+GpiYJKgweAF9LhAi5BuUyCkhrAGxShe8CZJc3SOA8APUGsmnMUa7GoLz1tWQp5I0mGwl5XQaYejdsEgDMDdWwF928gTe4CeyrFU19JcacWRyAEg==  |

Basically, `text/plain` contains the user-requested format in plain text, as it did before.  The `web application/x-schrodinger-sketcher` data contain the base64-encoded binary rdmol data, but this requires that the browser supporting custom web MIME types, which is currently only available on newer Chromium-based browsers.  (It's an accepted web standard and Firefox is [planning](https://bugzilla.mozilla.org/show_bug.cgi?id=1956304) on implementing it eventually, but it's relatively newish.)  The `text/html` data contains both the plain text and the binary rdmol data.  The rdmol is stored as a data attribute of an empty `div` tag, which means that anything other than Sketcher will ignore that data and only see the plain text, since some applications use `text/html` data to paste rich text.

When pasting, we first look for `web application/x-schrodinger-sketcher` data.  If that's not present, we look at `text/html` data and see if it contains any binary data.  If not, we use the `text/plain` data.  That way, copying from, e.g., Firefox to Firefox or between Firefox and Chrome will still transfer the binary data, and copying from Chrome to Chrome avoids the overhead of going through HTML.  I'm not worried about the CPU usage of the copy, but there are a bunch of behind-the-scenes operations that seem best to avoid wherever possible.  For example, browsers typically add additional HTML tags to the copied data, such as `<html><p>...</p></html>` or `<meta>` tags containing meta-data.  That's why `sketcher_start_browser_clipboard_read` needs to use a `DOMParser` instead of simple string matching to pull data out of the `<div>` block; the data that gets returned from the clipboard is different from the data that we put there in the first place.  Additionally, browsers do some sanitization and security checks to `text/html` data to make sure that it doesn't contain any malicious scripts.  I wouldn't expect anything we do to trigger any issues, but it's a bunch of additional moving parts that we avoid by using `web application/x-schrodinger-sketcher` in browsers that support it.

### Testing Done

I tested copies and pastes in and between Firefox and Chrome on Windows, and I used https://evercoder.github.io/clipboard-inspector/ to manually check clipboard contents.  I also sanity checked copy and paste on the desktop app.
