### PR TITLE
SKETCH-2763: Generate complement strand for nucleic acids

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -50,18 +50,6 @@ namespace rdkit_extensions
 
 using schrodinger::rdkit_extensions::Direction;
 
-// empty space gap between a monomer and the one following it in the chain. This
-// will be the length of the visibile bond line connecting the two.
-constexpr double SIDE_TO_SIDE_DISTANCE = 0.70;
-// when a monomer size is not specified or its value is lower than this, this
-// value is used as the minimum size
-constexpr double MONOMER_MINIMUM_SIZE = 0.80;
-
-// total distance from the center of one monomer to the center of the following
-// in the chain
-constexpr double MONOMER_BOND_LENGTH =
-    SIDE_TO_SIDE_DISTANCE + MONOMER_MINIMUM_SIZE;
-
 // maximum allowed bond length as a multiple of the ideal bond length. Any bond
 // longer than this will be considered "stretched"
 constexpr double MAX_BOND_STRETCH = 3.0;

--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.h
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.h
@@ -21,6 +21,15 @@ namespace rdkit_extensions
 // measured in scene units
 const std::string MONOMER_ITEM_SIZE{"monomerItemSize"};
 
+// Empty-space gap between a monomer and the next in the chain (the length of
+// the visible bond line connecting them).
+constexpr double SIDE_TO_SIDE_DISTANCE = 0.70;
+// Minimum monomer size, used when a size is unspecified or smaller than this.
+constexpr double MONOMER_MINIMUM_SIZE = 0.80;
+// Center-to-center distance between adjacent monomers in a chain.
+constexpr double MONOMER_BOND_LENGTH =
+    SIDE_TO_SIDE_DISTANCE + MONOMER_MINIMUM_SIZE;
+
 /**
  * Information about a turn in a snaking or coiling chain layout.
  */

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.cpp
@@ -16,6 +16,50 @@ namespace schrodinger
 namespace sketcher
 {
 
+// True when every selected monomer is part of a nucleic acid chain (no
+// peptides, no CHEM) AND at least one is an NA base — the gate for the
+// "Add Complementary Sequence" action visibility.
+static bool na_selection_with_at_least_one_base(
+    const std::unordered_set<const RDKit::Atom*>& atoms)
+{
+    // Any non-NA monomer type (peptide, CHEM, or an unknown future variant)
+    // disqualifies the whole selection.
+    auto is_na_monomer = [](const RDKit::Atom* a) {
+        switch (get_monomer_type(a)) {
+            case MonomerType::NA_BASE:
+            case MonomerType::NA_SUGAR:
+            case MonomerType::NA_PHOSPHATE:
+                return true;
+            default:
+                return false;
+        }
+    };
+    auto is_na_base = [](const RDKit::Atom* a) {
+        return get_monomer_type(a) == MonomerType::NA_BASE;
+    };
+    // any_of is false for an empty selection, so no explicit empty guard.
+    return std::ranges::all_of(atoms, is_na_monomer) &&
+           std::ranges::any_of(atoms, is_na_base);
+}
+
+// Filter the menu's selection down to NA bases whose symbol has a
+// Watson-Crick complement. Used to drive both the "enabled" state of
+// the action and the payload of the emitted signal.
+static std::unordered_set<const RDKit::Atom*>
+complementable_bases(const std::unordered_set<const RDKit::Atom*>& atoms)
+{
+    std::unordered_set<const RDKit::Atom*> out;
+    for (const auto* a : atoms) {
+        if (get_monomer_type(a) != MonomerType::NA_BASE) {
+            continue;
+        }
+        if (na_base_has_complement(get_monomer_res_name(a))) {
+            out.insert(a);
+        }
+    }
+    return out;
+}
+
 MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     AbstractContextMenu(parent)
 {
@@ -25,6 +69,7 @@ MonomerContextMenu::MonomerContextMenu(QWidget* parent) :
     createProtonateAction();
     createMutateBaseSubMenu();
     createSugarToggleAction();
+    createAddComplementaryStrandAction();
     createDeleteAction();
 }
 
@@ -174,6 +219,19 @@ void MonomerContextMenu::createSugarToggleAction()
     });
 }
 
+void MonomerContextMenu::createAddComplementaryStrandAction()
+{
+    m_add_complement_action =
+        addAction("Add Complementary Sequence", this, [this]() {
+            // Reuse the set computed in updateActions() rather than walking
+            // the selection a third time.
+            if (m_complement_bases.empty()) {
+                return;
+            }
+            emit addComplementaryStrandRequested(m_complement_bases);
+        });
+}
+
 void MonomerContextMenu::createDeleteAction()
 {
     addAction("Delete", this, [this]() { emit deleteRequested(m_atoms); });
@@ -193,6 +251,14 @@ void MonomerContextMenu::updateActions()
     m_protonate_action->setVisible(all_peptide);
     m_mutate_base_menu->menuAction()->setVisible(all_na_base);
     m_sugar_toggle_action->setVisible(all_na_sugar);
+
+    m_complement_bases = complementable_bases(m_atoms);
+    const bool na_with_base = na_selection_with_at_least_one_base(m_atoms);
+    m_add_complement_action->setVisible(na_with_base);
+    // Enabled iff at least one selected base has a Watson-Crick complement
+    // symbol; DB-level validation happens model-side.
+    m_add_complement_action->setEnabled(na_with_base &&
+                                        !m_complement_bases.empty());
 
     if (all_peptide) {
         bool any_d_form_toggleable = false;

--- a/src/schrodinger/sketcher/menu/monomer_context_menu.h
+++ b/src/schrodinger/sketcher/menu/monomer_context_menu.h
@@ -47,6 +47,11 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
     void mutateMonomerRequested(std::vector<MonomerMutation> mutations,
                                 QString description);
 
+    // `bases` holds raw atom pointers into the live molecule, so the receiver
+    // must consume them before it starts mutating the molecule.
+    void addComplementaryStrandRequested(
+        const std::unordered_set<const RDKit::Atom*>& bases);
+
   protected:
     void updateActions() override;
 
@@ -56,6 +61,7 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
     void createProtonateAction();
     void createMutateBaseSubMenu();
     void createSugarToggleAction();
+    void createAddComplementaryStrandAction();
     void createDeleteAction();
 
     QMenu* m_mutate_residue_menu = nullptr;
@@ -63,6 +69,12 @@ class SKETCHER_API MonomerContextMenu : public AbstractContextMenu
     QAction* m_protonate_action = nullptr;
     QMenu* m_mutate_base_menu = nullptr;
     QAction* m_sugar_toggle_action = nullptr;
+    QAction* m_add_complement_action = nullptr;
+
+    // Bases from the current selection that have a Watson-Crick complement.
+    // Computed once per updateActions() and reused both to set the action's
+    // enabled state and as the payload when the action is triggered.
+    std::unordered_set<const RDKit::Atom*> m_complement_bases;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
+#include <map>
 #include <variant>
 
 #include <fmt/format.h>
@@ -9,6 +11,7 @@
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/Bond.h>
 #include <rdkit/GraphMol/Conformer.h>
+#include <rdkit/GraphMol/MonomerInfo.h>
 #include <rdkit/GraphMol/MolOps.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <rdkit/GraphMol/SubstanceGroup.h>
@@ -28,6 +31,7 @@
 
 #include "schrodinger/rdkit_extensions/helm.h"
 #include "schrodinger/rdkit_extensions/molops.h"
+#include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/rdkit_extensions/rgroup.h"
 #include "schrodinger/sketcher/rdkit/sgroup.h"
@@ -169,6 +173,145 @@ void strip_notes_and_mol_model_tags(RDKit::ROMol& mol)
     for (auto& s_group : getSubstanceGroups(mol)) {
         s_group.clearProp(TAG_PROPERTY);
     }
+}
+
+/**
+ * @brief Per-base data needed to build one complement nucleotide (sugar, base,
+ * phosphate).
+ *
+ * @c original_base_idx is the index of the original base this nucleotide pairs
+ * with.
+ */
+struct ComplementNucleotide {
+    size_t original_base_idx;
+    std::string sugar_symbol;
+    std::string base_symbol;
+};
+
+/**
+ * @brief Group selected NA bases by their HELM polymer id.
+ *
+ * Atom indices are stored (not pointers) since pointers are invalidated by
+ * later edits. Null/non-base atoms are skipped. An ordered map keeps per-
+ * polymer processing deterministic, so the auto-numbered complement chains are
+ * reproducible.
+ *
+ * @param bases the selected atoms
+ * @return a map from polymer id to the contained base atom indices
+ */
+static std::map<std::string, std::vector<size_t>>
+group_bases_by_polymer(const std::unordered_set<const RDKit::Atom*>& bases)
+{
+    std::map<std::string, std::vector<size_t>> bases_by_polymer;
+    for (const auto* base : bases) {
+        if (base == nullptr || get_monomer_type(base) != MonomerType::NA_BASE) {
+            continue;
+        }
+        bases_by_polymer[rdkit_extensions::get_polymer_id(base)].push_back(
+            base->getIdx());
+    }
+    return bases_by_polymer;
+}
+
+/**
+ * @brief Resolve each base to the complement triplet that should pair with it.
+ *
+ * Bases without a Watson-Crick complement are skipped. The complement
+ * (A/U/T/G/C), sugar (R/dR), and phosphate (P) are all standard HELM monomers,
+ * so no monomer-DB lookup is needed.
+ *
+ * @param mol the monomer molecule
+ * @param base_idxs indices of the original base atoms (any order)
+ * @return one ComplementNucleotide per resolvable base, in residue-number order
+ */
+static std::vector<ComplementNucleotide>
+build_complement_nucleotides(const RDKit::ROMol& mol,
+                             std::vector<size_t> base_idxs)
+{
+    // Process in residue-number order, which matches HELM monomer ordering.
+    std::ranges::sort(base_idxs, {}, [&mol](size_t i) {
+        return rdkit_extensions::get_residue_number(mol.getAtomWithIdx(i));
+    });
+
+    std::vector<ComplementNucleotide> complement_nucleotides;
+    for (auto idx : base_idxs) {
+        const auto* base_atom = mol.getAtomWithIdx(idx);
+        const bool is_dna = is_dna_base(base_atom);
+        const auto base_symbol = get_monomer_res_name(base_atom);
+        auto complement_base_symbol =
+            is_dna ? get_dna_complement_base_symbol(base_symbol)
+                   : get_rna_complement_base_symbol(base_symbol);
+        if (!complement_base_symbol.has_value()) {
+            continue;
+        }
+        // Sugar identity (R vs dR) is per base to handle chimeric chains
+        // mixing R and dR within one polymer.
+        std::string sugar_symbol = is_dna ? "dR" : "R";
+        complement_nucleotides.push_back(
+            {idx, std::move(sugar_symbol), std::move(*complement_base_symbol)});
+    }
+    return complement_nucleotides;
+}
+
+/**
+ * @brief Capture the positions of the original bases up front.
+ *
+ * Needed because the modifying calls that follow invalidate any held conformer
+ * reference.
+ *
+ * @param mol the monomer molecule
+ * @param complement_nucleotides the complement nucleotides whose original
+ * bases to read
+ * @return each original base position, in @p complement_nucleotides order
+ */
+static std::vector<RDGeom::Point3D> get_base_positions(
+    const RDKit::ROMol& mol,
+    const std::vector<ComplementNucleotide>& complement_nucleotides)
+{
+    const auto& conf = mol.getConformer();
+    std::vector<RDGeom::Point3D> positions;
+    positions.reserve(complement_nucleotides.size());
+    for (const auto& complement : complement_nucleotides) {
+        positions.push_back(conf.getAtomPos(complement.original_base_idx));
+    }
+    return positions;
+}
+
+/**
+ * @brief Determine the direction from an original base toward its complement.
+ *
+ * The complement sits on the side of the base away from the base's own sugar,
+ * so deriving the axis from the geometry lets the complement follow a rotated
+ * or moved strand. Taken from the first base with a locatable sugar.
+ *
+ * @param mol the monomer molecule
+ * @param complement_nucleotides the complement nucleotides to inspect
+ * @return a unit vector toward the complement, or (0, -1) if no sugar is found
+ */
+static RDGeom::Point3D
+pairing_axis(const RDKit::ROMol& mol,
+             const std::vector<ComplementNucleotide>& complement_nucleotides)
+{
+    const auto& conf = mol.getConformer();
+    for (const auto& complement : complement_nucleotides) {
+        const auto* base_atom =
+            mol.getAtomWithIdx(complement.original_base_idx);
+        const auto& base_pos = conf.getAtomPos(complement.original_base_idx);
+        for (const auto* nbr : mol.atomNeighbors(base_atom)) {
+            if (get_monomer_type(nbr) != MonomerType::NA_SUGAR) {
+                continue;
+            }
+            const auto& sugar_pos = conf.getAtomPos(nbr->getIdx());
+            RDGeom::Point3D d(base_pos.x - sugar_pos.x,
+                              base_pos.y - sugar_pos.y, 0.0);
+            if (d.lengthSq() > 1e-6) {
+                d.normalize();
+                return d;
+            }
+            break; // a base has a single sugar; its position was degenerate
+        }
+    }
+    return RDGeom::Point3D(0.0, -1.0, 0.0);
 }
 
 } // namespace
@@ -937,6 +1080,122 @@ void MolModel::addMonomericConnection(const RDKit::Atom* const monomer_one,
                                           is_custom_bond);
     };
     doCommandUsingSnapshots(cmd_func, "Add monomeric connection",
+                            WhatChanged::MOLECULE);
+}
+
+void MolModel::addComplementaryStrand(
+    const std::unordered_set<const RDKit::Atom*>& selected_bases)
+{
+    auto bases_by_polymer = group_bases_by_polymer(selected_bases);
+    if (bases_by_polymer.empty()) {
+        return;
+    }
+    // One undo entry covers the complement chains for every source polymer.
+    auto undo_macro = createUndoMacro("Add Complementary Sequence");
+    for (const auto& [polymer_id, base_idxs] : bases_by_polymer) {
+        addComplementChainForPolymer(base_idxs);
+    }
+}
+
+void MolModel::addComplementChainForPolymer(
+    const std::vector<size_t>& base_idxs)
+{
+    const auto complement_nucleotides =
+        build_complement_nucleotides(m_mol, base_idxs);
+    if (complement_nucleotides.empty()) {
+        return;
+    }
+
+    // Capture base positions and the pairing axis up front: every modifying
+    // call below replaces m_mol's contents via snapshot restore, which
+    // invalidates any held conformer reference.
+    const auto orig_base_positions =
+        get_base_positions(m_mol, complement_nucleotides);
+    const RDGeom::Point3D pair_dir =
+        pairing_axis(m_mol, complement_nucleotides);
+    // Backbone axis: perpendicular to the pairing axis (-x for the canonical
+    // downward pair_dir).
+    const RDGeom::Point3D backbone_dir(pair_dir.y, -pair_dir.x, 0.0);
+    // Lay the complement out one monomer bond at a time so the spacing matches
+    // the rest of the monomer layout.
+    auto along = [](const RDGeom::Point3D& origin, const RDGeom::Point3D& dir,
+                    double dist) {
+        return RDGeom::Point3D(origin.x + dir.x * dist, origin.y + dir.y * dist,
+                               0.0);
+    };
+
+    // Build the complement chain antiparallel: iterate
+    // `complement_nucleotides` in reverse so the complement is constructed
+    // 5'→3' (paired with original 3'→5'). Record new atoms in chain order for
+    // the residue renumber below, so HELM PAIR sections round-trip without
+    // mis-targeting pairs.
+    size_t prev_phos_idx = std::numeric_limits<size_t>::max();
+    std::vector<size_t> new_chain_atom_idxs;
+    new_chain_atom_idxs.reserve(3 * complement_nucleotides.size());
+    for (size_t j = 0; j < complement_nucleotides.size(); ++j) {
+        const bool is_first = (j == 0);
+        const size_t complement_idx = complement_nucleotides.size() - 1 - j;
+        const auto& complement = complement_nucleotides[complement_idx];
+        const auto& orig_base_pos = orig_base_positions[complement_idx];
+
+        // Complement base sits across the pairing gap; its sugar one step
+        // further out so the new base faces back toward the original.
+        // Phosphate offsets along the backbone axis.
+        RDGeom::Point3D base_coord = along(
+            orig_base_pos, pair_dir, rdkit_extensions::MONOMER_BOND_LENGTH);
+        RDGeom::Point3D sugar_coord =
+            along(base_coord, pair_dir, rdkit_extensions::MONOMER_BOND_LENGTH);
+        RDGeom::Point3D phos_coord = along(
+            sugar_coord, backbone_dir, rdkit_extensions::MONOMER_BOND_LENGTH);
+
+        if (is_first) {
+            addMonomer(complement.sugar_symbol,
+                       rdkit_extensions::ChainType::RNA, sugar_coord);
+        } else {
+            addBoundMonomer(complement.sugar_symbol,
+                            rdkit_extensions::ChainType::RNA, sugar_coord,
+                            ap_model_name_for(NASugarAP::FIVE_PRIME),
+                            m_mol.getAtomWithIdx(prev_phos_idx),
+                            ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR));
+        }
+        const size_t new_sugar_idx = m_mol.getNumAtoms() - 1;
+        new_chain_atom_idxs.push_back(new_sugar_idx);
+
+        addBoundMonomer(complement.base_symbol,
+                        rdkit_extensions::ChainType::RNA, base_coord,
+                        ap_model_name_for(NA_BASE_AP_N1_9),
+                        m_mol.getAtomWithIdx(new_sugar_idx),
+                        ap_model_name_for(NASugarAP::ONE_PRIME));
+        const size_t new_base_idx = m_mol.getNumAtoms() - 1;
+        new_chain_atom_idxs.push_back(new_base_idx);
+
+        addBoundMonomer("P", rdkit_extensions::ChainType::RNA, phos_coord,
+                        ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR),
+                        m_mol.getAtomWithIdx(new_sugar_idx),
+                        ap_model_name_for(NASugarAP::THREE_PRIME));
+        prev_phos_idx = m_mol.getNumAtoms() - 1;
+        new_chain_atom_idxs.push_back(prev_phos_idx);
+
+        addMonomericConnection(
+            m_mol.getAtomWithIdx(complement.original_base_idx), NA_BASE_AP_PAIR,
+            m_mol.getAtomWithIdx(new_base_idx), NA_BASE_AP_PAIR);
+    }
+
+    // Renumber the new chain's residues 1..N in chain order so the HELM PAIR
+    // section (which references residue numbers) maps to the correct monomer
+    // after round-tripping through the parser.
+    auto renumber = [this, new_chain_atom_idxs]() {
+        for (size_t i = 0; i < new_chain_atom_idxs.size(); ++i) {
+            auto* atom = m_mol.getAtomWithIdx(new_chain_atom_idxs[i]);
+            auto* info = dynamic_cast<RDKit::AtomPDBResidueInfo*>(
+                atom->getMonomerInfo());
+            if (info == nullptr) {
+                continue;
+            }
+            info->setResidueNumber(static_cast<int>(i + 1));
+        }
+    };
+    doCommandUsingSnapshots(renumber, "Renumber monomer residues",
                             WhatChanged::MOLECULE);
 }
 

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -450,6 +450,14 @@ class SKETCHER_API MolModel : public AbstractUndoableModel
                                 const std::string& ap_name_two);
 
     /**
+     * Undoably add antiparallel Watson-Crick complement chain(s) for the
+     * given NA bases (grouped per polymer), linked back via "pair"
+     * connections. Bases without a DB complement are silently skipped.
+     */
+    void addComplementaryStrand(
+        const std::unordered_set<const RDKit::Atom*>& selected_bases);
+
+    /**
      * Undoably add a chain of atoms, where each atom is bound to the previous
      * and next atoms in the chain.
      *
@@ -1385,6 +1393,14 @@ class SKETCHER_API MolModel : public AbstractUndoableModel
                                            const size_t bond_end_idx,
                                            const std::string& linkage,
                                            const bool is_custom_bond);
+
+    /**
+     * Build and add one antiparallel complement chain for the given original
+     * NA base atom indices (a single source polymer), linking each new base
+     * back to its original via a "pair" connection. A no-op if no base has a
+     * usable DB complement. Must be called within an open undo macro.
+     */
+    void addComplementChainForPolymer(const std::vector<size_t>& base_idxs);
 
     /**
      * Add a non-molecular object (a plus sign or a reaction arrow).  This

--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -35,6 +35,13 @@ const std::string PEPTIDE_POLYMER_PREFIX = "PEPTIDE";
 // According to HELM, DNA is a subtype of RNA, so DNA also uses the RNA prefix
 const std::string NUCLEOTIDE_POLYMER_PREFIX = "RNA";
 
+const std::unordered_map<std::string_view, std::string_view>
+    DNA_BASE_COMPLEMENTS = {
+        {"A", "T"}, {"T", "A"}, {"U", "A"}, {"G", "C"}, {"C", "G"}};
+const std::unordered_map<std::string_view, std::string_view>
+    RNA_BASE_COMPLEMENTS = {
+        {"A", "U"}, {"T", "A"}, {"U", "A"}, {"G", "C"}, {"C", "G"}};
+
 // "Pretty" names for attachment points that are normally represented as "R#"
 // Note that the primes use apostrophes instead of a Unicode prime to avoid
 // issues with C++′s handling of Unicode.
@@ -71,6 +78,17 @@ const std::unordered_map<Direction, std::vector<Direction>>
 class NoAvailableDirectionsException : public std::exception
 {
 };
+
+std::optional<std::string> lookup_complement_base_symbol(
+    const std::unordered_map<std::string_view, std::string_view>& complements,
+    const std::string_view base_symbol)
+{
+    const auto complement = complements.find(base_symbol);
+    if (complement == complements.end()) {
+        return std::nullopt;
+    }
+    return std::string(complement->second);
+}
 
 } // namespace
 
@@ -128,6 +146,39 @@ std::string get_monomer_res_name(const RDKit::Atom* const monomer)
         return monomer_info->getName();
     }
     return res_info->getResidueName();
+}
+
+bool is_dna_base(const RDKit::Atom* const base)
+{
+    if (get_monomer_type(base) != MonomerType::NA_BASE) {
+        throw std::runtime_error("is_dna_base requires an NA_BASE atom");
+    }
+    const auto& mol = base->getOwningMol();
+    for (const auto* neighbor : mol.atomNeighbors(base)) {
+        if (get_monomer_type(neighbor) == MonomerType::NA_SUGAR &&
+            get_monomer_res_name(neighbor) == "dR") {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::optional<std::string>
+get_dna_complement_base_symbol(const std::string_view base_symbol)
+{
+    return lookup_complement_base_symbol(DNA_BASE_COMPLEMENTS, base_symbol);
+}
+
+std::optional<std::string>
+get_rna_complement_base_symbol(const std::string_view base_symbol)
+{
+    return lookup_complement_base_symbol(RNA_BASE_COMPLEMENTS, base_symbol);
+}
+
+bool na_base_has_complement(const std::string_view base_symbol)
+{
+    return DNA_BASE_COMPLEMENTS.contains(base_symbol) ||
+           RNA_BASE_COMPLEMENTS.contains(base_symbol);
 }
 
 bool contains_two_monomer_linkages(const RDKit::Bond* bond)

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <concepts>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -137,6 +139,38 @@ get_na_monomer_type_from_res_name(const std::string_view res_name);
  * Determine the text to use for the name of the given monomer
  */
 SKETCHER_API std::string get_monomer_res_name(const RDKit::Atom* const monomer);
+
+/**
+ * @return true if the given NA base atom is part of a DNA strand, i.e. its
+ * bound sugar's residue name is "dR". Returns false for RNA bases (sugar "R")
+ * and for bases with no bound sugar or a non-standard sugar.
+ *
+ * @throw std::runtime_error if the atom does not represent an NA_BASE monomer.
+ */
+SKETCHER_API bool is_dna_base(const RDKit::Atom* const base);
+
+/**
+ * @return the Watson-Crick DNA complement symbol for the given nucleic acid
+ * base residue name, or std::nullopt if the symbol has no standard complement.
+ * @param base_symbol the residue name of the base (e.g. "A", "G")
+ */
+SKETCHER_API std::optional<std::string>
+get_dna_complement_base_symbol(const std::string_view base_symbol);
+
+/**
+ * @return the Watson-Crick RNA complement symbol for the given nucleic acid
+ * base residue name, or std::nullopt if the symbol has no standard complement.
+ * @param base_symbol the residue name of the base (e.g. "A", "G")
+ */
+SKETCHER_API std::optional<std::string>
+get_rna_complement_base_symbol(const std::string_view base_symbol);
+
+/**
+ * @return true if the given nucleic acid base residue name has a standard
+ * Watson-Crick complement. Existence is independent of the DNA/RNA target, so
+ * this is suitable for gating UI before the target strand type is known.
+ */
+SKETCHER_API bool na_base_has_complement(const std::string_view base_symbol);
 
 /**
  * @return whether the given bond represents two connections between the same

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -1022,6 +1022,11 @@ void SketcherWidget::connectContextMenu(const MonomerContextMenu& menu)
                     m_mol_model->mutateMonomers(resolved, sym, target_type);
                 }
             });
+
+    connect(&menu, &MonomerContextMenu::addComplementaryStrandRequested, this,
+            [this](const auto& bases) {
+                m_mol_model->addComplementaryStrand(bases);
+            });
 }
 
 void SketcherWidget::connectContextMenu(const ModifyAtomsMenu& menu)

--- a/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
+++ b/test/schrodinger/sketcher/menu/test_monomer_context_menu.cpp
@@ -81,6 +81,22 @@ struct MutateRequestCapture {
     }
 };
 
+// Captures the most recent `addComplementaryStrandRequested` emission.
+struct ComplementRequestCapture {
+    std::unordered_set<const RDKit::Atom*> last_bases;
+    int call_count = 0;
+
+    void connectTo(MonomerContextMenu& menu)
+    {
+        QObject::connect(&menu,
+                         &MonomerContextMenu::addComplementaryStrandRequested,
+                         &menu, [this](auto bases) {
+                             last_bases = std::move(bases);
+                             ++call_count;
+                         });
+    }
+};
+
 // RAII helper for tests that need to inject custom monomer definitions.
 // Pairs with the LocalMonomerDbFixture global fixture, which redirects
 // the singleton to a per-binary scratch DB so we never touch the user's
@@ -895,6 +911,104 @@ BOOST_AUTO_TEST_CASE(test_custom_dna_registered_sugar_pair_enables_toggle)
 
     BOOST_REQUIRE(capture.last_mutations.size() == 1u);
     BOOST_TEST(capture.last_mutations[0].helm_symbol == "dYur");
+}
+
+/**
+ * "Add Complementary Sequence" hides for peptide selections — it only
+ * makes sense for nucleic acids.
+ */
+BOOST_AUTO_TEST_CASE(test_complement_action_hidden_for_peptide_selection)
+{
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* action = find_action(menu, "Add Complementary Sequence");
+    BOOST_REQUIRE(action != nullptr);
+    BOOST_TEST(!action->isVisible());
+}
+
+/**
+ * NA selection containing only sugars/phosphates (no bases) hides the
+ * action — there's nothing to complement.
+ */
+BOOST_AUTO_TEST_CASE(test_complement_action_hidden_for_no_bases)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    // atoms 0=R sugar, 1=A base, 2=P phosphate
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {0, 2}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* action = find_action(menu, "Add Complementary Sequence");
+    BOOST_REQUIRE(action != nullptr);
+    BOOST_TEST(!action->isVisible());
+}
+
+/**
+ * A single NA base selection enables the action.
+ */
+BOOST_AUTO_TEST_CASE(test_complement_action_visible_for_single_base)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    menu.setContextItems(atoms_from(*mol, {1}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* action = find_action(menu, "Add Complementary Sequence");
+    BOOST_REQUIRE(action != nullptr);
+    BOOST_TEST(action->isVisible());
+    BOOST_TEST(action->isEnabled());
+}
+
+/**
+ * Selection containing both bases and backbone monomers stays enabled —
+ * the action filters down to the bases when it emits.
+ */
+BOOST_AUTO_TEST_CASE(test_complement_action_visible_for_mixed_na_selection)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    ComplementRequestCapture capture;
+    capture.connectTo(menu);
+    menu.setContextItems(atoms_from(*mol, {0, 1, 2}), {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* action = find_action(menu, "Add Complementary Sequence");
+    BOOST_REQUIRE(action != nullptr);
+    BOOST_TEST(action->isVisible());
+    BOOST_TEST(action->isEnabled());
+    action->trigger();
+
+    BOOST_TEST(capture.call_count == 1);
+    BOOST_REQUIRE(capture.last_bases.size() == 1u);
+    BOOST_TEST(*capture.last_bases.begin() == mol->getAtomWithIdx(1));
+}
+
+/**
+ * Mixing an NA base with a peptide hides the action — the spec restricts
+ * it to "bases or full NAs only".
+ */
+BOOST_AUTO_TEST_CASE(test_complement_action_hidden_for_mixed_with_peptide)
+{
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R(A)P}|PEPTIDE1{A}$$$$V2.0");
+    TestMonomerContextMenu menu;
+    // atom 1 = RNA base A, atom 3 = PEPTIDE A (positions depend on parse
+    // order; verify with a quick monomer-type check).
+    std::unordered_set<const RDKit::Atom*> sel;
+    for (const auto* a : mol->atoms()) {
+        if (get_monomer_type(a) == MonomerType::NA_BASE ||
+            get_monomer_type(a) == MonomerType::PEPTIDE) {
+            sel.insert(a);
+        }
+    }
+    menu.setContextItems(sel, {}, {}, {}, {});
+    menu.updateActions();
+
+    auto* action = find_action(menu, "Add Complementary Sequence");
+    BOOST_REQUIRE(action != nullptr);
+    BOOST_TEST(!action->isVisible());
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -5120,6 +5120,154 @@ BOOST_AUTO_TEST_CASE(test_addMonomericConnection_pairing_two_nucleotides)
 }
 
 /**
+ * Single RNA base → one antiparallel complement nucleotide on a new RNA
+ * chain, paired via the standard "pair" connection. Confirms the HELM
+ * round-trip captures both the new chain and the pair annotation.
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_single_RNA_base)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{R(A)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Atom 1 is the A base (sugar=0, base=1, phosphate=2).
+    model.addComplementaryStrand({mol->getAtomWithIdx(1)});
+
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm ==
+               "RNA1{R(A)P}|RNA2{R(U)P}$RNA1,RNA2,2:pair-2:pair$$$V2.0");
+}
+
+/**
+ * DNA strand (sugar = dR) selects the DNA complement table: A→T, C→G.
+ * Antiparallel order: original 5'-AC-3' produces complement 5'-GT-3'.
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_DNA_strand)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{[dR](A)P.[dR](C)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Bases are at atoms 1 (A) and 4 (C) for [dR](A)P.[dR](C)P.
+    model.addComplementaryStrand(
+        {mol->getAtomWithIdx(1), mol->getAtomWithIdx(4)});
+
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{[dR](A)P.[dR](C)P}|RNA2{[dR](G)P.[dR](T)P}$"
+                       "RNA1,RNA2,5:pair-2:pair|"
+                       "RNA1,RNA2,2:pair-5:pair$$$V2.0");
+}
+
+/**
+ * Selecting only one base of a multi-base strand complements just that
+ * base — the spec is "complement only the selected bases".
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_partial_selection)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{R(A)P.R(C)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Pick only the second base (C at atom 4); first base (A at atom 1)
+    // should be left unpaired.
+    model.addComplementaryStrand({mol->getAtomWithIdx(4)});
+
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{R(A)P.R(C)P}|RNA2{R(G)P}$"
+                       "RNA1,RNA2,5:pair-2:pair$$$V2.0");
+}
+
+/**
+ * The whole construction lives in one undo macro: a single QUndoStack
+ * undo() reverses the entire complement strand and all pair connections.
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_grouped_undo)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{R(A)P.R(C)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    auto before = get_mol_text(&model, Format::HELM);
+    model.addComplementaryStrand(
+        {mol->getAtomWithIdx(1), mol->getAtomWithIdx(4)});
+    auto after = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(after != before);
+
+    undo_stack.undo();
+    BOOST_TEST(get_mol_text(&model, Format::HELM) == before);
+}
+
+/**
+ * Non-base atoms (sugars, phosphates) in the input are filtered out and
+ * the molecule is unchanged. (The model-side complement-table-miss path
+ * is a coverage gap — needs LocalMonomerDbFixture wiring.)
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_filters_non_base_atoms)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{R(A)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Pass the sugar (atom 0) — wrong type, should be ignored entirely.
+    model.addComplementaryStrand({mol->getAtomWithIdx(0)});
+
+    BOOST_TEST(get_mol_text(&model, Format::HELM) == "RNA1{R(A)P}$$$$V2.0");
+}
+
+/**
+ * Bases selected from two different polymers each get their own
+ * antiparallel complement chain, with pair connections targeting the
+ * correct source.
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_multi_polymer)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    add_text_to_mol_model(model, "RNA1{R(A)P}|RNA2{R(C)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Bases are at atoms 1 (RNA1's A) and 4 (RNA2's C).
+    model.addComplementaryStrand(
+        {mol->getAtomWithIdx(1), mol->getAtomWithIdx(4)});
+
+    auto helm = get_mol_text(&model, Format::HELM);
+    BOOST_TEST(helm == "RNA1{R(A)P}|RNA2{R(C)P}|RNA3{R(U)P}|RNA4{R(G)P}$"
+                       "RNA1,RNA3,2:pair-2:pair|"
+                       "RNA2,RNA4,2:pair-2:pair$$$V2.0");
+}
+
+/**
+ * Chimeric polymer (R and dR sugars in one chain) — each base picks its
+ * own sugar type for the complement, so we get e.g. dR for the DNA base
+ * and R for the RNA base in the same complement strand.
+ */
+BOOST_AUTO_TEST_CASE(test_addComplementaryStrand_chimeric_chain)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    // RNA sugar + A base, then DNA sugar + C base, in one chain.
+    add_text_to_mol_model(model, "RNA1{R(A)P.[dR](C)P}$$$$V2.0");
+
+    const auto* mol = model.getMol();
+    // Bases are at atoms 1 (RNA A) and 4 (DNA C).
+    model.addComplementaryStrand(
+        {mol->getAtomWithIdx(1), mol->getAtomWithIdx(4)});
+
+    auto helm = get_mol_text(&model, Format::HELM);
+    // Antiparallel: complement strand 5'→3' starts from the partner of
+    // the original 3' end, so [dR](G) (DNA G, paired with the dR-C)
+    // comes first, then R(U) (RNA U, paired with the R-A).
+    BOOST_TEST(helm == "RNA1{R(A)P.[dR](C)P}|RNA2{[dR](G)P.R(U)P}$"
+                       "RNA1,RNA2,5:pair-2:pair|"
+                       "RNA1,RNA2,2:pair-5:pair$$$V2.0");
+}
+
+/**
  * Make sure that adding disconnected monomers via addMonomer results in the
  * expected HELM strings, which should contain properly numbered chains without
  * any connection between the monomers.

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -20,6 +20,33 @@ namespace sketcher
 {
 
 /**
+ * DNA and RNA use separate complement tables so adenine resolves to thymine
+ * for DNA and uracil for RNA. The remaining standard pairings are shared.
+ */
+BOOST_AUTO_TEST_CASE(test_complement_base_symbols)
+{
+    const auto dna_a = get_dna_complement_base_symbol("A");
+    const auto rna_a = get_rna_complement_base_symbol("A");
+    BOOST_REQUIRE(dna_a.has_value());
+    BOOST_REQUIRE(rna_a.has_value());
+    BOOST_TEST(*dna_a == "T");
+    BOOST_TEST(*rna_a == "U");
+
+    const auto dna_g = get_dna_complement_base_symbol("G");
+    const auto rna_g = get_rna_complement_base_symbol("G");
+    BOOST_REQUIRE(dna_g.has_value());
+    BOOST_REQUIRE(rna_g.has_value());
+    BOOST_TEST(*dna_g == "C");
+    BOOST_TEST(*rna_g == "C");
+
+    BOOST_TEST(!get_dna_complement_base_symbol("X").has_value());
+    BOOST_TEST(!get_rna_complement_base_symbol("X").has_value());
+    BOOST_TEST(na_base_has_complement("T"));
+    BOOST_TEST(na_base_has_complement("U"));
+    BOOST_TEST(!na_base_has_complement("X"));
+}
+
+/**
  * Make sure that contains_two_monomer_linkages correctly detects two monomer
  * linkages in the same bond when there's a disulfide bond between neighboring
  * cysteines.


### PR DESCRIPTION
- Linked Case: SKETCH-2763

### Description

This revision offers support for the generation of a complement strand for a selected set of nucleic acids.

Adds a menu option to generate the complement whenever a set of nucleic acids are selected; mixed selections disables the option.

Ordering and pointer invalidation is a bit tricky for building up the sequences in this way, so we employ an index-based strategy to build up the nascent chain for each polymer.

### Testing Done

Adds some tests for conditions where menus should show, generation of complement, and undo.
