### PR TITLE
SKETCH-2812: Improving performance of highlighting path merging

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_highlighting_item.cpp
@@ -1,6 +1,7 @@
 #include "schrodinger/sketcher/molviewer/abstract_highlighting_item.h"
 
 #include <functional>
+#include <vector>
 
 #include <QList>
 
@@ -56,22 +57,41 @@ QList<const QGraphicsItem*> AbstractHighlightingItem::updateItemsToHighlight(
     return items;
 }
 
+/**
+ * Calculate the union of all specified paths. This function uses
+ * divide-and-conquer to keep the intermediate paths as small as possible, which
+ * dramatically improves performance over a naive for loop implementation.
+ */
+QPainterPath merge_paths(const std::vector<QPainterPath>& paths,
+                         const size_t begin, const size_t end)
+{
+    if (begin == end) {
+        return {};
+    }
+    if (begin + 1 == end) {
+        return paths[begin];
+    }
+
+    size_t mid = begin + (end - begin) / 2;
+    auto left = merge_paths(paths, begin, mid);
+    auto right = merge_paths(paths, mid, end);
+    return left | right;
+}
+
 QPainterPath AbstractHighlightingItem::buildHighlightingPathForItems(
     const QList<const QGraphicsItem*>& items) const
 {
-    QPainterPath path;
+    std::vector<QPainterPath> paths;
+
     for (auto item : items) {
         if (auto* molviewer_item =
                 dynamic_cast<const AbstractGraphicsItem*>(item)) {
-            QPainterPath local_path = getPathForItem(molviewer_item);
-            // We can't use addPath here, since that will result in the path
-            // being "hollowed out" where the path for two monomers intersects.
-            // E.g., there will be a hole in the selection highlighting between
-            // a nucleic acid sugar and base when both are selected.
-            path |= molviewer_item->mapToScene(local_path);
+            auto local_path = getPathForItem(molviewer_item);
+            auto scene_path = molviewer_item->mapToScene(local_path);
+            paths.push_back(scene_path);
         }
     }
-    return path;
+    return merge_paths(paths, 0, paths.size());
 }
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2812

### Description

My fix for SKETCH-2797 appears to have had a larger impact on performance than I expected based on the results from [this performance test](https://stu.schrodinger.com/performance/test/1016#metric7674-average-image-generation-with-highlighting-smiles-6-molecules-seconds).  I attempted to see the changes from that case had reintroduced the Maestro 2D overlay lag, but I wasn't able to trigger any lag even after reverting all of Matvey's speed ups.  This PR, however, appears to almost completely restore the old performance test behavior, at least according to local runs.  That means that it should hopefully fix any Maestro 2D overlay issues that may or may not have been introduced.

This change simply tweaks how we calculate the union of a bunch of QPainterPaths, using an approach that Codex came up with.  Basically, instead of unioning each path one-by-one onto an increasingly complex accumulated path, we instead use divide-and-conquer to merge the paths by recursively unioning the first half of the path list with the second half of the path list.  This keeps the intermediate paths as small as possible, which speeds up each individual union operation.

I was somewhat skeptical that this would have a substantial impact on performance, but it appears to have almost completely eliminated the slow down we got from SKETCH-2797.  We'll get a better idea of this once the change is merged into mmshare and we get official performance test results, but I'm cautiously optimistic that this will solve any potential issues here.

### Testing Done

Ran the performance tests locally, and confirmed that highlighting paths look correct in the Windows desktop app.
