### PR TITLE
SKETCH-2754: Bound monomeric attachments points are now labeled on hover with the select, erase, and move tools

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
@@ -1,5 +1,7 @@
 #include "schrodinger/sketcher/molviewer/abstract_highlighting_item.h"
 
+#include <functional>
+
 #include <QList>
 
 namespace schrodinger
@@ -25,7 +27,7 @@ void AbstractHighlightingItem::clearHighlightingPath()
     setHighlightingPath(QPainterPath());
 }
 
-void AbstractHighlightingItem::highlightItem(QGraphicsItem* const item)
+void AbstractHighlightingItem::highlightItem(const QGraphicsItem* const item)
 {
     highlightItems({item});
 }
@@ -33,26 +35,37 @@ void AbstractHighlightingItem::highlightItem(QGraphicsItem* const item)
 void AbstractHighlightingItem::highlightItems(
     const QList<QGraphicsItem*>& items)
 {
+    // Convert to const pointers and delegate to the const version
+    QList<const QGraphicsItem*> const_items;
+    std::ranges::transform(items, std::back_inserter(const_items),
+                           std::identity{});
+    highlightItems(const_items);
+}
+
+void AbstractHighlightingItem::highlightItems(
+    const QList<const QGraphicsItem*>& items)
+{
     auto updated_items = updateItemsToHighlight(items);
     QPainterPath path = buildHighlightingPathForItems(updated_items);
     setHighlightingPath(path);
 }
 
-QList<QGraphicsItem*> AbstractHighlightingItem::updateItemsToHighlight(
-    const QList<QGraphicsItem*>& items) const
+QList<const QGraphicsItem*> AbstractHighlightingItem::updateItemsToHighlight(
+    const QList<const QGraphicsItem*>& items) const
 {
     return items;
 }
 
 QPainterPath AbstractHighlightingItem::buildHighlightingPathForItems(
-    const QList<QGraphicsItem*>& items) const
+    const QList<const QGraphicsItem*>& items) const
 {
     QPainterPath path;
     // Set fill rule to ensure overlapping areas don't create "holes"
     path.setFillRule(Qt::WindingFill);
 
     for (auto item : items) {
-        if (auto* molviewer_item = dynamic_cast<AbstractGraphicsItem*>(item)) {
+        if (auto* molviewer_item =
+                dynamic_cast<const AbstractGraphicsItem*>(item)) {
             QPainterPath local_path = getPathForItem(molviewer_item);
             path.addPath(molviewer_item->mapToScene(local_path));
         }

--- a/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.h
+++ b/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.h
@@ -26,11 +26,16 @@ class AbstractHighlightingItem : public QGraphicsPathItem
      * Clear any existing highlighting and highlight only the specified graphics
      * item.
      */
-    void highlightItem(QGraphicsItem* const item);
+    void highlightItem(const QGraphicsItem* const item);
 
     /**
      * Clear any existing highlighting and highlight all specified graphics
      * items.
+     */
+    void highlightItems(const QList<const QGraphicsItem*>& items);
+
+    /**
+     * @overload for non-const QGraphicsItem pointers
      */
     void highlightItems(const QList<QGraphicsItem*>& items);
 
@@ -51,7 +56,7 @@ class AbstractHighlightingItem : public QGraphicsPathItem
      * Get the painter path to use for highlighting the specified graphics item.
      */
     virtual QPainterPath
-    getPathForItem(AbstractGraphicsItem* const item) const = 0;
+    getPathForItem(const AbstractGraphicsItem* const item) const = 0;
 
     /**
      * Modify the list of items to highlight immediately prior to highlighting.
@@ -59,14 +64,14 @@ class AbstractHighlightingItem : public QGraphicsPathItem
      * but subclasses may override this method to change which items get
      * highlighted.
      */
-    virtual QList<QGraphicsItem*>
-    updateItemsToHighlight(const QList<QGraphicsItem*>& items) const;
+    virtual QList<const QGraphicsItem*>
+    updateItemsToHighlight(const QList<const QGraphicsItem*>& items) const;
 
     /**
      * Create a painter path highlighting all specified graphics items.
      */
-    QPainterPath
-    buildHighlightingPathForItems(const QList<QGraphicsItem*>& items) const;
+    QPainterPath buildHighlightingPathForItems(
+        const QList<const QGraphicsItem*>& items) const;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/halo_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/halo_highlighting_item.cpp
@@ -19,8 +19,8 @@ HaloHighlightingItem::HaloHighlightingItem(qreal z_value) :
     setZValue(z_value);
 }
 
-QPainterPath
-HaloHighlightingItem::getPathForItem(AbstractGraphicsItem* const item) const
+QPainterPath HaloHighlightingItem::getPathForItem(
+    const AbstractGraphicsItem* const item) const
 {
     return item->selectionHighlightingPath();
 }

--- a/src/schrodinger/sketcher/molviewer/halo_highlighting_item.h
+++ b/src/schrodinger/sketcher/molviewer/halo_highlighting_item.h
@@ -17,7 +17,7 @@ class HaloHighlightingItem : public AbstractHighlightingItem
     HaloHighlightingItem(qreal z_value);
 
     QPainterPath
-    getPathForItem(AbstractGraphicsItem* const item) const override;
+    getPathForItem(const AbstractGraphicsItem* const item) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/predictive_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/predictive_highlighting_item.cpp
@@ -21,13 +21,13 @@ PredictiveHighlightingItem::PredictiveHighlightingItem() :
 }
 
 QPainterPath PredictiveHighlightingItem::getPathForItem(
-    AbstractGraphicsItem* const item) const
+    const AbstractGraphicsItem* const item) const
 {
     return item->predictiveHighlightingPath();
 }
 
-QList<QGraphicsItem*> PredictiveHighlightingItem::updateItemsToHighlight(
-    const QList<QGraphicsItem*>& items) const
+QList<const QGraphicsItem*> PredictiveHighlightingItem::updateItemsToHighlight(
+    const QList<const QGraphicsItem*>& items) const
 {
     if (auto molviewer_scene = dynamic_cast<Scene*>(scene())) {
         return molviewer_scene->ensureCompleteAttachmentPoints(items);

--- a/src/schrodinger/sketcher/molviewer/predictive_highlighting_item.h
+++ b/src/schrodinger/sketcher/molviewer/predictive_highlighting_item.h
@@ -18,10 +18,10 @@ class PredictiveHighlightingItem : public AbstractHighlightingItem
 
     // overriden AbstractHighlightingItem methods
     QPainterPath
-    getPathForItem(AbstractGraphicsItem* const item) const override;
+    getPathForItem(const AbstractGraphicsItem* const item) const override;
 
-    QList<QGraphicsItem*>
-    updateItemsToHighlight(const QList<QGraphicsItem*>& items) const override;
+    QList<const QGraphicsItem*> updateItemsToHighlight(
+        const QList<const QGraphicsItem*>& items) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -570,14 +570,15 @@ Scene::getCollidingItemsUsingBondMidpoints(QGraphicsItem* item) const
     return filtered_items;
 }
 
-QList<QGraphicsItem*>
-Scene::ensureCompleteAttachmentPoints(const QList<QGraphicsItem*>& items) const
+QList<const QGraphicsItem*> Scene::ensureCompleteAttachmentPoints(
+    const QList<const QGraphicsItem*>& items) const
 {
     // make sure that .find() calls are O(1) instead of O(N)
-    std::unordered_set<QGraphicsItem*> items_set(items.begin(), items.end());
-    QList<QGraphicsItem*> new_items;
+    std::unordered_set<const QGraphicsItem*> items_set(items.begin(),
+                                                       items.end());
+    QList<const QGraphicsItem*> new_items;
     for (auto* item : items) {
-        if (const auto* atom_item = qgraphicsitem_cast<AtomItem*>(item)) {
+        if (const auto* atom_item = qgraphicsitem_cast<const AtomItem*>(item)) {
             const auto* atom = atom_item->getAtom();
             if (const RDKit::Bond* ap_bond = get_attachment_point_bond(atom)) {
                 auto* bond_item = m_bond_to_bond_item.at(ap_bond);
@@ -585,7 +586,8 @@ Scene::ensureCompleteAttachmentPoints(const QList<QGraphicsItem*>& items) const
                     new_items.push_back(bond_item);
                 }
             }
-        } else if (auto* bond_item = qgraphicsitem_cast<BondItem*>(item)) {
+        } else if (const auto* bond_item =
+                       qgraphicsitem_cast<const BondItem*>(item)) {
             const auto* bond = bond_item->getBond();
             if (const RDKit::Atom* ap_atom = get_attachment_point_atom(bond)) {
                 auto* atom_item = m_atom_to_atom_item.at(ap_atom);
@@ -665,9 +667,9 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
     auto draw_tool = m_sketcher_model->getDrawTool();
     if (draw_tool == DrawTool::SELECT) {
         auto select_tool = m_sketcher_model->getSelectionTool();
-        return get_select_scene_tool(select_tool, this, m_mol_model);
+        return get_select_scene_tool(select_tool, m_fonts, this, m_mol_model);
     } else if (draw_tool == DrawTool::ERASE) {
-        return std::make_shared<EraseSceneTool>(this, m_mol_model);
+        return std::make_shared<EraseSceneTool>(m_fonts, this, m_mol_model);
     } else if (draw_tool == DrawTool::ATOM) {
         auto atom_tool = m_sketcher_model->getAtomTool();
         if (atom_tool == AtomTool::ELEMENT) {
@@ -683,14 +685,15 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
         auto bond_tool = m_sketcher_model->getBondTool();
         if (BOND_TOOL_BOND_MAP.count(bond_tool)) {
             // a non-query bond
-            return std::make_shared<DrawBondSceneTool>(bond_tool, this,
+            return std::make_shared<DrawBondSceneTool>(bond_tool, m_fonts, this,
                                                        m_mol_model);
         } else if (BOND_TOOL_QUERY_MAP.count(bond_tool)) {
             // a query bond
             return std::make_shared<DrawBondQuerySceneTool>(bond_tool, m_fonts,
                                                             this, m_mol_model);
         } else if (bond_tool == BondTool::ATOM_CHAIN) {
-            return std::make_shared<DrawChainSceneTool>(this, m_mol_model);
+            return std::make_shared<DrawChainSceneTool>(m_fonts, this,
+                                                        m_mol_model);
         }
     } else if (draw_tool == DrawTool::ENUMERATION) {
         switch (m_sketcher_model->getEnumerationTool()) {
@@ -703,33 +706,35 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
                     m_fonts, this, m_mol_model);
             case EnumerationTool::ATTACHMENT_POINT:
                 return std::make_shared<DrawAttachmentPointSceneTool>(
-                    this, m_mol_model);
+                    m_fonts, this, m_mol_model);
             case EnumerationTool::RXN_ARROW:
                 return std::make_shared<ArrowPlusSceneTool>(
-                    NonMolecularType::RXN_ARROW, this, m_mol_model);
+                    NonMolecularType::RXN_ARROW, m_fonts, this, m_mol_model);
             case EnumerationTool::RXN_PLUS:
                 return std::make_shared<ArrowPlusSceneTool>(
-                    NonMolecularType::RXN_PLUS, this, m_mol_model);
+                    NonMolecularType::RXN_PLUS, m_fonts, this, m_mol_model);
             case EnumerationTool::ADD_MAPPING:
                 return std::make_shared<AtomMappingSceneTool>(
-                    MappingAction::ADD, this, m_mol_model);
+                    MappingAction::ADD, m_fonts, this, m_mol_model);
             case EnumerationTool::REMOVE_MAPPING:
                 return std::make_shared<AtomMappingSceneTool>(
-                    MappingAction::REMOVE, this, m_mol_model);
+                    MappingAction::REMOVE, m_fonts, this, m_mol_model);
         }
     } else if (draw_tool == DrawTool::CHARGE) {
         auto charge_tool = m_sketcher_model->getChargeTool();
-        return std::make_shared<EditChargeSceneTool>(charge_tool, this,
+        return std::make_shared<EditChargeSceneTool>(charge_tool, m_fonts, this,
                                                      m_mol_model);
     } else if (draw_tool == DrawTool::MOVE_ROTATE) {
-        return std::make_shared<MoveRotateSceneTool>(this, m_mol_model);
+        return std::make_shared<MoveRotateSceneTool>(m_fonts, this,
+                                                     m_mol_model);
     } else if (draw_tool == DrawTool::RING) {
         auto ring_tool = m_sketcher_model->getRingTool();
         return get_draw_fragment_scene_tool(
             ring_tool, m_fonts, *m_sketcher_model->getAtomDisplaySettingsPtr(),
             *m_sketcher_model->getBondDisplaySettingsPtr(), this, m_mol_model);
     } else if (draw_tool == DrawTool::EXPLICIT_H) {
-        return std::make_shared<ExplicitHsSceneTool>(this, m_mol_model);
+        return std::make_shared<ExplicitHsSceneTool>(m_fonts, this,
+                                                     m_mol_model);
     } else if (draw_tool == DrawTool::MONOMER) {
         auto monomer_tool_type = m_sketcher_model->getMonomerToolType();
         if (monomer_tool_type == MonomerToolType::AMINO_ACID) {

--- a/src/schrodinger/sketcher/molviewer/scene.h
+++ b/src/schrodinger/sketcher/molviewer/scene.h
@@ -153,8 +153,8 @@ class SKETCHER_API Scene : public QGraphicsScene
      * attachment point dummy atom *and* the associated bond if either the atom
      * *or* the bond are included in the input list.
      */
-    QList<QGraphicsItem*>
-    ensureCompleteAttachmentPoints(const QList<QGraphicsItem*>& items) const;
+    QList<const QGraphicsItem*> ensureCompleteAttachmentPoints(
+        const QList<const QGraphicsItem*>& items) const;
 
     /**
      * display the appropriate context menu at the given position

--- a/src/schrodinger/sketcher/molviewer/selection_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/selection_highlighting_item.cpp
@@ -20,7 +20,7 @@ SelectionHighlightingItem::SelectionHighlightingItem() :
 }
 
 QPainterPath SelectionHighlightingItem::getPathForItem(
-    AbstractGraphicsItem* const item) const
+    const AbstractGraphicsItem* const item) const
 {
     return item->selectionHighlightingPath();
 }

--- a/src/schrodinger/sketcher/molviewer/selection_highlighting_item.h
+++ b/src/schrodinger/sketcher/molviewer/selection_highlighting_item.h
@@ -17,7 +17,7 @@ class SelectionHighlightingItem : public AbstractHighlightingItem
     SelectionHighlightingItem();
 
     QPainterPath
-    getPathForItem(AbstractGraphicsItem* const item) const override;
+    getPathForItem(const AbstractGraphicsItem* const item) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/abstract_draw_atom_bond_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_atom_bond_scene_tool.cpp
@@ -27,9 +27,9 @@ HintBondItem::HintBondItem(QGraphicsItem* parent) : QGraphicsLineItem(parent)
     setVisible(false);
 }
 
-AbstractDrawSceneTool::AbstractDrawSceneTool(Scene* scene,
+AbstractDrawSceneTool::AbstractDrawSceneTool(const Fonts& fonts, Scene* scene,
                                              MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model)
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
     m_highlight_types = InteractiveItemFlag::MOLECULAR_NOT_AP;
 }

--- a/src/schrodinger/sketcher/tool/abstract_draw_atom_bond_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_atom_bond_scene_tool.h
@@ -42,7 +42,8 @@ class HintBondItem : public QGraphicsLineItem
 class SKETCHER_API AbstractDrawSceneTool : public StandardSceneToolBase
 {
   public:
-    AbstractDrawSceneTool(Scene* scene, MolModel* mol_model);
+    AbstractDrawSceneTool(const Fonts& fonts, Scene* scene,
+                          MolModel* mol_model);
 
     // Reimplemented AbstractSceneTool methods
     std::vector<QGraphicsItem*> getGraphicsItems() override;

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
@@ -51,6 +51,7 @@ void AbstractMonomerSceneTool::updateColorsAfterBackgroundColorChange(
 
 void AbstractMonomerSceneTool::onStructureUpdated()
 {
+    StandardSceneToolBase::onStructureUpdated();
     // the unbound attachment point items themselves were children of their
     // respective monomers, so Qt destroyed them when the monomers were
     // destroyed. We just need to clear out the stale pointers here.

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
@@ -1,19 +1,13 @@
 #include "schrodinger/sketcher/tool/abstract_monomer_scene_tool.h"
 
-#include <algorithm>
-#include <cmath>
 #include <vector>
 
 #include <QGraphicsItem>
-#include <QPainterPath>
 
 #include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
-#include "schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h"
 #include "schrodinger/sketcher/molviewer/monomer_connector_item.h"
 #include "schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h"
-#include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/molviewer/scene.h"
-#include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
 
 namespace schrodinger
@@ -30,30 +24,11 @@ get_default_coords_for_bound_monomer(const RDGeom::Point3D monomer_pos,
     return monomer_pos + offset;
 }
 
-template <typename T>
-void release_after_parent_destroyed(QGraphicsItemGroup& group,
-                                    std::vector<T*>& unbound_ap_items)
-{
-    for (auto* item : group.childItems()) {
-        group.removeFromGroup(item);
-        delete item;
-    }
-    unbound_ap_items.clear();
-}
-
-// explicitly instanatiate the UnboundMonomericAttachmentPointItem version of
-// this function since it's used in DrawMonomerSceneTool
-template void release_after_parent_destroyed(
-    QGraphicsItemGroup& group,
-    std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
-
 AbstractMonomerSceneTool::AbstractMonomerSceneTool(const Fonts& fonts,
                                                    Scene* scene,
                                                    MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model),
-    m_fonts(fonts)
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
-    m_attachment_point_labels_group.setZValue(static_cast<qreal>(ZOrder::HINT));
 }
 
 AbstractMonomerSceneTool::~AbstractMonomerSceneTool()
@@ -66,31 +41,22 @@ AbstractMonomerSceneTool::~AbstractMonomerSceneTool()
     clearAttachmentPointsLabelsAndHintFragmentItem();
 }
 
-std::vector<QGraphicsItem*> AbstractMonomerSceneTool::getGraphicsItems()
-{
-    auto items = StandardSceneToolBase::getGraphicsItems();
-    items.push_back(&m_attachment_point_labels_group);
-    return items;
-}
-
 void AbstractMonomerSceneTool::updateColorsAfterBackgroundColorChange(
     bool is_dark_mode)
 {
     StandardSceneToolBase::updateColorsAfterBackgroundColorChange(is_dark_mode);
     m_unbound_ap_label_color =
         is_dark_mode ? UNBOUND_AP_LABEL_COLOR_DARK_BG : UNBOUND_AP_LABEL_COLOR;
-    m_bound_ap_label_color =
-        is_dark_mode ? BOUND_AP_LABEL_COLOR_DARK_BG : BOUND_AP_LABEL_COLOR;
 }
 
 void AbstractMonomerSceneTool::onStructureUpdated()
 {
-    release_after_parent_destroyed(m_attachment_point_labels_group,
-                                   m_unbound_ap_items);
-    m_hovered_item = nullptr;
+    // the unbound attachment point items themselves were children of their
+    // respective monomers, so Qt destroyed them when the monomers were
+    // destroyed. We just need to clear out the stale pointers here.
+    m_unbound_ap_items.clear();
     m_hovered_ap_item = nullptr;
     clearHintFragmentItem();
-    m_predictive_highlighting_item.clearHighlightingPath();
 }
 
 bool AbstractMonomerSceneTool::isItemPartOfHintFragment(
@@ -99,6 +65,18 @@ bool AbstractMonomerSceneTool::isItemPartOfHintFragment(
     return m_hint_fragment_item != nullptr &&
            (item == m_hint_fragment_item ||
             item->group() == m_hint_fragment_item);
+}
+
+QGraphicsItem*
+AbstractMonomerSceneTool::getTopMonomericItemAt(const QPointF& scene_pos) const
+{
+    auto hovered_monomer_item = getTopMonomerItemAt(scene_pos);
+    QGraphicsItem* hovered_item = hovered_monomer_item;
+    if (hovered_monomer_item == nullptr) {
+        // if we're not over a monomer, check to see if we're over a connector
+        hovered_item = getTopMonomerConnectorItemAt(scene_pos);
+    }
+    return hovered_item;
 }
 
 AbstractMonomerItem*
@@ -145,7 +123,7 @@ AbstractMonomerSceneTool::getTopMonomerItemAt(const QPointF& scene_pos) const
         for (auto cur_unbound_ap : unbound_aps) {
             auto unbound_ap_hover_area =
                 get_hover_area_for_unbound_monomer_attachment_point_item(
-                    cur_unbound_ap, monomer_item, m_fonts);
+                    cur_unbound_ap, monomer_item, *m_fonts);
             if (unbound_ap_hover_area.contains(local_pos)) {
                 return monomer_item;
             }
@@ -167,56 +145,28 @@ MonomerConnectorItem* AbstractMonomerSceneTool::getTopMonomerConnectorItemAt(
     return nullptr;
 }
 
-void AbstractMonomerSceneTool::drawAttachmentPointLabelsFor(
+void AbstractMonomerSceneTool::drawMonomericAttachmentPointLabelsFor(
     QGraphicsItem* const item)
 {
     clearAttachmentPointsLabelsAndHintFragmentItem();
-    if (item == nullptr) {
-        return;
-    }
-    if (item_matches_type_flag(item, InteractiveItemFlag::MONOMER)) {
+    StandardSceneToolBase::drawMonomericAttachmentPointLabelsFor(item);
+    if (item != nullptr &&
+        item_matches_type_flag(item, InteractiveItemFlag::MONOMER)) {
         // hovering over a monomer
         auto* monomer_item = static_cast<AbstractMonomerItem*>(item);
         const auto* monomer = monomer_item->getAtom();
-        labelUnboundAttachmentPointsOnHoveredMonomer(monomer, monomer_item);
-    } else if (item_matches_type_flag(item,
-                                      InteractiveItemFlag::MONOMER_CONNECTOR)) {
-        // hovering over a monomeric connector
-        auto* connector_item = qgraphicsitem_cast<MonomerConnectorItem*>(item);
-        const auto* connector = connector_item->getBond();
-        labelAttachmentPointsOnConnector(
-            connector, connector_item->isSecondaryConnection());
+        labelUnboundAttachmentPointsOnMonomer(monomer, monomer_item,
+                                              m_attachment_point_labels_group,
+                                              m_unbound_ap_items);
     }
-}
-
-template <typename T>
-static void clear_graphics_item_group_and_list(QGraphicsItemGroup& group,
-                                               std::vector<T*>& items_list)
-{
-    for (auto* item : group.childItems()) {
-        group.removeFromGroup(item);
-        delete item;
-    }
-    for (auto* item : items_list) {
-        delete item;
-    }
-    items_list.clear();
 }
 
 void AbstractMonomerSceneTool::clearAttachmentPointsLabelsAndHintFragmentItem()
 {
-    clear_graphics_item_group_and_list(m_attachment_point_labels_group,
-                                       m_unbound_ap_items);
+    clear_graphics_item_group(m_attachment_point_labels_group);
+    delete_all_unbound_ap_items(m_unbound_ap_items);
     m_hovered_ap_item = nullptr;
     clearHintFragmentItem();
-}
-
-void AbstractMonomerSceneTool::labelUnboundAttachmentPointsOnHoveredMonomer(
-    const RDKit::Atom* const monomer, AbstractMonomerItem* const monomer_item)
-{
-    labelUnboundAttachmentPointsOnMonomer(monomer, monomer_item,
-                                          m_attachment_point_labels_group,
-                                          m_unbound_ap_items);
 }
 
 void AbstractMonomerSceneTool::labelUnboundAttachmentPointsOnMonomer(
@@ -227,19 +177,8 @@ void AbstractMonomerSceneTool::labelUnboundAttachmentPointsOnMonomer(
     auto [bound_aps, unbound_aps] = get_attachment_points_for_monomer(monomer);
     for (auto& cur_ap : unbound_aps) {
         auto* item = new UnboundMonomericAttachmentPointItem(
-            cur_ap, monomer_item, m_unbound_ap_label_color, m_fonts);
+            cur_ap, monomer_item, m_unbound_ap_label_color, *m_fonts);
         unbound_ap_items.push_back(item);
-    }
-}
-
-void AbstractMonomerSceneTool::labelAttachmentPointsOnConnector(
-    const RDKit::Bond* const connector, const bool is_secondary_connection)
-{
-    auto ap_label_items = create_attachment_point_labels_for_connector(
-        connector, is_secondary_connection, m_bound_ap_label_color, m_fonts,
-        m_scene);
-    for (auto* item : ap_label_items) {
-        m_attachment_point_labels_group.addToGroup(item);
     }
 }
 
@@ -256,6 +195,15 @@ void AbstractMonomerSceneTool::setCursorHintShown(bool show)
                                          : QPixmap());
         m_cursor_hint_shown = show;
     }
+}
+
+void delete_all_unbound_ap_items(
+    std::vector<UnboundMonomericAttachmentPointItem*>& items_list)
+{
+    for (auto* item : items_list) {
+        delete item;
+    }
+    items_list.clear();
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
@@ -110,8 +110,8 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
      */
     void clearAttachmentPointsLabelsAndHintFragmentItem();
     /**
-     * Label all unbound attachment points on the given monomer, placing all newly
-     * created graphics items into the specified group and list.
+     * Label all unbound attachment points on the given monomer, placing all
+     * newly created graphics items into the specified group and list.
      */
     void labelUnboundAttachmentPointsOnMonomer(
         const RDKit::Atom* const monomer,

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
@@ -44,23 +44,9 @@ get_default_coords_for_bound_monomer(const RDGeom::Point3D monomer_pos,
                                      const rdkit_extensions::Direction dir);
 
 /**
- * Release the tool's references to attachment-point label items after the
- * parent monomer has just been destroyed by a structure update. Bound AP
- * labels in `group` were reparented to the group by addToGroup, so they
- * survive the monomer's destruction and must still be deleted normally.
- * Items in `unbound_ap_items` were Qt children of the now-gone monomer and
- * have already been destroyed by Qt — drop the dangling pointers without
- * deleting. Compare to clear_graphics_item_group_and_list (defined later),
- * which deletes both and is only safe while the parent monomer is alive.
- */
-template <typename T> SKETCHER_API void
-release_after_parent_destroyed(QGraphicsItemGroup& group,
-                               std::vector<T*>& unbound_ap_items);
-
-/**
- * Abstract base class for scene tools that work with monomers.
- * Provides common functionality for finding monomer items, managing hint
- * fragments, and drawing attachment point labels.
+ * Abstract base class for scene tools that draw monomers. Provides common
+ * functionality for drawing unbound attachment point labels and managing hint
+ * fragments.
  */
 class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
 {
@@ -68,23 +54,22 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
     AbstractMonomerSceneTool(const Fonts& fonts, Scene* scene,
                              MolModel* mol_model);
     virtual ~AbstractMonomerSceneTool();
-
     // Reimplemented StandardSceneToolBase methods
-    std::vector<QGraphicsItem*> getGraphicsItems() override;
+    void onStructureUpdated() override;
     void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
-    virtual void onStructureUpdated() override;
 
   protected:
-    Fonts m_fonts;
     MonomerHintFragmentItem* m_hint_fragment_item = nullptr;
-    QGraphicsItemGroup m_attachment_point_labels_group;
     const UnboundMonomericAttachmentPointItem* m_hovered_ap_item = nullptr;
     std::vector<UnboundMonomericAttachmentPointItem*> m_unbound_ap_items;
     QColor m_unbound_ap_label_color = UNBOUND_AP_LABEL_COLOR;
-    QColor m_bound_ap_label_color = BOUND_AP_LABEL_COLOR;
-    const QGraphicsItem* m_hovered_item = nullptr;
     QColor m_monomer_background_color = LIGHT_BACKGROUND_COLOR;
     bool m_cursor_hint_shown = true;
+
+    // we override this method so that hovering over an unbound attachment point
+    // label counts as hovering over the monomer
+    QGraphicsItem*
+    getTopMonomericItemAt(const QPointF& scene_pos) const override;
 
     /**
      * Return the top graphics item representing a monomer at the given
@@ -104,12 +89,8 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
     MonomerConnectorItem*
     getTopMonomerConnectorItemAt(const QPointF& scene_pos) const;
 
-    /**
-     * Clear any existing attachment point labels and draw new ones for the
-     * specified monomeric graphics item. If item is nullptr, then all labels
-     * will be cleared and no new ones will be drawn.
-     */
-    void drawAttachmentPointLabelsFor(QGraphicsItem* const item);
+    void
+    drawMonomericAttachmentPointLabelsFor(QGraphicsItem* const item) override;
 
     /**
      * Remove the hint fragment item from the scene, then destroy it as well as
@@ -128,19 +109,9 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
      * clear the hint fragment item and the associated structure.
      */
     void clearAttachmentPointsLabelsAndHintFragmentItem();
-
     /**
-     * Label all unbound attachment points on the given hovered monomer
-     */
-    void labelUnboundAttachmentPointsOnHoveredMonomer(
-        const RDKit::Atom* const monomer,
-        AbstractMonomerItem* const monomer_item);
-
-    /**
-     * Label all unbound attachment points on the given monomer, placing all
-     * newly created graphics items into the specified group and list. (You
-     * probably want to call either labelUnboundAttachmentPointsOnHoveredMonomer
-     * or labelAttachmentPointsOnDragEndMonomer instead of this.)
+     * Label all unbound attachment points on the given monomer, placing all newly
+     * created graphics items into the specified group and list.
      */
     void labelUnboundAttachmentPointsOnMonomer(
         const RDKit::Atom* const monomer,
@@ -149,22 +120,13 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
         std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
 
     /**
-     * Label both attachment points for the given monomeric connector
-     * @param connector The monomeric connector to label
-     * @param is_secondary_connection Whether this method should label the
-     * secondary connection of the bond instead of the primary connection.
-     * Secondary connections occur when a single RDKit::Bond* represents
-     * multiple connections, e.g. two neighboring cysteines that are disulfide
-     * bonded to each other.
-     */
-    void labelAttachmentPointsOnConnector(const RDKit::Bond* const connector,
-                                          const bool is_secondary_connection);
-
-    /**
      * Show or hide the cursor hint
      */
     void setCursorHintShown(bool show);
 };
+
+void delete_all_unbound_ap_items(
+    std::vector<UnboundMonomericAttachmentPointItem*>& items_list);
 
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/arrow_plus_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/arrow_plus_scene_tool.cpp
@@ -12,8 +12,9 @@ namespace sketcher
 {
 
 ArrowPlusSceneTool::ArrowPlusSceneTool(const NonMolecularType& type,
-                                       Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model),
+                                       const Fonts& fonts, Scene* scene,
+                                       MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model),
     m_type(type)
 {
 }

--- a/src/schrodinger/sketcher/tool/arrow_plus_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/arrow_plus_scene_tool.h
@@ -18,8 +18,8 @@ enum class NonMolecularType;
 class SKETCHER_API ArrowPlusSceneTool : public StandardSceneToolBase
 {
   public:
-    ArrowPlusSceneTool(const NonMolecularType& type, Scene* scene,
-                       MolModel* mol_model);
+    ArrowPlusSceneTool(const NonMolecularType& type, const Fonts& fonts,
+                       Scene* scene, MolModel* mol_model);
 
     // reimplemented AbstractSceneTool method
     void onLeftButtonClick(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/atom_mapping_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/atom_mapping_scene_tool.cpp
@@ -31,8 +31,9 @@ ArrowLineItem::ArrowLineItem()
 }
 
 AtomMappingSceneTool::AtomMappingSceneTool(const MappingAction& action,
-                                           Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model),
+                                           const Fonts& fonts, Scene* scene,
+                                           MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model),
     m_action(action)
 {
     m_highlight_types = InteractiveItemFlag::ATOM_NOT_R_NOT_AP;

--- a/src/schrodinger/sketcher/tool/atom_mapping_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/atom_mapping_scene_tool.h
@@ -33,8 +33,8 @@ enum class MappingAction : bool { ADD, REMOVE };
 class SKETCHER_API AtomMappingSceneTool : public StandardSceneToolBase
 {
   public:
-    AtomMappingSceneTool(const MappingAction& action, Scene* scene,
-                         MolModel* mol_model);
+    AtomMappingSceneTool(const MappingAction& action, const Fonts& fonts,
+                         Scene* scene, MolModel* mol_model);
 
     // reimplemented AbstractSceneTool method
     void onLeftButtonPress(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/attachment_point_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/attachment_point_scene_tool.cpp
@@ -22,8 +22,8 @@ HintSquiggleItem::HintSquiggleItem(QGraphicsItem* parent) :
 }
 
 DrawAttachmentPointSceneTool::DrawAttachmentPointSceneTool(
-    Scene* scene, MolModel* mol_model) :
-    AbstractDrawSceneTool(scene, mol_model)
+    const Fonts& fonts, Scene* scene, MolModel* mol_model) :
+    AbstractDrawSceneTool(fonts, scene, mol_model)
 {
 }
 

--- a/src/schrodinger/sketcher/tool/attachment_point_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/attachment_point_scene_tool.h
@@ -29,7 +29,8 @@ class HintSquiggleItem : public QGraphicsPathItem
 class SKETCHER_API DrawAttachmentPointSceneTool : public AbstractDrawSceneTool
 {
   public:
-    DrawAttachmentPointSceneTool(Scene* scene, MolModel* mol_model);
+    DrawAttachmentPointSceneTool(const Fonts& fonts, Scene* scene,
+                                 MolModel* mol_model);
 
   protected:
     HintSquiggleItem m_hint_squiggle_item = HintSquiggleItem();

--- a/src/schrodinger/sketcher/tool/draw_atom_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_atom_scene_tool.cpp
@@ -22,8 +22,7 @@ namespace sketcher
 AbstractDrawAtomSceneTool::AbstractDrawAtomSceneTool(const Fonts& fonts,
                                                      Scene* scene,
                                                      MolModel* mol_model) :
-    AbstractDrawSceneTool(scene, mol_model),
-    m_fonts(&fonts)
+    AbstractDrawSceneTool(fonts, scene, mol_model)
 {
 }
 

--- a/src/schrodinger/sketcher/tool/draw_atom_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_atom_scene_tool.h
@@ -36,8 +36,6 @@ class SKETCHER_API AbstractDrawAtomSceneTool : public AbstractDrawSceneTool
                               MolModel* mol_model);
 
   protected:
-    const Fonts* m_fonts;
-
     // reimplemented AbstractDrawSceneTool methods
     void onBondClicked(const RDKit::Bond* const bond) override;
     void onEmptySpaceClicked(const RDGeom::Point3D& pos) override;

--- a/src/schrodinger/sketcher/tool/draw_bond_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_bond_scene_tool.cpp
@@ -16,9 +16,10 @@ namespace schrodinger
 namespace sketcher
 {
 
-AbstractDrawBondSceneTool::AbstractDrawBondSceneTool(Scene* scene,
+AbstractDrawBondSceneTool::AbstractDrawBondSceneTool(const Fonts& fonts,
+                                                     Scene* scene,
                                                      MolModel* mol_model) :
-    AbstractDrawSceneTool(scene, mol_model)
+    AbstractDrawSceneTool(fonts, scene, mol_model)
 {
 }
 
@@ -48,9 +49,9 @@ void AbstractDrawBondSceneTool::onEmptySpaceClicked(const RDGeom::Point3D& pos)
     addTwoBoundAtoms(pos, pos2);
 }
 
-DrawBondSceneTool::DrawBondSceneTool(BondTool bond_tool, Scene* scene,
-                                     MolModel* mol_model) :
-    AbstractDrawBondSceneTool(scene, mol_model)
+DrawBondSceneTool::DrawBondSceneTool(BondTool bond_tool, const Fonts& fonts,
+                                     Scene* scene, MolModel* mol_model) :
+    AbstractDrawBondSceneTool(fonts, scene, mol_model)
 {
     m_bond_tool = bond_tool;
     std::tie(m_bond_type, m_bond_dir, m_flippable, m_cursor_hint_path) =
@@ -122,8 +123,7 @@ QPixmap DrawBondSceneTool::createDefaultCursorPixmap() const
 DrawBondQuerySceneTool::DrawBondQuerySceneTool(BondTool bond_tool,
                                                const Fonts& fonts, Scene* scene,
                                                MolModel* mol_model) :
-    AbstractDrawBondSceneTool(scene, mol_model),
-    m_fonts(&fonts)
+    AbstractDrawBondSceneTool(fonts, scene, mol_model)
 {
     m_bond_tool = bond_tool;
     m_query_type = get_label_for_bond_query(getQueryAndBondType().first.get());

--- a/src/schrodinger/sketcher/tool/draw_bond_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_bond_scene_tool.h
@@ -28,7 +28,8 @@ namespace sketcher
 class SKETCHER_API AbstractDrawBondSceneTool : public AbstractDrawSceneTool
 {
   public:
-    AbstractDrawBondSceneTool(Scene* scene, MolModel* mol_model);
+    AbstractDrawBondSceneTool(const Fonts& fonts, Scene* scene,
+                              MolModel* mol_model);
 
   protected:
     /**
@@ -68,7 +69,8 @@ class SKETCHER_API AbstractDrawBondSceneTool : public AbstractDrawSceneTool
 class SKETCHER_API DrawBondSceneTool : public AbstractDrawBondSceneTool
 {
   public:
-    DrawBondSceneTool(BondTool bond_tool, Scene* scene, MolModel* mol_model);
+    DrawBondSceneTool(BondTool bond_tool, const Fonts& fonts, Scene* scene,
+                      MolModel* mol_model);
 
   protected:
     BondTool m_bond_tool;
@@ -115,8 +117,6 @@ class SKETCHER_API DrawBondQuerySceneTool : public AbstractDrawBondSceneTool
      * The text to use for labeling the drawn queries
      */
     std::string m_query_type;
-
-    const Fonts* m_fonts;
 
     /**
      * @return the query and bond type to use for bonds

--- a/src/schrodinger/sketcher/tool/draw_chain_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_chain_scene_tool.cpp
@@ -42,8 +42,9 @@ void HintChainItem::setCoords(QList<QPointF> coords)
     m_label_item.setText(QString::number(coords.size() - 1));
 }
 
-DrawChainSceneTool::DrawChainSceneTool(Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model)
+DrawChainSceneTool::DrawChainSceneTool(const Fonts& fonts, Scene* scene,
+                                       MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
     m_highlight_types = InteractiveItemFlag::ATOM_NOT_AP;
 }

--- a/src/schrodinger/sketcher/tool/draw_chain_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_chain_scene_tool.h
@@ -44,7 +44,7 @@ class HintChainItem : public QGraphicsItemGroup
 class SKETCHER_API DrawChainSceneTool : public StandardSceneToolBase
 {
   public:
-    DrawChainSceneTool(Scene* scene, MolModel* mol_model);
+    DrawChainSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
 
     // Overridden AbstractSceneTool methods
     std::vector<QGraphicsItem*> getGraphicsItems() override;

--- a/src/schrodinger/sketcher/tool/draw_fragment_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_fragment_scene_tool.cpp
@@ -248,7 +248,7 @@ DrawFragmentSceneTool::DrawFragmentSceneTool(
     const AtomDisplaySettings& atom_display_settings,
     const BondDisplaySettings& bond_display_settings, Scene* scene,
     MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model),
+    StandardSceneToolBase(fonts, scene, mol_model),
     m_frag(fragment),
     m_hint_item(m_frag, fonts, atom_display_settings, bond_display_settings)
 {

--- a/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
@@ -140,7 +140,7 @@ QPixmap DrawMonomerFragmentSceneTool::createDefaultCursorPixmap() const
     // tiny. (Enlarging the font size would just make the outlines larger, which
     // means we'd need to scale the coordinates less, which means we'd wind up
     // with the same problem, so that won't help us here.)
-    Fonts fonts_copy(m_fonts);
+    Fonts fonts_copy(*m_fonts);
     fonts_copy.setSize(FONT_SIZE);
     fonts_copy.m_main_label_font.setBold(true);
     fonts_copy.updateFontMetrics();
@@ -171,18 +171,6 @@ void DrawMonomerFragmentSceneTool::onMouseMove(
     }
     QPointF scene_pos = event->scenePos();
     auto hovered_monomer_item = getTopMonomerItemAt(scene_pos);
-    QGraphicsItem* hovered_item = hovered_monomer_item;
-    if (hovered_monomer_item == nullptr) {
-        // if we're not over a monomer, check to see if we're over a connector
-        hovered_item = getTopMonomerConnectorItemAt(scene_pos);
-    }
-
-    if (hovered_item != m_hovered_item) {
-        // we're hovering over something new, so update the attachment point
-        // labels
-        m_hovered_item = hovered_item;
-        drawAttachmentPointLabelsFor(hovered_item);
-    }
 
     auto* hovered_ap_item =
         getConnectableUnboundAttachmentPointAt(scene_pos, hovered_monomer_item);
@@ -246,7 +234,7 @@ void DrawMonomerFragmentSceneTool::onLeftButtonPress(
         move_mol_to_coords_and_rotate(*frag_copy, m_index_to_center_on_click,
                                       to_mol_xy(scene_pos), 0.0);
         m_hint_fragment_item = new MonomerHintFragmentItem(
-            frag_copy, m_fonts, {}, -1, m_monomer_background_color);
+            frag_copy, *m_fonts, {}, -1, m_monomer_background_color);
         m_scene->addItem(m_hint_fragment_item);
     }
 }
@@ -395,7 +383,7 @@ void DrawMonomerFragmentSceneTool::drawFragmentHintFor(
         attachment_info.frag_monomer_ap_model_name);
 
     m_hint_fragment_item = new MonomerHintFragmentItem(
-        hint_mol, m_fonts, {hovered_monomer_copy_idx}, new_connection_idx,
+        hint_mol, *m_fonts, {hovered_monomer_copy_idx}, new_connection_idx,
         m_monomer_background_color);
     m_scene->addItem(m_hint_fragment_item);
 }

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -62,17 +62,17 @@ DrawMonomerSceneTool::DrawMonomerSceneTool(
     const Fonts& fonts, Scene* scene, MolModel* mol_model) :
     AbstractMonomerSceneTool(fonts, scene, mol_model),
     m_res_name(res_name),
-    m_chain_type(chain_type)
+    m_chain_type(chain_type),
+    m_bolded_fonts(fonts)
 {
     // we handle predictive highlighting manually in onMouseMove, so we disable
     // StandardSceneToolsBase's predictive highlighting
     m_highlight_types = InteractiveItemFlag::NONE;
     // make sure that the cursor hint font is more easily readable at small
-    // size. (Note that m_fonts is a copy of the Scene's fonts, not a reference,
-    // so this change won't affect anything else.)
-    m_fonts.m_main_label_font.setBold(true);
-    m_fonts.updateFontMetrics();
-    m_attachment_point_labels_group.setZValue(static_cast<qreal>(ZOrder::HINT));
+    // size. (Note that m_bolded_fonts is a copy of the Scene's fonts, so this
+    // change won't affect anything else.)
+    m_bolded_fonts.m_main_label_font.setBold(true);
+    m_bolded_fonts.updateFontMetrics();
     if (chain_type == rdkit_extensions::ChainType::PEPTIDE) {
         m_monomer_type = MonomerType::PEPTIDE;
     } else if (chain_type == rdkit_extensions::ChainType::CHEM) {
@@ -95,8 +95,11 @@ DrawMonomerSceneTool::~DrawMonomerSceneTool()
 void DrawMonomerSceneTool::onStructureUpdated()
 {
     AbstractMonomerSceneTool::onStructureUpdated();
-    release_after_parent_destroyed(m_drag_end_attachment_point_labels_group,
-                                   m_drag_end_unbound_ap_items);
+    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
+    // any drag-end attachment point graphics items have already been deleted in
+    // response to their parent monomer graphics item being deleted due to the
+    // structure update. We're just clear the stale pointers here
+    m_drag_end_unbound_ap_items.clear();
     m_drag_start_monomer_item = nullptr;
     m_drag_end_monomer_item = nullptr;
 }
@@ -379,11 +382,12 @@ DrawMonomerSceneTool::getUnboundDragEndAttachmentPointAt(
 std::tuple<const RDKit::Atom*, MonomerType>
 DrawMonomerSceneTool::getHoveredMonomerAndType() const
 {
-    if (!item_matches_type_flag(m_hovered_item, InteractiveItemFlag::MONOMER)) {
+    if (!item_matches_type_flag(m_hovered_monomeric_item,
+                                InteractiveItemFlag::MONOMER)) {
         throw std::runtime_error("No hovered monomer");
     }
     const auto* monomer_item =
-        static_cast<const AbstractMonomerItem*>(m_hovered_item);
+        static_cast<const AbstractMonomerItem*>(m_hovered_monomeric_item);
     return get_monomer_and_type(monomer_item);
 }
 
@@ -410,8 +414,9 @@ bool DrawMonomerSceneTool::clickShouldMutate(
 bool DrawMonomerSceneTool::shouldShowPredictiveHighlighting() const
 {
 
-    if (m_hovered_item == nullptr ||
-        !item_matches_type_flag(m_hovered_item, InteractiveItemFlag::MONOMER)) {
+    if (m_hovered_monomeric_item == nullptr ||
+        !item_matches_type_flag(m_hovered_monomeric_item,
+                                InteractiveItemFlag::MONOMER)) {
         return false;
     }
     auto [monomer, monomer_type] = getHoveredMonomerAndType();
@@ -424,25 +429,20 @@ bool DrawMonomerSceneTool::shouldShowPredictiveHighlighting() const
 
 void DrawMonomerSceneTool::onMouseMove(QGraphicsSceneMouseEvent* const event)
 {
+    // the base class call updates m_hovered_monomeric_item and the attachment
+    // point labels
+    auto prev_hovered_monomeric_item = m_hovered_monomeric_item;
     AbstractMonomerSceneTool::onMouseMove(event);
     if (m_mouse_pressed) {
         // drag logic is handled in onDragMove
         return;
     }
     QPointF scene_pos = event->scenePos();
-    QGraphicsItem* hovered_item;
-    hovered_item = getTopMonomerItemAt(scene_pos);
-    bool found_monomer = hovered_item != nullptr;
-    if (!found_monomer) {
-        // if we're not over a monomer, check to see if we're over a connector
-        hovered_item = getTopMonomerConnectorItemAt(scene_pos);
-    }
 
-    if (hovered_item != m_hovered_item) {
-        m_hovered_item = hovered_item;
-        drawAttachmentPointLabelsFor(hovered_item);
+    if (m_hovered_monomeric_item != prev_hovered_monomeric_item) {
         if (shouldShowPredictiveHighlighting()) {
-            m_predictive_highlighting_item.highlightItem(hovered_item);
+            m_predictive_highlighting_item.highlightItem(
+                m_hovered_monomeric_item);
         } else {
             m_predictive_highlighting_item.clearHighlightingPath();
         }
@@ -491,7 +491,7 @@ void DrawMonomerSceneTool::drawBoundMonomerHintFor(
         return;
     }
     const auto* monomer_item =
-        static_cast<const AbstractMonomerItem*>(m_hovered_item);
+        static_cast<const AbstractMonomerItem*>(m_hovered_monomeric_item);
     auto hovered_monomer_info =
         createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
             monomer_item, ap_item->getAttachmentPoint().model_name);
@@ -535,7 +535,7 @@ void DrawMonomerSceneTool::createHintFragmentItem(
     }
 
     m_hint_fragment_item = new MonomerHintFragmentItem(
-        frag, m_fonts, atom_indices_to_hide, bond_index_to_label,
+        frag, m_bolded_fonts, atom_indices_to_hide, bond_index_to_label,
         m_monomer_background_color);
     m_scene->addItem(m_hint_fragment_item);
 }
@@ -951,7 +951,7 @@ QPixmap DrawMonomerSceneTool::createDefaultCursorPixmap() const
         rdkit_extensions::makeMonomer(m_res_name, chain_id, 1, false);
 
     std::shared_ptr<AbstractMonomerItem> monomer_item;
-    monomer_item.reset(get_monomer_graphics_item(monomer.get(), m_fonts));
+    monomer_item.reset(get_monomer_graphics_item(monomer.get(), *m_fonts));
     monomer_item->setMonomerColors(Qt::GlobalColor::transparent,
                                    CURSOR_HINT_COLOR, CURSOR_HINT_COLOR);
     // make sure that the cursor hint is at least a little smaller than an
@@ -969,24 +969,10 @@ void DrawMonomerSceneTool::labelAttachmentPointsOnDragEndMonomer(
         m_drag_end_unbound_ap_items);
 }
 
-template <typename T>
-static void clear_graphics_item_group_and_list(QGraphicsItemGroup& group,
-                                               std::vector<T*>& items_list)
-{
-    for (auto* item : group.childItems()) {
-        group.removeFromGroup(item);
-        delete item;
-    }
-    for (auto* item : items_list) {
-        delete item;
-    }
-    items_list.clear();
-}
-
 void DrawMonomerSceneTool::clearDragEndAttachmentPointsLabels()
 {
-    clear_graphics_item_group_and_list(m_drag_end_attachment_point_labels_group,
-                                       m_drag_end_unbound_ap_items);
+    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
+    delete_all_unbound_ap_items(m_drag_end_unbound_ap_items);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -94,6 +94,7 @@ class SKETCHER_API DrawMonomerSceneTool : public AbstractMonomerSceneTool
     std::string m_res_name;
     rdkit_extensions::ChainType m_chain_type;
     MonomerType m_monomer_type;
+    Fonts m_bolded_fonts;
 
     bool m_drag_ignored;
     AbstractMonomerItem* m_drag_start_monomer_item = nullptr;

--- a/src/schrodinger/sketcher/tool/edit_charge_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/edit_charge_scene_tool.cpp
@@ -13,9 +13,10 @@ namespace schrodinger
 namespace sketcher
 {
 
-EditChargeSceneTool::EditChargeSceneTool(ChargeTool charge_tool, Scene* scene,
+EditChargeSceneTool::EditChargeSceneTool(ChargeTool charge_tool,
+                                         const Fonts& fonts, Scene* scene,
                                          MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model),
+    StandardSceneToolBase(fonts, scene, mol_model),
     m_charge_tool(charge_tool)
 {
     m_highlight_types = InteractiveItemFlag::ATOM_NOT_R_NOT_AP;

--- a/src/schrodinger/sketcher/tool/edit_charge_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/edit_charge_scene_tool.h
@@ -17,7 +17,7 @@ namespace sketcher
 class SKETCHER_API EditChargeSceneTool : public StandardSceneToolBase
 {
   public:
-    EditChargeSceneTool(ChargeTool bond_tool, Scene* scene,
+    EditChargeSceneTool(ChargeTool bond_tool, const Fonts& fonts, Scene* scene,
                         MolModel* mol_model);
 
   protected:

--- a/src/schrodinger/sketcher/tool/explicit_h_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/explicit_h_scene_tool.cpp
@@ -10,8 +10,9 @@ namespace schrodinger
 namespace sketcher
 {
 
-ExplicitHsSceneTool::ExplicitHsSceneTool(Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model)
+ExplicitHsSceneTool::ExplicitHsSceneTool(const Fonts& fonts, Scene* scene,
+                                         MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
     m_highlight_types = InteractiveItemFlag::ATOM_NOT_R_NOT_AP;
 }

--- a/src/schrodinger/sketcher/tool/explicit_h_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/explicit_h_scene_tool.h
@@ -18,7 +18,7 @@ namespace sketcher
 class SKETCHER_API ExplicitHsSceneTool : public StandardSceneToolBase
 {
   public:
-    ExplicitHsSceneTool(Scene* scene, MolModel* mol_model);
+    ExplicitHsSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
 
   protected:
     void onLeftButtonClick(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/move_rotate_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/move_rotate_scene_tool.cpp
@@ -22,8 +22,9 @@ MoveSelectionItem::MoveSelectionItem() : QGraphicsRectItem()
     setZValue(static_cast<qreal>(ZOrder::SELECTION_HIGHLIGHTING));
 }
 
-MoveRotateSceneTool::MoveRotateSceneTool(Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model)
+MoveRotateSceneTool::MoveRotateSceneTool(const Fonts& fonts, Scene* scene,
+                                         MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
     m_allow_context_menu = false;
     m_highlight_types = InteractiveItemFlag::NONE;

--- a/src/schrodinger/sketcher/tool/move_rotate_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/move_rotate_scene_tool.h
@@ -34,7 +34,7 @@ enum class Action { ROTATE, TRANSLATE, NONE };
 class SKETCHER_API MoveRotateSceneTool : public StandardSceneToolBase
 {
   public:
-    MoveRotateSceneTool(Scene* scene, MolModel* mol_model);
+    MoveRotateSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
     virtual void onMouseMove(QGraphicsSceneMouseEvent* const event) override;
     virtual void
     onLeftButtonDragStart(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/select_erase_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/select_erase_scene_tool.cpp
@@ -29,21 +29,23 @@ namespace
 } // unnamed namespace
 
 std::shared_ptr<AbstractSceneTool>
-get_select_scene_tool(SelectionTool selection_type, Scene* scene,
-                      MolModel* mol_model)
+get_select_scene_tool(SelectionTool selection_type, const Fonts& fonts,
+                      Scene* scene, MolModel* mol_model)
 {
     if (selection_type == SelectionTool::RECTANGLE) {
-        return std::make_shared<RectSelectSceneTool>(scene, mol_model);
+        return std::make_shared<RectSelectSceneTool>(fonts, scene, mol_model);
     } else if (selection_type == SelectionTool::ELLIPSE) {
-        return std::make_shared<EllipseSelectSceneTool>(scene, mol_model);
+        return std::make_shared<EllipseSelectSceneTool>(fonts, scene,
+                                                        mol_model);
     } else { // selection_type == SelectionTool::LASSO
-        return std::make_shared<LassoSelectSceneTool>(scene, mol_model);
+        return std::make_shared<LassoSelectSceneTool>(fonts, scene, mol_model);
     }
 }
 
 template <typename T>
-SelectSceneTool<T>::SelectSceneTool(Scene* scene, MolModel* mol_model) :
-    StandardSceneToolBase(scene, mol_model)
+SelectSceneTool<T>::SelectSceneTool(const Fonts& fonts, Scene* scene,
+                                    MolModel* mol_model) :
+    StandardSceneToolBase(fonts, scene, mol_model)
 {
     m_highlight_types = InteractiveItemFlag::ALL;
     m_select_item.setVisible(false);
@@ -186,8 +188,9 @@ void SelectSceneTool<T>::onSelectionMade(const QList<QGraphicsItem*>& items,
                         non_molecular_objects, select_mode);
 }
 
-LassoSelectSceneTool::LassoSelectSceneTool(Scene* scene, MolModel* mol_model) :
-    SelectSceneTool(scene, mol_model)
+LassoSelectSceneTool::LassoSelectSceneTool(const Fonts& fonts, Scene* scene,
+                                           MolModel* mol_model) :
+    SelectSceneTool(fonts, scene, mol_model)
 {
 }
 
@@ -223,9 +226,9 @@ QPixmap LassoSelectSceneTool::createDefaultCursorPixmap() const
 }
 
 template <typename T>
-ShapeSelectSceneTool<T>::ShapeSelectSceneTool(Scene* scene,
+ShapeSelectSceneTool<T>::ShapeSelectSceneTool(const Fonts& fonts, Scene* scene,
                                               MolModel* mol_model) :
-    SelectSceneTool<T>(scene, mol_model)
+    SelectSceneTool<T>(fonts, scene, mol_model)
 {
 }
 
@@ -248,8 +251,9 @@ template <> QPixmap EllipseSelectSceneTool::createDefaultCursorPixmap() const
     return cursor_hint_from_svg(":/icons/select_ellipse.svg");
 }
 
-EraseSceneTool::EraseSceneTool(Scene* scene, MolModel* mol_model) :
-    RectSelectSceneTool(scene, mol_model)
+EraseSceneTool::EraseSceneTool(const Fonts& fonts, Scene* scene,
+                               MolModel* mol_model) :
+    RectSelectSceneTool(fonts, scene, mol_model)
 {
 }
 

--- a/src/schrodinger/sketcher/tool/select_erase_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/select_erase_scene_tool.h
@@ -37,8 +37,8 @@ enum class SelectMode;
  * @return The newly instantiated scene tool
  */
 SKETCHER_API std::shared_ptr<AbstractSceneTool>
-get_select_scene_tool(SelectionTool selection_type, Scene* scene,
-                      MolModel* mol_model);
+get_select_scene_tool(SelectionTool selection_type, const Fonts& fonts,
+                      Scene* scene, MolModel* mol_model);
 
 /**
  * A base class for the lasso and marquee selection scene tools, as well as the
@@ -50,7 +50,7 @@ template <typename T> class SKETCHER_API SelectSceneTool
     : public StandardSceneToolBase
 {
   public:
-    SelectSceneTool(Scene* scene, MolModel* mol_model);
+    SelectSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
 
     virtual void
     onLeftButtonDragStart(QGraphicsSceneMouseEvent* const event) override;
@@ -98,7 +98,7 @@ class SKETCHER_API LassoSelectSceneTool
     : public SelectSceneTool<LassoSelectionItem>
 {
   public:
-    LassoSelectSceneTool(Scene* scene, MolModel* mol_model);
+    LassoSelectSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
     void onLeftButtonPress(QGraphicsSceneMouseEvent* const event) override;
     void onMouseMove(QGraphicsSceneMouseEvent* const event) override;
     void
@@ -116,7 +116,7 @@ template <typename T> class SKETCHER_API ShapeSelectSceneTool
     : public SelectSceneTool<T>
 {
   public:
-    ShapeSelectSceneTool(Scene* scene, MolModel* mol_model);
+    ShapeSelectSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
     void onLeftButtonDragMove(QGraphicsSceneMouseEvent* const event) override;
     QPixmap createDefaultCursorPixmap() const override;
 };
@@ -129,7 +129,7 @@ typedef ShapeSelectSceneTool<EllipseSelectionItem> EllipseSelectSceneTool;
 class SKETCHER_API EraseSceneTool : public RectSelectSceneTool
 {
   public:
-    EraseSceneTool(Scene* scene, MolModel* mol_model);
+    EraseSceneTool(const Fonts& fonts, Scene* scene, MolModel* mol_model);
     void onLeftButtonClick(QGraphicsSceneMouseEvent* const event) override;
     void
     onLeftButtonDoubleClick(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/standard_scene_tool_base.cpp
+++ b/src/schrodinger/sketcher/tool/standard_scene_tool_base.cpp
@@ -2,18 +2,35 @@
 
 #include <algorithm>
 
+#include <QGraphicsItem>
+#include <QPainterPath>
+
 #include <GraphMol/MolOps.h>
 
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/model/mol_model.h"
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/atom_item.h"
 #include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h"
+#include "schrodinger/sketcher/molviewer/monomer_connector_item.h"
+#include "schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h"
+#include "schrodinger/sketcher/molviewer/monomer_utils.h"
+#include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
 
 namespace schrodinger
 {
 namespace sketcher
 {
+
+void clear_graphics_item_group(QGraphicsItemGroup& group)
+{
+    for (auto* item : group.childItems()) {
+        group.removeFromGroup(item);
+        delete item;
+    }
+}
 
 AngleTextItem::AngleTextItem() : QGraphicsSimpleTextItem()
 {
@@ -51,16 +68,15 @@ void MergeHintItem::setCoordinates(std::vector<QPointF> centers)
 
 void MergeHintItem::clear()
 {
-    for (auto* child : childItems()) {
-        removeFromGroup(child);
-        delete child;
-    }
+    clear_graphics_item_group(*this);
 }
 
-StandardSceneToolBase::StandardSceneToolBase(Scene* scene,
+StandardSceneToolBase::StandardSceneToolBase(const Fonts& fonts, Scene* scene,
                                              MolModel* mol_model) :
-    AbstractSceneTool(scene, mol_model)
+    AbstractSceneTool(scene, mol_model),
+    m_fonts(&fonts)
 {
+    m_attachment_point_labels_group.setZValue(static_cast<qreal>(ZOrder::HINT));
 }
 
 void StandardSceneToolBase::updateColorsAfterBackgroundColorChange(
@@ -72,6 +88,17 @@ void StandardSceneToolBase::updateColorsAfterBackgroundColorChange(
     m_predictive_highlighting_item.setBrush(color);
     m_angle_text_item.setPen(is_dark_mode ? ANNOTATION_COLOR_DARK_BG
                                           : ANNOTATION_COLOR);
+    m_bound_ap_label_color =
+        is_dark_mode ? BOUND_AP_LABEL_COLOR_DARK_BG : BOUND_AP_LABEL_COLOR;
+}
+
+void StandardSceneToolBase::onStructureUpdated()
+{
+    // The unbound attachment point items are children of their monomer, so they
+    // may have been deleted automatically when the structure changed.
+    clear_graphics_item_group(m_attachment_point_labels_group);
+    m_hovered_monomeric_item = nullptr;
+    m_predictive_highlighting_item.clearHighlightingPath();
 }
 
 void StandardSceneToolBase::onRightButtonClick(
@@ -92,6 +119,9 @@ void StandardSceneToolBase::onMouseMove(QGraphicsSceneMouseEvent* const event)
         QGraphicsItem* item =
             m_scene->getTopInteractiveItemAt(scene_pos, m_highlight_types);
         m_predictive_highlighting_item.highlightItem(item);
+    }
+    if (!m_mouse_pressed) {
+        updateMonomericAttachmentPointLabels(event->scenePos());
     }
     AbstractSceneTool::onMouseMove(event);
 }
@@ -231,7 +261,7 @@ void StandardSceneToolBase::updateGraphicsItemsDuringTranslation(
 std::vector<QGraphicsItem*> StandardSceneToolBase::getGraphicsItems()
 {
     return {&m_predictive_highlighting_item, &m_merge_hint_item,
-            &m_angle_text_item};
+            &m_angle_text_item, &m_attachment_point_labels_group};
 }
 
 RDGeom::Point3D StandardSceneToolBase::findPivotPointForRotation()
@@ -361,6 +391,55 @@ std::vector<std::pair<unsigned int, unsigned int>> get_overlapping_atom_idxs(
         }
     }
     return overlaps;
+}
+
+void StandardSceneToolBase::updateMonomericAttachmentPointLabels(
+    const QPointF& scene_pos)
+{
+    auto hovered_item = getTopMonomericItemAt(scene_pos);
+    if (hovered_item != m_hovered_monomeric_item) {
+        // we're hovering over something new, so update the attachment point
+        // labels
+        m_hovered_monomeric_item = hovered_item;
+        drawMonomericAttachmentPointLabelsFor(hovered_item);
+    }
+}
+
+QGraphicsItem*
+StandardSceneToolBase::getTopMonomericItemAt(const QPointF& scene_pos) const
+{
+    auto items = m_scene->items(scene_pos);
+    auto it = std::ranges::find_if(items, [](auto* item) {
+        return item_matches_type_flag(item, InteractiveItemFlag::MONOMERIC);
+    });
+    return it == items.end() ? nullptr : *it;
+}
+
+void StandardSceneToolBase::drawMonomericAttachmentPointLabelsFor(
+    QGraphicsItem* const item)
+{
+    clear_graphics_item_group(m_attachment_point_labels_group);
+    if (item == nullptr) {
+        return;
+    }
+    if (item_matches_type_flag(item, InteractiveItemFlag::MONOMER_CONNECTOR)) {
+        // hovering over a monomeric connector
+        auto* connector_item = qgraphicsitem_cast<MonomerConnectorItem*>(item);
+        const auto* connector = connector_item->getBond();
+        labelAttachmentPointsOnConnector(
+            connector, connector_item->isSecondaryConnection());
+    }
+}
+
+void StandardSceneToolBase::labelAttachmentPointsOnConnector(
+    const RDKit::Bond* const connector, const bool is_secondary_connection)
+{
+    auto ap_label_items = create_attachment_point_labels_for_connector(
+        connector, is_secondary_connection, m_bound_ap_label_color, *m_fonts,
+        m_scene);
+    for (auto* item : ap_label_items) {
+        m_attachment_point_labels_group.addToGroup(item);
+    }
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/standard_scene_tool_base.h
+++ b/src/schrodinger/sketcher/tool/standard_scene_tool_base.h
@@ -3,6 +3,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <QColor>
+#include <QGraphicsItemGroup>
 #include <QPen>
 #include <QPixmap>
 
@@ -12,10 +14,18 @@
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/model/non_molecular_object.h"
 #include "schrodinger/sketcher/molviewer/constants.h"
+#include "schrodinger/sketcher/molviewer/fonts.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
 #include "schrodinger/sketcher/molviewer/predictive_highlighting_item.h"
 #include "schrodinger/sketcher/molviewer/rotation_item.h"
 #include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/tool/abstract_scene_tool.h"
+
+namespace RDKit
+{
+class Atom;
+class Bond;
+} // namespace RDKit
 
 namespace schrodinger
 {
@@ -23,6 +33,11 @@ namespace sketcher
 {
 class Scene;
 class MolModel;
+
+/**
+ * A convenience function to delete all children of the group
+ */
+void clear_graphics_item_group(QGraphicsItemGroup& group);
 
 /**
  * A graphics item that shows the rotation angle's value
@@ -69,8 +84,11 @@ class MergeHintItem : public QGraphicsItemGroup
 class SKETCHER_API StandardSceneToolBase : public AbstractSceneTool
 {
   public:
-    StandardSceneToolBase(Scene* scene, MolModel* mol_model);
+    StandardSceneToolBase(const Fonts& fonts, Scene* scene,
+                          MolModel* mol_model);
+    virtual ~StandardSceneToolBase() = default;
     virtual std::vector<QGraphicsItem*> getGraphicsItems() override;
+    virtual void onStructureUpdated() override;
 
   protected:
     /**
@@ -157,6 +175,51 @@ class SKETCHER_API StandardSceneToolBase : public AbstractSceneTool
 
     MergeHintItem m_merge_hint_item = MergeHintItem();
     AngleTextItem m_angle_text_item = AngleTextItem();
+
+    // A pointer to the Scene's fonts. The Scene owns this object and outlives
+    // its scene tools, so the pointer remains valid for the lifetime of the
+    // tool. Subclasses that need to tweak the fonts (e.g. setting bold on the
+    // cursor-hint font) should make their own copy rather than modifying this.
+    const Fonts* m_fonts;
+
+    // Members supporting monomeric attachment point labels. The base class
+    // automatically updates these in onMouseMove via
+    // updateMonomericAttachmentPointLabels.
+    QGraphicsItemGroup m_attachment_point_labels_group;
+    QColor m_bound_ap_label_color = BOUND_AP_LABEL_COLOR;
+    const QGraphicsItem* m_hovered_monomeric_item = nullptr;
+
+    /**
+     * Update which attachment point labels are drawn based on what the cursor
+     * is hovering over. If the cursor is over a monomer, draw its unbound
+     * attachment points; if over a monomer connector, label the bound
+     * attachment points of the connector; otherwise, clear any labels.
+     * @param scene_pos The position in Scene coordinates
+     */
+    void updateMonomericAttachmentPointLabels(const QPointF& scene_pos);
+
+    virtual QGraphicsItem*
+    getTopMonomericItemAt(const QPointF& scene_pos) const;
+
+    /**
+     * Clear any existing attachment point labels and draw new ones for the
+     * specified monomeric graphics item. If item is nullptr, then all labels
+     * will be cleared and no new ones will be drawn.
+     */
+    virtual void
+    drawMonomericAttachmentPointLabelsFor(QGraphicsItem* const item);
+
+    /**
+     * Label both attachment points for the given monomeric connector
+     * @param connector The monomeric connector to label
+     * @param is_secondary_connection Whether this method should label the
+     * secondary connection of the bond instead of the primary connection.
+     * Secondary connections occur when a single RDKit::Bond* represents
+     * multiple connections, e.g. two neighboring cysteines that are disulfide
+     * bonded to each other.
+     */
+    void labelAttachmentPointsOnConnector(const RDKit::Bond* const connector,
+                                          const bool is_secondary_connection);
 
     /**
      * compute the pivot point for a rotation. This is the selected atom that

--- a/test/schrodinger/sketcher/molviewer/test_scene.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_scene.cpp
@@ -71,17 +71,17 @@ BOOST_AUTO_TEST_CASE(test_getInteractiveItems)
     auto scene = TestScene::getScene();
     auto items = scene->getInteractiveItems();
     BOOST_TEST(items.size() == 0);
-    BOOST_TEST(scene->items().size() == 7); // selection and highlighting items
+    BOOST_TEST(scene->items().size() == 8); // selection and highlighting items
 
     import_mol_text(scene->m_mol_model, "CC", Format::SMILES);
     items = scene->getInteractiveItems();
     BOOST_TEST(items.size() == 3); // two atoms and a bond
-    BOOST_TEST(scene->items().size() == 10);
+    BOOST_TEST(scene->items().size() == 11);
 
     scene->m_mol_model->clear();
     items = scene->getInteractiveItems();
     BOOST_TEST(items.size() == 0);
-    BOOST_TEST(scene->items().size() == 7);
+    BOOST_TEST(scene->items().size() == 8);
 }
 
 BOOST_AUTO_TEST_CASE(test_item_selection)

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(test_undo_monomer_after_hint_fragment_no_crash)
     fix.confirmIsEmpty();
 
     // moving the mouse a little crashes pre-fix because the tool's cached
-    // m_unbound_ap_items / m_hovered_item are dangling
+    // m_unbound_ap_items / m_hovered_monomeric_item are dangling
     fix.mouseMove(c_ap_pos + QPointF(5, 5));
 }
 


### PR DESCRIPTION
- Linked Case: SKETCH-2754

### Description

This PR moves the logic for labeling the attachment points of monomeric connectors from AbstractMonomerSceneTool to StandardSceneToolBase.  As a result, these labels will appear when using the select, erase, and move tools.  This required a bit of work to detangle the logic for labeling bound attachment points on monomeric connectors from the logic for labeling unbound attachment points on monomers (which is still in AbstractMonomerSceneTool).  Note that the diff here is _quite_ large, but there's no actual new logic; just a lot of moved and refactored code.

Because the labeling logic is now in StandardScenToolBase, these bound attachment point labels will also appear with the atomistic tools once those tools can be active with a monomer present in the workspace.  That seems like it's the right behavior.  The monomeric connections get labels but no predictive highlight (unless the tool is already set to highlight monomeric connections), so there's no implication that the tool would be able interact with the connections.  If anyone thinks this might be confusing to the user, let me know.  It wouldn't be hard to put the attachment point labeling stuff in it's own AbstractSceneToolWithMonomerLabels subclass, which would let us control where it's active.

There are also a few quasi-related changes here that were required for this refactoring.  (These are why this diff touches so many files.)

- All scene tool constructors now take a Fonts object (since we need fonts to generate the labels)
- AbstractHighlightingItem::highlightItems now has two overloads, one that takes a list of `QGraphicsItem*`s and one that takes a list of `const QGraphicsItem*`s.  (`QGraphicsItem*` can be implicitly coerced into a `const QGraphicsItem*`, but that conversion doesn't apply to _containers_ of pointers, so we need an explicit overload.)  I've almost needed this a handful of times and here it was required to avoid a const cast, so I had Claude do the tedious work of implementing this.

### Testing Done

All existing unit tests pass, and I confirmed that the appropriate labels appear with the select, move, and erase tools.
