### PR TITLE
SKETCH-2754: Fix test_scene linker error from const signature change

### DIFF
--- a/test/schrodinger/sketcher/molviewer/test_scene.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_scene.cpp
@@ -122,9 +122,9 @@ BOOST_AUTO_TEST_CASE(test_ensureCompleteAttachmentPoints)
     import_mol_text(scene->m_mol_model, "CC* |$;;_AP1$|", Format::SMILES);
     auto mol = scene->m_mol_model->getMol();
     auto* ap_atom = mol->getAtomWithIdx(2);
-    auto* ap_atom_item = scene->m_atom_to_atom_item.at(ap_atom);
+    const auto* ap_atom_item = scene->m_atom_to_atom_item.at(ap_atom);
     auto* ap_bond = mol->getBondWithIdx(1);
-    auto* ap_bond_item = scene->m_bond_to_bond_item.at(ap_bond);
+    const auto* ap_bond_item = scene->m_bond_to_bond_item.at(ap_bond);
 
     // test with attachment point atom
     auto complete_items = scene->ensureCompleteAttachmentPoints({ap_atom_item});
@@ -140,14 +140,14 @@ BOOST_AUTO_TEST_CASE(test_ensureCompleteAttachmentPoints)
 
     // test with non-attachment point atom
     auto* c_atom = mol->getAtomWithIdx(1);
-    auto* c_atom_item = scene->m_atom_to_atom_item.at(c_atom);
+    const auto* c_atom_item = scene->m_atom_to_atom_item.at(c_atom);
     complete_items = scene->ensureCompleteAttachmentPoints({c_atom_item});
     BOOST_TEST(complete_items.size() == 1);
     BOOST_TEST(complete_items.contains(c_atom_item));
 
     // test with non-attachment point bond
     auto* cc_bond = mol->getBondWithIdx(0);
-    auto* cc_bond_item = scene->m_bond_to_bond_item.at(cc_bond);
+    const auto* cc_bond_item = scene->m_bond_to_bond_item.at(cc_bond);
     complete_items = scene->ensureCompleteAttachmentPoints({cc_bond_item});
     BOOST_TEST(complete_items.size() == 1);
     BOOST_TEST(complete_items.contains(cc_bond_item));


### PR DESCRIPTION
- Linked Case: SKETCH-2754

### Description

@aidanfike fixed this issue on mmshare with https://github.com/schrodinger/mmshare/pull/9907, so I'm just porting his fix to the `sketcher` repo here.  Basically, in https://github.com/schrodinger/sketcher/pull/368, I forgot to add `const` to a few pointers in the unit tests, so those tests wind up passing a `QList` of `QGraphicsItem*`s to a function that expects a `QList` of `const QGraphicsItem*`s.  That's not allowed, but it was only triggering an error on Linux build sandboxes; other build environments were doing an implicit conversion.

### Testing Done

Ran the tests locally.
