### PR TITLE
SHARED-12500: Cherry-pick four commits

### DIFF
--- a/src/schrodinger/rdkit_extensions/monomer_database.cpp
+++ b/src/schrodinger/rdkit_extensions/monomer_database.cpp
@@ -1162,6 +1162,14 @@ MonomerDatabase::getComplexMonomerQueries() const
                 }
             }
         }
+
+        // Sort by descending number of atoms so that toMonomeric() will give
+        // precedence to the larger complex monomer in cases where one complex
+        // monomer is a substructure of another.
+        std::ranges::sort(queries, {}, [](auto& q) {
+            return -static_cast<int>(q.mol->getNumAtoms());
+        });
+
         m_complex_monomer_queries = std::move(queries);
     }
     return *m_complex_monomer_queries;

--- a/src/schrodinger/rdkit_extensions/monomer_database.cpp
+++ b/src/schrodinger/rdkit_extensions/monomer_database.cpp
@@ -32,6 +32,7 @@
 
 #include "sqlite3.h"
 
+#include "schrodinger/rdkit_extensions/capture_rdkit_log.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h" // ChainType
 #include "schrodinger/rdkit_extensions/monomer_db_schema.h"
 #include "schrodinger/rdkit_extensions/monomer_db_default_monomers.h"
@@ -549,7 +550,11 @@ std::vector<std::string> enumerate_smiles(const std::string& smiles)
         // to the output vector.
         if (!found_mapnum) {
             // The mols we check against have all Hs removed.
-            RDKit::MolOps::removeAllHs(*mol);
+            try {
+                RDKit::MolOps::removeAllHs(*mol);
+            } catch (const RDKit::MolSanitizeException&) {
+                continue;
+            }
             enumerated_smiles.push_back(RDKit::MolToSmiles(*mol));
         }
     }
@@ -987,6 +992,7 @@ const std::unordered_map<std::string, std::string>&
 MonomerDatabase::getEnumeratedCoreSmiles() const
 {
     if (!m_enumerated_core_smiles_cache.has_value()) {
+        schrodinger::rdkit_extensions::CaptureRDErrorLog rdkit_log;
         std::unordered_map<std::string, std::string> core_smiles_to_monomer;
 
         for (auto& [smiles, symbol] : getAllSMILES()) {

--- a/src/schrodinger/rdkit_extensions/monomer_database.h
+++ b/src/schrodinger/rdkit_extensions/monomer_database.h
@@ -63,6 +63,14 @@ struct RDKIT_EXTENSIONS_API ResidueQuery {
     /// Whether to consider chirality while doing the substructure search.
     /// Usually false for generic queries but true for specific monomers.
     bool use_chirality;
+
+    /// Getter for calling from Python.
+    // (I gave up on trying to get SWIG to convert the type of mol correctly
+    // when accessing the member variable directly.)
+    boost::shared_ptr<RDKit::RWMol> getMol() const
+    {
+        return mol;
+    }
 };
 
 class RDKIT_EXTENSIONS_API MonomerDatabase : public boost::noncopyable

--- a/src/schrodinger/rdkit_extensions/to_monomeric.cpp
+++ b/src/schrodinger/rdkit_extensions/to_monomeric.cpp
@@ -1127,7 +1127,7 @@ buildMonomerMol(const RDKit::ROMol& atomistic_mol,
     if (monomers.size() == 1) {
         auto& monomer = monomers.front();
         auto helm_symbol = findHelmSymbol(atomistic_mol, monomer);
-        if (!helm_symbol) {
+        if (!helm_symbol && allow_smiles) {
             addMonomer(*monomer_mol, RDKit::MolToSmiles(atomistic_mol), 1,
                        "CHEM1", MonomerType::SMILES);
             return monomer_mol;

--- a/src/schrodinger/rdkit_extensions/to_monomeric.cpp
+++ b/src/schrodinger/rdkit_extensions/to_monomeric.cpp
@@ -86,13 +86,13 @@ ResidueQuery prepare_static_mol_query(const char* smarts_query,
 // attachment points 1 and 2 are backbone attachment points,
 // 8 is the side chain attachment point, 3 is cysteine's sulfur
 static const ResidueQuery CYSTEINE_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+:1][CX4H]([CX4H2][S:3])[CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H]([CX4H2][S:3])[CX3:2](=[OX1])[O,#7:9]",
     "CYSTEINE")}; // matches C, dC, meC
 static const ResidueQuery GENERIC_AMINO_ACID_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+:1][CX4H]([*:8])[CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H]([*:8])[CX3:2](=[OX1])[O,#7:9]",
     "GENERIC")};
 static const ResidueQuery GLYCINE_AMINO_ACID_QUERY{prepare_static_mol_query(
-    "[NX3,NX4+:1][CX4H2][CX3:2](=[OX1])[O,N:9]",
+    "[NX3,NX4+:1][CX4H2][CX3:2](=[OX1])[O,#7:9]",
     "GLYCINE")}; // no side chain
 // clang-format on
 


### PR DESCRIPTION
- Linked Case: SHARED-12500

### Description

This is just a cherry-picking of the following patches from mmshare, all of which are for bugfix tickets spun off from SHARED-12500:

```
SHARED-12519: honor allow_smiles flag for 1-monomer chains (#10184)
SHARED-12512: Sort complex monomer queries by size (#10164)
SHARED-12505: allow aromatic nitrogen in peptide bonds (#10100)
SHARED-12499: Catch sanitization errors when enumerating SMILES (#10086)
```

### Testing Done

Built locally.