### PR TITLE
SKETCH-2782: get_residue_number_for_new_monomer now uses one residue number per monomer, even for nucleic acids

### DIFF
--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -745,11 +745,20 @@ int get_residue_number_for_new_monomer(
     auto existing_res_nums =
         get_all_residue_numbers_in_polymer(bound_to_monomer);
 
-    // first, determine what the ideal residue number would be based on the
-    // residue number of the monomer we're binding to
+    // First, determine what the "ideal" residue number would be based on the
+    // offset from the residue number of the monomer we're binding to. For
+    // example, the ideal residue number of a new C-terminal peptide is one
+    // higher than the bound peptide, and the ideal residue number of a new
+    // N-terminal peptide is one lower than the bound peptide. We refer to it as
+    // an "ideal" residue number since we don't know whether we'll actually be
+    // able to use that number; it may be non-positive, which isn't allowed, or
+    // it may already be taken by an existing monomer. In those cases, we'll
+    // just use one more than the highest current residue number, since we know
+    // that's available and valid.
+
     int res_num_offset = 1;
     if (chain_type == ChainType::PEPTIDE &&
-        new_monomer_ap_name == ap_model_name_for(PeptideAP::N)) {
+        new_monomer_ap_name == ap_model_name_for(PeptideAP::C)) {
         // a new C terminal peptide residue
         res_num_offset = -1;
     } else if (chain_type == ChainType::RNA) {
@@ -765,22 +774,23 @@ int get_residue_number_for_new_monomer(
                 // a new sugar bound to its base
                 res_num_offset = -1;
             }
-        } else if (monomer_type == MonomerType::NA_BASE &&
-                   new_monomer_ap_name == ap_model_name_for(NA_BASE_AP_N1_9)) {
-            res_num_offset = -1;
-        } else if (monomer_type == MonomerType::NA_PHOSPHATE &&
-                   new_monomer_ap_name ==
-                       ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)) {
-            res_num_offset = -1;
+        } else if (monomer_type == MonomerType::NA_PHOSPHATE) {
+            if (new_monomer_ap_name ==
+                ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)) {
+                res_num_offset = 2;
+            } else if (new_monomer_ap_name ==
+                       ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR)) {
+                res_num_offset = -1;
+            }
         }
     }
     auto bound_to_res_num =
         rdkit_extensions::get_residue_number(bound_to_monomer);
     int new_res_num = bound_to_res_num + res_num_offset;
 
-    // if the ideal residue number is not available, just use one more than the
-    // highest current residue number, since we know that's available
-    if (new_res_num < 0 || existing_res_nums.contains(new_res_num)) {
+    if (new_res_num <= 0 || existing_res_nums.contains(new_res_num)) {
+        // the ideal residue number isn't valid or isn't available. Note that
+        // residue numbers of 0 confuse HELM generation, so we avoid them.
         new_res_num = *std::ranges::max_element(existing_res_nums) + 1;
     }
     return new_res_num;

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -733,11 +733,11 @@ get_all_residue_numbers_in_polymer(const RDKit::Atom* const atom_in_polymer)
     return residue_numbers;
 }
 
-int
-get_residue_number_for_new_monomer(const std::string_view res_name,
-                                   const rdkit_extensions::ChainType chain_type,
-                                   const std::string_view new_monomer_ap_name,
-                                   const RDKit::Atom* const bound_to_monomer)
+int get_residue_number_for_new_monomer(
+    const std::string_view res_name,
+    const rdkit_extensions::ChainType chain_type,
+    const std::string_view new_monomer_ap_name,
+    const RDKit::Atom* const bound_to_monomer)
 {
     using rdkit_extensions::ChainType;
 

--- a/src/schrodinger/sketcher/model/mol_model.cpp
+++ b/src/schrodinger/sketcher/model/mol_model.cpp
@@ -712,12 +712,11 @@ get_monomer_type_from_chain_type(const rdkit_extensions::ChainType chain_type,
 }
 
 /**
- * @return a set of all residue numbers for monomers of the specified type that
- * are in the same polymer as the given atom.
+ * @return a set of all residue numbers for monomers that are in the same
+ * polymer as the given atom.
  */
 static std::unordered_set<int>
-get_all_residue_numbers_of_monomer_type_in_polymer(
-    const MonomerType monomer_type, const RDKit::Atom* const atom_in_polymer)
+get_all_residue_numbers_in_polymer(const RDKit::Atom* const atom_in_polymer)
 {
     // we make a copy of the molecule so we can flag it as monomeric
     auto mol = atom_in_polymer->getOwningMol();
@@ -728,30 +727,13 @@ get_all_residue_numbers_of_monomer_type_in_polymer(
     std::unordered_set<int> residue_numbers;
     for (auto atom_idx : atom_idxs) {
         auto* atom = mol.getAtomWithIdx(atom_idx);
-        if (get_monomer_type(atom) == monomer_type) {
-            auto res_num = rdkit_extensions::get_residue_number(atom);
-            residue_numbers.insert(res_num);
-        }
+        auto res_num = rdkit_extensions::get_residue_number(atom);
+        residue_numbers.insert(res_num);
     }
     return residue_numbers;
 }
 
-/**
- * Determine the appropriate residue number to use for a new monomer that will
- * be connected to an existing monomer.
- * @param res_name The residue name of the monomer to be added
- * @param chain_type The type of the monomer to be added
- * @param new_monomer_ap_name The new monomer's attachment point that will be
- * used to connect it to bound_to_monomer
- * @param bound_to_monomer The existing monomer that the new monomer will be
- * bound to
- * @return the residue number, which is guaranteed to be:
- *   - non-negative (since get_residue_number returns unsigned ints)
- *   - unique amongst all residues with the same monomer type (This allows,
- *     e.g., an RNA base and sugar to have the same residue number, but ensures
- *     that peptide monomers are uniquely numbered.)
- */
-static int
+int
 get_residue_number_for_new_monomer(const std::string_view res_name,
                                    const rdkit_extensions::ChainType chain_type,
                                    const std::string_view new_monomer_ap_name,
@@ -760,35 +742,44 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
     using rdkit_extensions::ChainType;
 
     auto monomer_type = get_monomer_type_from_chain_type(chain_type, res_name);
-    auto existing_res_nums = get_all_residue_numbers_of_monomer_type_in_polymer(
-        monomer_type, bound_to_monomer);
+    auto existing_res_nums =
+        get_all_residue_numbers_in_polymer(bound_to_monomer);
 
+    // first, determine what the ideal residue number would be based on the
+    // residue number of the monomer we're binding to
     int res_num_offset = 1;
-    auto bound_to_monomer_chain_type =
-        rdkit_extensions::getChainType(*bound_to_monomer);
     if (chain_type == ChainType::PEPTIDE &&
-        bound_to_monomer_chain_type == ChainType::PEPTIDE &&
         new_monomer_ap_name == ap_model_name_for(PeptideAP::N)) {
+        // a new C terminal peptide residue
         res_num_offset = -1;
-    } else if (chain_type == ChainType::RNA &&
-               bound_to_monomer_chain_type == ChainType::RNA) {
-        if (monomer_type == MonomerType::NA_SUGAR &&
-            new_monomer_ap_name == ap_model_name_for(NASugarAP::THREE_PRIME)) {
-            // sugars can link to the previous residue
+    } else if (chain_type == ChainType::RNA) {
+        if (monomer_type == MonomerType::NA_SUGAR) {
+            if (new_monomer_ap_name ==
+                ap_model_name_for(NASugarAP::THREE_PRIME)) {
+                // a new sugar bound to the next phosphate. We skip a number
+                // since the base is typically given the number immediately
+                // after the sugar
+                res_num_offset = -2;
+            } else if (new_monomer_ap_name ==
+                       ap_model_name_for(NASugarAP::ONE_PRIME)) {
+                // a new sugar bound to its base
+                res_num_offset = -1;
+            }
+        } else if (monomer_type == MonomerType::NA_BASE &&
+                   new_monomer_ap_name == ap_model_name_for(NA_BASE_AP_N1_9)) {
             res_num_offset = -1;
-        } else if (!((monomer_type == MonomerType::NA_PHOSPHATE &&
-                      new_monomer_ap_name ==
-                          ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR)) ||
-                     (monomer_type == MonomerType::NA_BASE &&
-                      new_monomer_ap_name == NA_BASE_AP_PAIR))) {
-            // phosphates and bases can link to the next residue, but all other
-            // linkages are probably within the same residue
-            res_num_offset = 0;
+        } else if (monomer_type == MonomerType::NA_PHOSPHATE &&
+                   new_monomer_ap_name ==
+                       ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)) {
+            res_num_offset = -1;
         }
     }
     auto bound_to_res_num =
         rdkit_extensions::get_residue_number(bound_to_monomer);
     int new_res_num = bound_to_res_num + res_num_offset;
+
+    // if the ideal residue number is not available, just use one more than the
+    // highest current residue number, since we know that's available
     if (new_res_num < 0 || existing_res_nums.contains(new_res_num)) {
         new_res_num = *std::ranges::max_element(existing_res_nums) + 1;
     }

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -1736,6 +1736,5 @@ get_residue_number_for_new_monomer(const std::string_view res_name,
                                    const std::string_view new_monomer_ap_name,
                                    const RDKit::Atom* const bound_to_monomer);
 
-
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -1714,5 +1714,28 @@ SKETCHER_API void add_text_to_mol_model(
     const std::optional<RDGeom::Point3D> position = std::nullopt,
     const bool recenter_view = true);
 
+/**
+ * Determine the appropriate residue number to use for a new monomer that will
+ * be connected to an existing monomer via a standard connection
+ * @param res_name The residue name of the monomer to be added
+ * @param chain_type The type of the monomer to be added, which must be the same
+ * as the chain type of bound_to_monomer (since otherwise the new residue should
+ * be a separate chain)
+ * @param new_monomer_ap_name The new monomer's attachment point that will be
+ * used to connect it to bound_to_monomer
+ * @param bound_to_monomer The existing monomer that the new monomer will be
+ * bound to
+ * @return the residue number, which is guaranteed to be:
+ *   - non-negative (since get_residue_number returns unsigned ints)
+ *   - unique amongst all residues in the same chain (The HELM reader and writer
+ *     expect one monomer per residue number, even for nucleic acids.)
+ */
+SKETCHER_API int
+get_residue_number_for_new_monomer(const std::string_view res_name,
+                                   const rdkit_extensions::ChainType chain_type,
+                                   const std::string_view new_monomer_ap_name,
+                                   const RDKit::Atom* const bound_to_monomer);
+
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/model/mol_model.h
+++ b/src/schrodinger/sketcher/model/mol_model.h
@@ -1726,7 +1726,7 @@ SKETCHER_API void add_text_to_mol_model(
  * @param bound_to_monomer The existing monomer that the new monomer will be
  * bound to
  * @return the residue number, which is guaranteed to be:
- *   - non-negative (since get_residue_number returns unsigned ints)
+ *   - positive
  *   - unique amongst all residues in the same chain (The HELM reader and writer
  *     expect one monomer per residue number, even for nucleic acids.)
  */

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -26,6 +26,7 @@
 #include <rdkit/GraphMol/FileParsers/FileParsers.h>
 #include <rdkit/GraphMol/FileParsers/MolSupplier.h>
 #include <rdkit/GraphMol/MolTransforms/MolTransforms.h>
+#include <rdkit/GraphMol/MonomerInfo.h>
 #include <rdkit/GraphMol/QueryAtom.h>
 #include <rdkit/GraphMol/QueryBond.h>
 #include <rdkit/GraphMol/ROMol.h>
@@ -4801,124 +4802,121 @@ BOOST_AUTO_TEST_CASE(test_addBoundMonomer_RNA)
 }
 
 /**
- * Test get_residue_number_for_new_monomer() for peptide chains.
- *
- * The function picks a residue number based on the residue number of the
- * monomer being bound to, an offset that depends on the chain type and the
- * attachment point used, and the set of residue numbers already in the chain.
- * For peptides:
- *   - connecting via the new monomer's N attachment point (R1) uses an offset
- *     of -1
- *   - any other attachment point uses the default offset of +1
- * If the resulting "ideal" number is negative or already taken, the function
- * instead falls back to one more than the highest existing residue number.
- *
- * Note that the function only reads the residue number and polymer of
- * bound_to_monomer; it does not require the attachment points to form a valid
- * connection, so we can drive each branch independently.
+ * Test get_residue_number_for_new_monomer() for a peptide
  */
 BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_peptide)
 {
-    using rdkit_extensions::get_residue_number;
-    const auto N_AP = ap_model_name_for(PeptideAP::N);
-    const auto C_AP = ap_model_name_for(PeptideAP::C);
-
     QUndoStack undo_stack;
     TestMolModel model(&undo_stack);
-    // residue numbers {1, 2, 3} for the three alanines
-    add_text_to_mol_model(model, "PEPTIDE1{A.A.A}$$$$V2.0");
-    const auto* res1 = model.getMol()->getAtomWithIdx(0);
-    const auto* res3 = model.getMol()->getAtomWithIdx(2);
-    BOOST_REQUIRE(get_residue_number(res1) == 1u);
-    BOOST_REQUIRE(get_residue_number(res3) == 3u);
 
-    // Offset of -1 (new monomer's N attachment point) applied to residue 1. The
-    // ideal number (1 - 1 = 0) is available, so it is used as-is. This also
-    // covers the documented guarantee that the residue number is non-negative
-    // at its lower boundary.
-    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, N_AP,
-                                                  res1) == 0);
+    // create an amino acid with a residue number of 10
+    auto mol = rdkit_extensions::to_rdkit("PEPTIDE1{A}$$$$V2.0", Format::HELM);
+    auto* res_info = static_cast<RDKit::AtomPDBResidueInfo*>(
+        mol->getAtomWithIdx(0)->getMonomerInfo());
+    res_info->setResidueNumber(10);
+    model.addMol(*mol);
+    auto peptide = model.getMol()->getAtomWithIdx(0);
+    BOOST_REQUIRE(rdkit_extensions::get_residue_number(peptide) == 10u);
 
-    // Default offset of +1 (any non-N attachment point) applied to residue 3,
-    // the highest in the chain. The ideal number (3 + 1 = 4) is available.
-    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, C_AP,
-                                                  res3) == 4);
+    // check residue numbers for the previous and next peptide
+    auto prev_peptide_num = get_residue_number_for_new_monomer(
+        "C", ChainType::PEPTIDE, ap_model_name_for(PeptideAP::C), peptide);
+    auto next_peptide_num = get_residue_number_for_new_monomer(
+        "C", ChainType::PEPTIDE, ap_model_name_for(PeptideAP::N), peptide);
+    BOOST_TEST(prev_peptide_num == 9u);
+    BOOST_TEST(next_peptide_num == 11u);
 
-    // Fallback when the ideal number is already taken: the default +1 offset
-    // applied to residue 1 yields 2, which is already used, so the function
-    // falls back to one more than the highest existing number (3 + 1 = 4).
-    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, C_AP,
-                                                  res1) == 4);
+    // add a new amino acid so we can check what happens when the ideal residue
+    // numbers is already assigned to an existing monomer
+    model.addBoundMonomer("C", ChainType::PEPTIDE, {1.0, 0.0, 0.0},
+                          ap_model_name_for(PeptideAP::N), peptide,
+                          ap_model_name_for(PeptideAP::C));
+    peptide = model.getMol()->getAtomWithIdx(0);
+    next_peptide_num = get_residue_number_for_new_monomer(
+        "C", ChainType::PEPTIDE, ap_model_name_for(PeptideAP::N), peptide);
+    BOOST_TEST(next_peptide_num == 12u);
 }
 
 /**
- * Test get_residue_number_for_new_monomer() for RNA chains, where the offset
- * depends on both the monomer type (sugar/base/phosphate, derived from the new
- * monomer's residue name) and the attachment point used:
- *   - new sugar via its 3' attachment point (R2): offset -2 (a number is
- *     skipped to leave room for the sugar's base)
- *   - new sugar via its 1' attachment point (R3): offset -1
- *   - new base via its N1/N9 attachment point (R1): offset -1
- *   - new phosphate via its attachment point to the previous sugar (R1):
- *     offset -1
- *   - anything else: default offset of +1
+ * Test get_residue_number_for_new_monomer() for a nucleic acid sugar
  */
-BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_rna)
+BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_na_sugar)
 {
-    using rdkit_extensions::get_residue_number;
-
     QUndoStack undo_stack;
     TestMolModel model(&undo_stack);
-    // RNA1{R(A)P} gives a sugar (residue 1), a base (residue 2), and a
-    // phosphate (residue 3)
-    add_text_to_mol_model(model, "RNA1{R(A)P}$$$$V2.0");
-    const auto* sugar = model.getMol()->getAtomWithIdx(0);
-    const auto* base = model.getMol()->getAtomWithIdx(1);
-    const auto* phosphate = model.getMol()->getAtomWithIdx(2);
-    BOOST_REQUIRE(get_residue_number(sugar) == 1u);
-    BOOST_REQUIRE(get_residue_number(base) == 2u);
-    BOOST_REQUIRE(get_residue_number(phosphate) == 3u);
 
-    // New base via its N1/N9 attachment point (R1): offset -1 applied to the
-    // sugar (residue 1). Ideal number 1 - 1 = 0 is available.
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "A", ChainType::RNA, ap_model_name_for(NA_BASE_AP_N1_9),
-                   sugar) == 0);
+    // create a sugar with a residue number of 10
+    auto mol = rdkit_extensions::to_rdkit("RNA1{R}$$$$V2.0", Format::HELM);
+    auto* res_info = static_cast<RDKit::AtomPDBResidueInfo*>(
+        mol->getAtomWithIdx(0)->getMonomerInfo());
+    res_info->setResidueNumber(10);
+    model.addMol(*mol);
+    auto sugar = model.getMol()->getAtomWithIdx(0);
+    BOOST_REQUIRE(rdkit_extensions::get_residue_number(sugar) == 10u);
 
-    // New phosphate via its attachment point to the previous sugar (R1): offset
-    // -1 applied to the sugar (residue 1). Ideal number 1 - 1 = 0 is available.
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "P", ChainType::RNA,
-                   ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR),
-                   sugar) == 0);
+    // check residue numbers for a base and phosphates bound to the sugar
+    auto base_num = get_residue_number_for_new_monomer(
+        "A", ChainType::RNA, ap_model_name_for(NA_BASE_AP_N1_9), sugar);
+    auto next_phos_num = get_residue_number_for_new_monomer(
+        "P", ChainType::RNA, ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR),
+        sugar);
+    auto prev_phos_num = get_residue_number_for_new_monomer(
+        "P", ChainType::RNA, ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR),
+        sugar);
+    BOOST_TEST(base_num == 11u);
+    BOOST_TEST(next_phos_num == 12u);
+    BOOST_TEST(prev_phos_num == 9u);
+}
 
-    // New sugar via its 1' attachment point (R3): offset -1 applied to the
-    // sugar (residue 1). Ideal number 1 - 1 = 0 is available.
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "R", ChainType::RNA, ap_model_name_for(NASugarAP::ONE_PRIME),
-                   sugar) == 0);
+/**
+ * Test get_residue_number_for_new_monomer() for a nucleic acid phosphate
+ */
+BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_na_phosphate)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
 
-    // New sugar via its 3' attachment point (R2): offset -2 applied to the base
-    // (residue 2). Ideal number 2 - 2 = 0 is available.
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "R", ChainType::RNA,
-                   ap_model_name_for(NASugarAP::THREE_PRIME), base) == 0);
+    // create a phosphate with a residue number of 10
+    auto mol = rdkit_extensions::to_rdkit("RNA1{P}$$$$V2.0", Format::HELM);
+    auto* res_info = static_cast<RDKit::AtomPDBResidueInfo*>(
+        mol->getAtomWithIdx(0)->getMonomerInfo());
+    res_info->setResidueNumber(10);
+    model.addMol(*mol);
+    auto phosphate = model.getMol()->getAtomWithIdx(0);
+    BOOST_REQUIRE(rdkit_extensions::get_residue_number(phosphate) == 10u);
 
-    // New phosphate via its attachment point to the next sugar (R2): not a
-    // special case, so the default +1 offset applies. Applied to the phosphate
-    // (residue 3, the highest), ideal number 3 + 1 = 4 is available.
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "P", ChainType::RNA,
-                   ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR),
-                   phosphate) == 4);
+    // check residue numbers for sugars bound to the phosphate
+    auto prev_sugar_num = get_residue_number_for_new_monomer(
+        "R", ChainType::RNA, ap_model_name_for(NASugarAP::THREE_PRIME),
+        phosphate);
+    auto next_sugar_num = get_residue_number_for_new_monomer(
+        "R", ChainType::RNA, ap_model_name_for(NASugarAP::FIVE_PRIME),
+        phosphate);
+    BOOST_TEST(prev_sugar_num == 8u);
+    BOOST_TEST(next_sugar_num == 11u);
+}
 
-    // Fallback to the negative-number branch: the new sugar's 3' offset of -2
-    // applied to the sugar (residue 1) gives an ideal number of 1 - 2 = -1.
-    // Since that is negative, the function falls back to one more than the
-    // highest existing number (3 + 1 = 4).
-    BOOST_TEST(get_residue_number_for_new_monomer(
-                   "R", ChainType::RNA,
-                   ap_model_name_for(NASugarAP::THREE_PRIME), sugar) == 4);
+/**
+ * Test get_residue_number_for_new_monomer() for a nucleic acid base
+ */
+BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_na_base)
+{
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+
+    // create a base with a residue number of 10
+    auto mol = rdkit_extensions::to_rdkit("RNA1{A}$$$$V2.0", Format::HELM);
+    auto* res_info = static_cast<RDKit::AtomPDBResidueInfo*>(
+        mol->getAtomWithIdx(0)->getMonomerInfo());
+    res_info->setResidueNumber(10);
+    model.addMol(*mol);
+    auto base = model.getMol()->getAtomWithIdx(0);
+    BOOST_REQUIRE(rdkit_extensions::get_residue_number(base) == 10u);
+
+    // check residue number for a sugar bound to the base
+    auto sugar_num = get_residue_number_for_new_monomer(
+        "R", ChainType::RNA, ap_model_name_for(NASugarAP::ONE_PRIME), base);
+    BOOST_TEST(sugar_num == 9);
 }
 
 /**

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4834,8 +4834,8 @@ BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_peptide)
 
     // Offset of -1 (new monomer's N attachment point) applied to residue 1. The
     // ideal number (1 - 1 = 0) is available, so it is used as-is. This also
-    // covers the documented guarantee that the residue number is non-negative at
-    // its lower boundary.
+    // covers the documented guarantee that the residue number is non-negative
+    // at its lower boundary.
     BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, N_AP,
                                                   res1) == 0);
 
@@ -4869,8 +4869,8 @@ BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_rna)
 
     QUndoStack undo_stack;
     TestMolModel model(&undo_stack);
-    // RNA1{R(A)P} gives a sugar (residue 1), a base (residue 2), and a phosphate
-    // (residue 3)
+    // RNA1{R(A)P} gives a sugar (residue 1), a base (residue 2), and a
+    // phosphate (residue 3)
     add_text_to_mol_model(model, "RNA1{R(A)P}$$$$V2.0");
     const auto* sugar = model.getMol()->getAtomWithIdx(0);
     const auto* base = model.getMol()->getAtomWithIdx(1);
@@ -4889,10 +4889,11 @@ BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_rna)
     // -1 applied to the sugar (residue 1). Ideal number 1 - 1 = 0 is available.
     BOOST_TEST(get_residue_number_for_new_monomer(
                    "P", ChainType::RNA,
-                   ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR), sugar) == 0);
+                   ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR),
+                   sugar) == 0);
 
-    // New sugar via its 1' attachment point (R3): offset -1 applied to the sugar
-    // (residue 1). Ideal number 1 - 1 = 0 is available.
+    // New sugar via its 1' attachment point (R3): offset -1 applied to the
+    // sugar (residue 1). Ideal number 1 - 1 = 0 is available.
     BOOST_TEST(get_residue_number_for_new_monomer(
                    "R", ChainType::RNA, ap_model_name_for(NASugarAP::ONE_PRIME),
                    sugar) == 0);

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4801,6 +4801,126 @@ BOOST_AUTO_TEST_CASE(test_addBoundMonomer_RNA)
 }
 
 /**
+ * Test get_residue_number_for_new_monomer() for peptide chains.
+ *
+ * The function picks a residue number based on the residue number of the
+ * monomer being bound to, an offset that depends on the chain type and the
+ * attachment point used, and the set of residue numbers already in the chain.
+ * For peptides:
+ *   - connecting via the new monomer's N attachment point (R1) uses an offset
+ *     of -1
+ *   - any other attachment point uses the default offset of +1
+ * If the resulting "ideal" number is negative or already taken, the function
+ * instead falls back to one more than the highest existing residue number.
+ *
+ * Note that the function only reads the residue number and polymer of
+ * bound_to_monomer; it does not require the attachment points to form a valid
+ * connection, so we can drive each branch independently.
+ */
+BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_peptide)
+{
+    using rdkit_extensions::get_residue_number;
+    const auto N_AP = ap_model_name_for(PeptideAP::N);
+    const auto C_AP = ap_model_name_for(PeptideAP::C);
+
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    // residue numbers {1, 2, 3} for the three alanines
+    add_text_to_mol_model(model, "PEPTIDE1{A.A.A}$$$$V2.0");
+    const auto* res1 = model.getMol()->getAtomWithIdx(0);
+    const auto* res3 = model.getMol()->getAtomWithIdx(2);
+    BOOST_REQUIRE(get_residue_number(res1) == 1u);
+    BOOST_REQUIRE(get_residue_number(res3) == 3u);
+
+    // Offset of -1 (new monomer's N attachment point) applied to residue 1. The
+    // ideal number (1 - 1 = 0) is available, so it is used as-is. This also
+    // covers the documented guarantee that the residue number is non-negative at
+    // its lower boundary.
+    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, N_AP,
+                                                  res1) == 0);
+
+    // Default offset of +1 (any non-N attachment point) applied to residue 3,
+    // the highest in the chain. The ideal number (3 + 1 = 4) is available.
+    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, C_AP,
+                                                  res3) == 4);
+
+    // Fallback when the ideal number is already taken: the default +1 offset
+    // applied to residue 1 yields 2, which is already used, so the function
+    // falls back to one more than the highest existing number (3 + 1 = 4).
+    BOOST_TEST(get_residue_number_for_new_monomer("G", ChainType::PEPTIDE, C_AP,
+                                                  res1) == 4);
+}
+
+/**
+ * Test get_residue_number_for_new_monomer() for RNA chains, where the offset
+ * depends on both the monomer type (sugar/base/phosphate, derived from the new
+ * monomer's residue name) and the attachment point used:
+ *   - new sugar via its 3' attachment point (R2): offset -2 (a number is
+ *     skipped to leave room for the sugar's base)
+ *   - new sugar via its 1' attachment point (R3): offset -1
+ *   - new base via its N1/N9 attachment point (R1): offset -1
+ *   - new phosphate via its attachment point to the previous sugar (R1):
+ *     offset -1
+ *   - anything else: default offset of +1
+ */
+BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_rna)
+{
+    using rdkit_extensions::get_residue_number;
+
+    QUndoStack undo_stack;
+    TestMolModel model(&undo_stack);
+    // RNA1{R(A)P} gives a sugar (residue 1), a base (residue 2), and a phosphate
+    // (residue 3)
+    add_text_to_mol_model(model, "RNA1{R(A)P}$$$$V2.0");
+    const auto* sugar = model.getMol()->getAtomWithIdx(0);
+    const auto* base = model.getMol()->getAtomWithIdx(1);
+    const auto* phosphate = model.getMol()->getAtomWithIdx(2);
+    BOOST_REQUIRE(get_residue_number(sugar) == 1u);
+    BOOST_REQUIRE(get_residue_number(base) == 2u);
+    BOOST_REQUIRE(get_residue_number(phosphate) == 3u);
+
+    // New base via its N1/N9 attachment point (R1): offset -1 applied to the
+    // sugar (residue 1). Ideal number 1 - 1 = 0 is available.
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "A", ChainType::RNA, ap_model_name_for(NA_BASE_AP_N1_9),
+                   sugar) == 0);
+
+    // New phosphate via its attachment point to the previous sugar (R1): offset
+    // -1 applied to the sugar (residue 1). Ideal number 1 - 1 = 0 is available.
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "P", ChainType::RNA,
+                   ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR), sugar) == 0);
+
+    // New sugar via its 1' attachment point (R3): offset -1 applied to the sugar
+    // (residue 1). Ideal number 1 - 1 = 0 is available.
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "R", ChainType::RNA, ap_model_name_for(NASugarAP::ONE_PRIME),
+                   sugar) == 0);
+
+    // New sugar via its 3' attachment point (R2): offset -2 applied to the base
+    // (residue 2). Ideal number 2 - 2 = 0 is available.
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "R", ChainType::RNA,
+                   ap_model_name_for(NASugarAP::THREE_PRIME), base) == 0);
+
+    // New phosphate via its attachment point to the next sugar (R2): not a
+    // special case, so the default +1 offset applies. Applied to the phosphate
+    // (residue 3, the highest), ideal number 3 + 1 = 4 is available.
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "P", ChainType::RNA,
+                   ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR),
+                   phosphate) == 4);
+
+    // Fallback to the negative-number branch: the new sugar's 3' offset of -2
+    // applied to the sugar (residue 1) gives an ideal number of 1 - 2 = -1.
+    // Since that is negative, the function falls back to one more than the
+    // highest existing number (3 + 1 = 4).
+    BOOST_TEST(get_residue_number_for_new_monomer(
+                   "R", ChainType::RNA,
+                   ap_model_name_for(NASugarAP::THREE_PRIME), sugar) == 4);
+}
+
+/**
  * Confirm that combining two peptide chains via a standard backbone connection
  * produces HELM output with only a single chain
  */

--- a/test/schrodinger/sketcher/model/test_mol_model.cpp
+++ b/test/schrodinger/sketcher/model/test_mol_model.cpp
@@ -4892,7 +4892,11 @@ BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_na_phosphate)
     auto next_sugar_num = get_residue_number_for_new_monomer(
         "R", ChainType::RNA, ap_model_name_for(NASugarAP::FIVE_PRIME),
         phosphate);
+    // the base is expected to be numbered in between the previous sugar and
+    // this phosphate, so we skip 9 and instead assign 8 to the previous sugar
     BOOST_TEST(prev_sugar_num == 8u);
+    // the next base should get 12 (i.e. be numbered after the next sugar), so
+    // we don't need to skip a number between this phosphate and the next sugar
     BOOST_TEST(next_sugar_num == 11u);
 }
 
@@ -4916,6 +4920,8 @@ BOOST_AUTO_TEST_CASE(test_get_residue_number_for_new_monomer_na_base)
     // check residue number for a sugar bound to the base
     auto sugar_num = get_residue_number_for_new_monomer(
         "R", ChainType::RNA, ap_model_name_for(NASugarAP::ONE_PRIME), base);
+    // the base should be numbered after the sugar, so the sugar should get 9
+    // (instead of 11)
     BOOST_TEST(sugar_num == 9);
 }
 


### PR DESCRIPTION
- Linked Case: SKETCH-2782

### Description

Based on [this discussion](https://github.com/schrodinger/sketcher/pull/367#discussion_r3364753980), I've modified `get_residue_number_for_new_monomer` to use one residue number per monomer, even for nucleic acids.

### Testing Done

Added unit tests coverage for the new logic.
