### PR TITLE
SKETCH-2797: Fixing highlighting path generation

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
@@ -60,17 +60,18 @@ QPainterPath AbstractHighlightingItem::buildHighlightingPathForItems(
     const QList<const QGraphicsItem*>& items) const
 {
     QPainterPath path;
-    // Set fill rule to ensure overlapping areas don't create "holes"
-    path.setFillRule(Qt::WindingFill);
-
     for (auto item : items) {
         if (auto* molviewer_item =
                 dynamic_cast<const AbstractGraphicsItem*>(item)) {
             QPainterPath local_path = getPathForItem(molviewer_item);
-            path.addPath(molviewer_item->mapToScene(local_path));
+            // We can't use addPath here, since that will result in the path
+            // being "hollowed out" where the path for two monomers intersects.
+            // E.g., there will be a hole in the selection highlighting between
+            // a nucleic acid sugar and base when both are selected.
+            path |= molviewer_item->mapToScene(local_path);
         }
     }
-    return path.simplified();
+    return path;
 }
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2797

### Description

This reverts the AbstractHighlightingItem changes from https://github.com/schrodinger/mmshare/pull/5798 (and adds an explanatory comment), since those changes are causing selection paths to be generated incorrectly  when there's an overlap in the path, most notably for nucleic acids:
<img width="400" height="259" alt="image" src="https://github.com/user-attachments/assets/e322e7be-3772-4ced-90eb-db63a352927c" />
Here's the same image after this revert:
<img width="318" height="181" alt="image" src="https://github.com/user-attachments/assets/88cb6d36-cd54-4b8e-a605-1174cdaacf09" />

@matvey83, I have vague memories of you saying that the measurable speedup in SKETCH-2604 was from the signal disconnection and not the path generation.  Is that right?  The slowdown in that case happened as soon as the user starting selecting anything, right?  It didn't kick in only when the selection path was complicated?  I just wanted to sanity check that we don't need to worry about re-introducing any performance issues here.  I wouldn't expect these calculations to take any observable amount of time even with a fairly sizable selection.

### Testing Done

Generated the above images.
