### PR TITLE
SKETCH-2778: rename help_btn to avoid overly general style sheets

### DIFF
--- a/src/schrodinger/sketcher/ui/sketcher_top_bar.ui
+++ b/src/schrodinger/sketcher/ui/sketcher_top_bar.ui
@@ -271,7 +271,7 @@ QToolButton::menu-indicator{width:0px;}</string>
     </widget>
    </item>
    <item>
-    <widget class="QToolButton" name="help_btn">
+    <widget class="QToolButton" name="sketcher_help_btn">
      <property name="toolTip">
       <string>Help</string>
      </property>

--- a/src/schrodinger/sketcher/widget/sketcher_top_bar.cpp
+++ b/src/schrodinger/sketcher/widget/sketcher_top_bar.cpp
@@ -126,7 +126,7 @@ void SketcherTopBar::initMenus()
 
     // Set up "Help" menu
     m_help_menu = new HelpMenu(this);
-    ui->help_btn->setMenu(m_help_menu);
+    ui->sketcher_help_btn->setMenu(m_help_menu);
     connect(m_help_menu->m_help_act, &QAction::triggered, this,
             &SketcherTopBar::onHelpClicked);
     connect(m_more_actions_menu->m_invert_selection_act, &QAction::triggered,


### PR DESCRIPTION
- Linked Case: SKETCH-2778

### Description

The issue here was that [this commit](https://github.com/schrodinger/mmshare/commit/3bdfedad4305c61311c116a144beb198596a1e61) added a style sheet with a `help_btn` rule that gets applied to the Maestro main window, which means that it gets inherited by everything that has the Maestro main window as a parent, meaning pretty much every help_btn everywhere.  This is probably only noticeable with Sketcher since most other help_btns use the same icon.  I'll add a comment to that Jira case about the issue, but it's probably also worth renaming our help button to something less generic, which is what this PR does.  Based on past experience, this isn't an uncommon occurrence.

### Testing Done

Confirmed that the Maestro Sketcher panel has the correct help icon with this change or when changing the help_btn rule in mmshare/maestro/data/res/stylesheets/mutateresidue.sty.
