### PR TITLE
SKETCH-2649: is_polymer_annotation_s_group no longer requires ANNOTATION and ID properties

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/helm_utils.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/helm_utils.cpp
@@ -183,6 +183,18 @@ std::vector<std::string> get_polymer_ids(const RDKit::ROMol& monomer_mol)
     return polymer_ids;
 }
 
+/**
+ * @return the value of the prop_name property from rd_prop, if present.
+ * Otherwise, returns an empty string.
+ */
+static std::string get_string_prop_if_present(const RDKit::RDProps& rd_prop,
+                                              const std::string& prop_name)
+{
+    std::string prop_val;
+    rd_prop.getPropIfPresent<std::string>(prop_name, prop_val);
+    return prop_val;
+}
+
 Chain get_polymer(const RDKit::ROMol& monomer_mol, std::string_view polymer_id)
 {
     std::vector<unsigned int> atoms;
@@ -216,8 +228,8 @@ Chain get_polymer(const RDKit::ROMol& monomer_mol, std::string_view polymer_id)
         if (!is_polymer_annotation_s_group(sg)) {
             continue;
         }
-        if (sg.getProp<std::string>("ID") == polymer_id) {
-            annotation = sg.getProp<std::string>(ANNOTATION);
+        if (get_string_prop_if_present(sg, "ID") == polymer_id) {
+            annotation = get_string_prop_if_present(sg, ANNOTATION);
             break;
         }
     }
@@ -258,8 +270,7 @@ is_supplementary_information_s_group(const RDKit::SubstanceGroup& sgroup)
 is_polymer_annotation_s_group(const RDKit::SubstanceGroup& sgroup)
 {
     std::string type;
-    return sgroup.getPropIfPresent("TYPE", type) && type == "COP" &&
-           sgroup.hasProp(ANNOTATION) && sgroup.hasProp("ID");
+    return sgroup.getPropIfPresent("TYPE", type) && type == "COP";
 }
 
 std::string get_extended_annotations(const ::RDKit::ROMol& mol)

--- a/test/schrodinger/rdkit_extensions/test_helm_utils.cpp
+++ b/test/schrodinger/rdkit_extensions/test_helm_utils.cpp
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 #include <rdkit/GraphMol/ROMol.h>
 #include <rdkit/GraphMol/RWMol.h>
+#include <rdkit/GraphMol/SubstanceGroup.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -18,6 +19,7 @@ using helm::rdkit_to_helm;
 using schrodinger::rdkit_extensions::extract_helm_polymers;
 using schrodinger::rdkit_extensions::get_atoms_in_polymer_chain;
 using schrodinger::rdkit_extensions::get_atoms_in_polymer_chains;
+using schrodinger::rdkit_extensions::get_polymer;
 using schrodinger::rdkit_extensions::is_polymer_annotation_s_group;
 
 namespace bdata = boost::unit_test::data;
@@ -77,6 +79,36 @@ BOOST_AUTO_TEST_CASE(TestAtomisticMolsAreUnsupported)
                       std::invalid_argument);
     BOOST_CHECK_THROW(std::ignore = get_atoms_in_polymer_chains(mol, {}),
                       std::invalid_argument);
+}
+
+/**
+ * Ensure that get_polymer works correctly even if there's a COP substance group
+ * that's missing the ANNOTATION and ID properties.
+ */
+BOOST_DATA_TEST_CASE(TestGetPolymerIgnoresEmptyPolymerAnnotationSGroup,
+                     bdata::make(std::vector<bool>{false, true}),
+                     create_empty_s_group)
+{
+    auto mol =
+        helm_to_rdkit(R"(PEPTIDE1{A.A.A}"Alpha"|PEPTIDE2{C.C}"Beta"$$$$V2.0)");
+    if (create_empty_s_group) {
+        RDKit::SubstanceGroup sgroup{mol.get(), "COP"};
+        RDKit::addSubstanceGroup(*mol, sgroup);
+    }
+
+    const atoms_t expected_peptide1_atoms{0, 1, 2};
+    const atoms_t expected_peptide1_bonds{0, 1};
+    const auto peptide1 = get_polymer(*mol, "PEPTIDE1");
+    BOOST_TEST(peptide1.atoms == expected_peptide1_atoms);
+    BOOST_TEST(peptide1.bonds == expected_peptide1_bonds);
+    BOOST_TEST(peptide1.annotation == "Alpha");
+
+    const atoms_t expected_peptide2_atoms{3, 4};
+    const atoms_t expected_peptide2_bonds{2};
+    const auto peptide2 = get_polymer(*mol, "PEPTIDE2");
+    BOOST_TEST(peptide2.atoms == expected_peptide2_atoms);
+    BOOST_TEST(peptide2.bonds == expected_peptide2_bonds);
+    BOOST_TEST(peptide2.annotation == "Beta");
 }
 
 BOOST_AUTO_TEST_SUITE(TestPolymerExtraction)


### PR DESCRIPTION
- Linked Case: SKETCH-2649

### Description

`rdkit_extensions::is_polymer_annotation_s_group`  now returns `true` for any S-group with a type of "COP" and no longer requires that the ANNOTATION or ID properties are present.  This means that Sketcher will stop displaying the "co" text for monomeric models that have one of these S-groups.  

### Testing Done

I tested by generating images with schrodinger.livedesign.cmdline after reverting the mmshare changes for the original fix (https://github.com/schrodinger/mmshare/pull/6582/changes).  I had to enable the `LDBIO_KB_RDMOL_HASHING` feature flag to generate an image with the incorrect "co" in the middle, but I then applied these changes to mmshare and confirmed that new images didn't contain the "co".   I'll include that revert in the mmshare version of this PR since that code won't be needed any longer.  (Those files don't exist in the `sketcher` repo, so I can't include those changes here.)

I also added a new unit test to confirm that `get_polymer` doesn't throw an exception when a COP S-group is missing the ANNOTATION and ID properties.