### PR TITLE
SKETCH-2757 and SKETCH-2756: Docstring fixes and label position tweak based on Claude's mmshare PR comments

### DIFF
--- a/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
+++ b/src/schrodinger/sketcher/molviewer/monomer_attachment_point_labels.cpp
@@ -175,7 +175,7 @@ static QGraphicsItem* create_attachment_point_label(const QString& label,
     // label_rect.top() would give us the top of the pixels actually covered by
     // the label text. However, QGraphicsSimpleTextItem::setPos wants the top of
     // a "typical" line of text (i.e. the top of the font's ascent). As such, we
-    // use label_rect.bottom() + fm.ascent() for the vertical positioning here.
+    // use label_rect.bottom() - fm.ascent() for the vertical positioning here.
     pos.ry() -= fonts.m_monomeric_attachment_point_label_fm.ascent();
     label_item->setPos(pos);
     return label_item;
@@ -265,7 +265,7 @@ create_label_for_center_of_connector(const RDKit::Atom* const begin_monomer,
     perpendicular.setLength((connector_angle < 90 ? 1 : -1) *
                             MONOMERIC_PAIR_CONNECTOR_LABEL_DIST);
     auto label_rect =
-        fonts.m_monomeric_attachment_point_label_fm.boundingRect(label);
+        fonts.m_monomeric_attachment_point_label_fm.tightBoundingRect(label);
     QPointF label_pos = perpendicular.p2();
     label_rect.moveCenter(label_pos);
 

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
@@ -130,17 +130,17 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
     void clearAttachmentPointsLabelsAndHintFragmentItem();
 
     /**
-     * Label all attachment points on the given hovered monomer
+     * Label all unbound attachment points on the given hovered monomer
      */
     void labelUnboundAttachmentPointsOnHoveredMonomer(
         const RDKit::Atom* const monomer,
         AbstractMonomerItem* const monomer_item);
 
     /**
-     * Label all attachment points on the given monomer, placing all newly
-     * created graphics items into the specified group and list. (You probably
-     * want to call either labelUnboundAttachmentPointsOnHoveredMonomer or
-     * labelAttachmentPointsOnDragEndMonomer instead of this.)
+     * Label all unbound attachment points on the given monomer, placing all
+     * newly created graphics items into the specified group and list. (You
+     * probably want to call either labelUnboundAttachmentPointsOnHoveredMonomer
+     * or labelAttachmentPointsOnDragEndMonomer instead of this.)
      */
     void labelUnboundAttachmentPointsOnMonomer(
         const RDKit::Atom* const monomer,


### PR DESCRIPTION
- Linked Case: SKETCH-2757, SKETCH-2756

### Description

On the mmshare PR, Claude found four minor issues: three of them were docstrings tweaks, and one of them was a very minor issue causing the "pair" attachment point label to be a few pixels lower than it should be:

| Before this PR | With this PR |
|----------------|--------------|
| <img width="307" height="296" alt="image" src="https://github.com/user-attachments/assets/8559180e-f67e-47ac-92c4-1717a38c00e1" />| <img width="304" height="302" alt="image" src="https://github.com/user-attachments/assets/37f4b2b3-c6fd-4adb-bd2b-42ad99a509b6" />|

None of these changes are particularly critical, but there's no reason not to make them.

### Testing Done

Confirmed that the "pair" label actually did move by a handful of pixels.
