### PR TITLE
SKETCH-2802: Fixing valgrind error from trying to paint an empty bond annotation at an uninitialized angle

### DIFF
--- a/src/schrodinger/sketcher/molviewer/bond_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/bond_item.cpp
@@ -710,13 +710,15 @@ void BondItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
         painter->setClipPath(annotation_region);
         paintBondLinesAndPolygons(painter);
         painter->restore();
-        // paint the annotation
-        painter->save();
-        painter->setPen(m_chirality_pen);
-        painter->setFont(m_fonts.m_chirality_font);
-        paintAnnotation(painter, m_text_angle, m_text_pos, m_text_size,
-                        m_annotation_text);
-        painter->restore();
+        if (!m_annotation_text.isEmpty()) {
+            // paint the annotation text if there is any
+            painter->save();
+            painter->setPen(m_chirality_pen);
+            painter->setFont(m_fonts.m_chirality_font);
+            paintAnnotation(painter, m_text_angle, m_text_pos, m_text_size,
+                            m_annotation_text);
+            painter->restore();
+        }
     } else {
         paintBondLinesAndPolygons(painter);
     }
@@ -903,11 +905,11 @@ QPolygonF BondItem::getAnnotationPolygon()
     transform.rotate(-m_text_angle);
     return transform.map(QPolygonF(bounding_rect));
 }
+
 void BondItem::paintAnnotation(QPainter* painter, qreal angle,
                                const QPointF& text_pos, const QSizeF& text_size,
                                const QString& text)
 {
-    painter->save();
     // Position and rotate the painter to the correct angle
     painter->translate(text_pos);
     painter->rotate(-angle);
@@ -917,8 +919,6 @@ void BondItem::paintAnnotation(QPainter* painter, qreal angle,
     auto rect = QRectF(QPointF(0, 0), text_size);
     rect.moveCenter(QPointF(0, 0));
     painter->drawText(rect, text);
-    // Restore the painter's original state
-    painter->restore();
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/molviewer/bond_item.h
+++ b/src/schrodinger/sketcher/molviewer/bond_item.h
@@ -410,7 +410,9 @@ class SKETCHER_API BondItem : public AbstractBondOrConnectorItem
      */
     QPolygonF getAnnotationPolygon();
 
-    /** Paint text annontation .
+    /**
+     * Paint text annontation. Note that this function will modify the QPainter
+     * and the calling scope is responsible for resetting it.
      *
      * @param painter  the qt painter to be used
      * @param angle  the angle of the annotation text

--- a/test/schrodinger/sketcher/molviewer/test_bond_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_bond_item.cpp
@@ -8,7 +8,9 @@
 #include <rdkit/GraphMol/ROMol.h>
 #include <rdkit/GraphMol/RWMol.h>
 #include <QGraphicsItem>
+#include <QImage>
 #include <QLineF>
+#include <QPainter>
 #include <QPointF>
 #include <QPolygonF>
 #include <QtGlobal>
@@ -349,6 +351,24 @@ BOOST_AUTO_TEST_CASE(test_bond_stereo_tooltips)
         }
     }
     BOOST_TEST(found_stereo_bond);
+}
+
+/**
+ * Paint a bond that has no bond annotation, but is bound to an atom with a
+ * chirality label. This test is primarily intended so that Valgrind can confirm
+ * that we're not trying to paint an empty annotation using an uninitialized
+ * angle. See SKETCH-2801.
+ */
+BOOST_AUTO_TEST_CASE(test_chiral_atom_no_bond_annotation)
+{
+    auto [bond_items, scene] = createStructure("N[C@@H](C)C(=O)O |r:2|");
+    // paint the whole scene
+    QImage image(800, 600, QImage::Format::Format_ARGB32);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    // bonds 0, 1, and 2 don't have any annotation, but are all bound to an atom
+    // with a chiral label
+    scene->render(&painter);
 }
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2802

### Description

The issue here was that `BondItem::paint` would attempt to paint the bond annotation text if either:
- there was bond annotation text to paint
- or if one of the bound atoms had a chirality label

When only the second condition was true, this meant that `BondItem::paint` would try to paint an empty bond annotation string at an uninitialized angle, and Valgrind complained when `paintAnnotation` tried to rotate the QPainter by the uninitialized angle.  The intent of this code was to make text more readable in either of those two scenarios (by applying partial transparency behind the text for any sort of nearby label), but the code was missing a `!m_annotation_text.isEmpty()` check before it tried to paint the bond annotation itself.

This PR:
  - adds in the `!m_annotation_text.isEmpty()` check to fix the error
  - adds in a unit test that would've caught this error
  - gets rid of redundant `QPainter::save()` and `QPainter::restore()` calls in `BondItem::paintAnnotation`.  (`paintAnnotation` is only called from one spot, and that spot already calls `QPainter::save()` and `QPainter::restore()`)

I'll merge this fix into 2026-3 in the `sketcher` repo once I've pushed it to master, and I'll file the mmshare PR against 2026-3.  Valgrind also went a bit crazy with Jira cases for this issue, so I think this PR fixes SKETCH-2801 through SKETCH-2810.  I'll close all of the relevant cases once this is pushed and the mmshare memtests pass.

### Testing Done

I've confirmed that the new test would've caused the `sketcher` memtest runner to fail without these changes, and confirmed that the relevant mmshare memtests now pass after removing the suppressions.
