### PR TITLE
SKETCH-2779: Creating monomeric connection tool

### DIFF
--- a/src/schrodinger/sketcher/icons/monomeric_connection.svg
+++ b/src/schrodinger/sketcher/icons/monomeric_connection.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 30 32"
+   style="enable-background:new 0 0 30 32;"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+<style
+   type="text/css"
+   id="style1">
+	.st0{fill:#666666;}
+</style>
+<g
+   id="g1">
+	<rect
+   x="4.290565"
+   y="14.508935"
+   transform="rotate(-0.03205834)"
+   class="st0"
+   width="21.399361"
+   height="2.9999104"
+   id="rect1"
+   style="stroke-width:0.99997" />
+</g>
+</svg>

--- a/src/schrodinger/sketcher/model/sketcher_model.cpp
+++ b/src/schrodinger/sketcher/model/sketcher_model.cpp
@@ -62,6 +62,7 @@ std::vector<ModelKey> get_model_keys()
         ModelKey::CHARGE_TOOL,
         ModelKey::RING_TOOL,
         ModelKey::ENUMERATION_TOOL,
+        ModelKey::MONOMERIC_CONNECTION_TOOL,
         ModelKey::ELEMENT,
         ModelKey::ATOM_QUERY,
         ModelKey::RGROUP_NUMBER,
@@ -128,6 +129,12 @@ RingTool SketcherModel::getRingTool() const
 EnumerationTool SketcherModel::getEnumerationTool() const
 {
     return m_model_map.at(ModelKey::ENUMERATION_TOOL).value<EnumerationTool>();
+}
+
+MonomericConnectionTool SketcherModel::getMonomericConnectionTool() const
+{
+    return m_model_map.at(ModelKey::MONOMERIC_CONNECTION_TOOL)
+        .value<MonomericConnectionTool>();
 }
 
 Element SketcherModel::getElement() const
@@ -240,6 +247,8 @@ void SketcherModel::reset()
         {ModelKey::RING_TOOL, QVariant::fromValue(RingTool::CYCLOPROPANE)},
         {ModelKey::ENUMERATION_TOOL,
          QVariant::fromValue(EnumerationTool::NEW_RGROUP)},
+        {ModelKey::MONOMERIC_CONNECTION_TOOL,
+         QVariant::fromValue(MonomericConnectionTool::COVALENT_OR_DISULFIDE)},
         {ModelKey::ELEMENT, QVariant::fromValue(Element::C)},
         {ModelKey::ATOM_QUERY, QVariant::fromValue(AtomQuery::A)},
         {ModelKey::RGROUP_NUMBER, 1u},

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -239,6 +239,11 @@ enum class EnumerationTool : int {
     RXN_PLUS,
 };
 
+enum class MonomericConnectionTool : int {
+    COVALENT_OR_DISULFIDE,
+    HBOND,
+};
+
 /**
  * Possible draw tools.
  *
@@ -260,6 +265,7 @@ enum class DrawTool {
     RESIDUE,
     EXPLICIT_H,
     MONOMER,
+    MONOMERIC_CONNECTION,
 };
 
 /**
@@ -280,6 +286,7 @@ enum class ModelKey {
     CHARGE_TOOL,
     RING_TOOL,
     ENUMERATION_TOOL,
+    MONOMERIC_CONNECTION_TOOL,
     ELEMENT,
     ATOM_QUERY,
     RGROUP_NUMBER,
@@ -519,6 +526,7 @@ class SKETCHER_API SketcherModel : public QObject
     ChargeTool getChargeTool() const;
     RingTool getRingTool() const;
     EnumerationTool getEnumerationTool() const;
+    MonomericConnectionTool getMonomericConnectionTool() const;
     Element getElement() const;
     AtomQuery getAtomQuery() const;
     MonomerToolType getMonomerToolType() const;

--- a/src/schrodinger/sketcher/molviewer/monomer_constants.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_constants.h
@@ -275,6 +275,15 @@ const qreal MONOMER_CONNECTOR_ARROWHEAD_RADIUS = 6;
 const QColor DRAG_END_INACTIVE_AP = QColor("#EEEEEE");
 const QColor DRAG_END_INACTIVE_AP_DARK_BG = QColor("#555555");
 
+// constants describing the line shown when dragging the connection tool to
+// empty space (which can't create a connection)
+const QColor CONNECTION_TOOL_INVALID_DRAG_COLOR = QColor("#EEEEEE");
+const QColor CONNECTION_TOOL_INVALID_DRAG_COLOR_DARK_BG = QColor("#555555");
+const qreal CONNECTION_TOOL_INVALID_DRAG_LINE_WIDTH = 2.0;
+
+const QColor CONNECTION_TOOL_AP_LABEL_HOVER_COLOR = QColor("#444444");
+const QColor CONNECTION_TOOL_AP_LABEL_HOVER_COLOR_DARK_BG = QColor("#EEEEEE");
+
 /**
  * A scaling factor for generating the cursor hints for monomers. If this value
  * is greater than one, then the cursor hint for smaller monomers (as measured

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -48,6 +48,7 @@
 #include "schrodinger/sketcher/tool/draw_fragment_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_monomer_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.h"
+#include "schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_r_group_scene_tool.h"
 #include "schrodinger/sketcher/tool/edit_charge_scene_tool.h"
 #include "schrodinger/sketcher/tool/move_rotate_scene_tool.h"
@@ -772,6 +773,12 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
                     sugar.toStdString(), base.toStdString(), phos.toStdString(),
                     m_fonts, this, m_mol_model);
             }
+        }
+    } else if (draw_tool == DrawTool::MONOMERIC_CONNECTION) {
+        auto connection_tool = m_sketcher_model->getMonomericConnectionTool();
+        if (connection_tool == MonomericConnectionTool::COVALENT_OR_DISULFIDE) {
+            return std::make_shared<DrawMonomericConnectionSceneTool>(
+                m_fonts, this, m_mol_model);
         }
     }
     // tool not yet implemented

--- a/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.cpp
@@ -214,6 +214,7 @@ void UnboundMonomericAttachmentPointItem::setColor(const QColor& color)
 {
     m_line_pen.setColor(color);
     m_circle_brush.setColor(color);
+    update();
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/sketcher.qrc
+++ b/src/schrodinger/sketcher/sketcher.qrc
@@ -46,6 +46,7 @@
     <file>icons/mode_erase.svg</file>
     <file>icons/mode_erase_dis.svg</file>
     <file>icons/mode_monomer.svg</file>
+    <file>icons/monomeric_connection.svg</file>
     <file>icons/periodic_table.svg</file>
     <file>icons/periodic_table_dis.svg</file>
     <file>icons/reaction_arrow.svg</file>

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -1,0 +1,794 @@
+#include "schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <QtAssert>
+#include <QtMath>
+#include <QGraphicsItem>
+#include <QGraphicsSimpleTextItem>
+#include <QPainterPath>
+#include <QPen>
+
+#include <rdkit/Geometry/point.h>
+#include <rdkit/GraphMol/Conformer.h>
+#include <rdkit/GraphMol/ROMol.h>
+#include <rdkit/GraphMol/RWMol.h>
+
+#include "schrodinger/rdkit_extensions/helm.h"
+#include "schrodinger/rdkit_extensions/monomer_directions.h"
+#include "schrodinger/rdkit_extensions/monomer_mol.h"
+#include "schrodinger/sketcher/molviewer/abstract_graphics_item.h"
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h"
+#include "schrodinger/sketcher/molviewer/monomer_connector_item.h"
+#include "schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h"
+#include "schrodinger/sketcher/molviewer/monomer_utils.h"
+#include "schrodinger/sketcher/molviewer/scene.h"
+#include "schrodinger/sketcher/molviewer/scene_utils.h"
+#include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+using rdkit_extensions::Direction;
+
+AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(
+        const std::string& res_name,
+        const rdkit_extensions::ChainType chain_type, const Fonts& fonts,
+        Scene* scene, MolModel* mol_model) :
+    AbstractMonomerSceneTool(fonts, scene, mol_model),
+    m_res_name(res_name),
+    m_chain_type(chain_type),
+    m_bolded_fonts(fonts)
+{
+    // we handle predictive highlighting manually in onMouseMove, so we disable
+    // StandardSceneToolsBase's predictive highlighting
+    m_highlight_types = InteractiveItemFlag::NONE;
+    // make sure that the cursor hint font is more easily readable at small
+    // size. (Note that m_bolded_fonts is a copy of the Scene's fonts, so this
+    // change won't affect anything else.)
+    m_bolded_fonts.m_main_label_font.setBold(true);
+    m_bolded_fonts.updateFontMetrics();
+    if (chain_type == rdkit_extensions::ChainType::PEPTIDE) {
+        m_monomer_type = MonomerType::PEPTIDE;
+    } else if (chain_type == rdkit_extensions::ChainType::CHEM) {
+        m_monomer_type = MonomerType::CHEM;
+    } else {
+        m_monomer_type = get_na_monomer_type_from_res_name(res_name);
+    }
+}
+
+AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    ~AbstractDrawMonomerOrMonomericConnectionSceneTool()
+{
+    // explicitly erase any drag end attachment point labels. Without this, the
+    // bound attachment point labels would be deleted regardless when
+    // m_drag_end_attachment_point_labels_group is destroyed, but the unbound
+    // attachment point labels are parented to their monomer, so they would
+    // outlive the scene tool without this call.
+    clearDragEndAttachmentPointsLabels();
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::onStructureUpdated()
+{
+    AbstractMonomerSceneTool::onStructureUpdated();
+    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
+    // any drag-end attachment point graphics items have already been deleted in
+    // response to their parent monomer graphics item being deleted due to the
+    // structure update. We're just clear the stale pointers here
+    m_drag_end_unbound_ap_items.clear();
+    m_drag_start_monomer_item = nullptr;
+    m_drag_end_monomer_item = nullptr;
+}
+
+std::vector<QGraphicsItem*>
+AbstractDrawMonomerOrMonomericConnectionSceneTool::getGraphicsItems()
+{
+    auto items = AbstractMonomerSceneTool::getGraphicsItems();
+    items.push_back(&m_drag_end_attachment_point_labels_group);
+    return items;
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    updateColorsAfterBackgroundColorChange(bool is_dark_mode)
+{
+    AbstractMonomerSceneTool::updateColorsAfterBackgroundColorChange(
+        is_dark_mode);
+    m_monomer_background_color =
+        is_dark_mode ? DARK_BACKGROUND_COLOR : LIGHT_BACKGROUND_COLOR;
+    m_drag_end_inactive_ap_color =
+        is_dark_mode ? DRAG_END_INACTIVE_AP_DARK_BG : DRAG_END_INACTIVE_AP;
+}
+
+UnboundMonomericAttachmentPointItem* find_preferred_attachment_point_by_num(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
+    const std::vector<int>& preferred_order)
+{
+    auto index_of = [&preferred_order](const auto* ap_item) {
+        auto it = std::ranges::find(preferred_order,
+                                    ap_item->getAttachmentPoint().num);
+        auto dist = std::distance(preferred_order.begin(), it);
+        // we know that dist is positive
+        return static_cast<std::size_t>(dist);
+    };
+    auto min_it = std::ranges::min_element(
+        unbound_ap_items,
+        [&index_of](const auto* ap_item_left, const auto* ap_item_right) {
+            return index_of(ap_item_left) < index_of(ap_item_right);
+        });
+    // make sure that the attachment point we found is actually on the
+    // preferred_order list
+    if (index_of(*min_it) < preferred_order.size()) {
+        return *min_it;
+    }
+    return nullptr;
+}
+
+UnboundMonomericAttachmentPointItem* find_min_attachment_point_by_num(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
+{
+    auto min_it = std::ranges::min_element(
+        unbound_ap_items,
+        [](const auto* ap_item_left, const auto* ap_item_right) {
+            auto left_num = ap_item_left->getAttachmentPoint().num;
+            auto right_num = ap_item_right->getAttachmentPoint().num;
+            return right_num < 0 || (left_num >= 0 && left_num < right_num);
+        });
+    return *min_it;
+}
+
+UnboundMonomericAttachmentPointItem* find_attachment_point_with_name(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
+    const std::string_view name)
+{
+    auto it =
+        std::ranges::find_if(unbound_ap_items, [&name](const auto* ap_item) {
+            return (ap_item->getAttachmentPoint().model_name == name);
+        });
+    if (it == unbound_ap_items.end()) {
+        return nullptr;
+    }
+    return *it;
+}
+
+/**
+ * @return the unbound attachment point graphics item representing an attachment
+ * point with the given number. Will return nullptr if no such attachment point
+ * is found.
+ */
+[[nodiscard]] static UnboundMonomericAttachmentPointItem*
+find_attachment_point_with_num(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
+    const int num)
+{
+    auto it =
+        std::ranges::find_if(unbound_ap_items, [&num](const auto* ap_item) {
+            return (ap_item->getAttachmentPoint().num == num);
+        });
+    if (it == unbound_ap_items.end()) {
+        return nullptr;
+    }
+    return *it;
+}
+
+UnboundMonomericAttachmentPointItem* get_default_attachment_point(
+    const MonomerType hovered_type, const MonomerType tool_type,
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
+{
+    if (unbound_ap_items.empty()) {
+        return nullptr;
+    } else if (hovered_type == MonomerType::CHEM) {
+        return find_min_attachment_point_by_num(unbound_ap_items);
+    } else if (hovered_type == MonomerType::PEPTIDE) {
+        if (tool_type == MonomerType::PEPTIDE) {
+            return find_preferred_attachment_point_by_num(
+                unbound_ap_items,
+                {PeptideAP::C, PeptideAP::N, PeptideAP::SIDECHAIN});
+        } else if (tool_type == MonomerType::CHEM) {
+            return find_attachment_point_with_num(unbound_ap_items,
+                                                  PeptideAP::SIDECHAIN);
+        }
+    } else if (hovered_type == MonomerType::NA_BASE) {
+        if (tool_type == MonomerType::NA_BASE ||
+            tool_type == MonomerType::CHEM) {
+            return find_attachment_point_with_name(unbound_ap_items,
+                                                   NA_BASE_AP_PAIR);
+        } else if (tool_type == MonomerType::NA_SUGAR) {
+            return find_attachment_point_with_num(unbound_ap_items,
+                                                  NA_BASE_AP_N1_9);
+        }
+    } else if (hovered_type == MonomerType::NA_SUGAR) {
+        if (tool_type == MonomerType::NA_BASE) {
+            return find_attachment_point_with_num(unbound_ap_items,
+                                                  NASugarAP::ONE_PRIME);
+        } else if (tool_type == MonomerType::NA_PHOSPHATE) {
+            return find_preferred_attachment_point_by_num(
+                unbound_ap_items,
+                {NASugarAP::THREE_PRIME, NASugarAP::FIVE_PRIME});
+        }
+    } else if (hovered_type == MonomerType::NA_PHOSPHATE) {
+        if (tool_type == MonomerType::NA_SUGAR) {
+            return find_preferred_attachment_point_by_num(
+                unbound_ap_items,
+                {NAPhosphateAP::TO_NEXT_SUGAR, NAPhosphateAP::TO_PREV_SUGAR});
+        }
+    }
+    return nullptr;
+}
+
+std::string
+get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
+                                     const std::string_view existing_monomer_ap,
+                                     const MonomerType new_monomer_type)
+{
+    switch (new_monomer_type) {
+        case MonomerType::CHEM:
+            return "R1";
+        case MonomerType::PEPTIDE:
+            if (existing_monomer_type == MonomerType::PEPTIDE) {
+                if (existing_monomer_ap == ap_model_name_for(PeptideAP::N)) {
+                    return ap_model_name_for(PeptideAP::C);
+                } else if (existing_monomer_ap ==
+                           ap_model_name_for(PeptideAP::C)) {
+                    return ap_model_name_for(PeptideAP::N);
+                }
+            }
+            return ap_model_name_for(PeptideAP::SIDECHAIN);
+        case MonomerType::NA_BASE:
+            if (existing_monomer_type == MonomerType::NA_SUGAR &&
+                existing_monomer_ap ==
+                    ap_model_name_for(NASugarAP::ONE_PRIME)) {
+                return ap_model_name_for(NA_BASE_AP_N1_9);
+            }
+            return NA_BASE_AP_PAIR;
+        case MonomerType::NA_SUGAR:
+            if (existing_monomer_type == MonomerType::NA_PHOSPHATE) {
+                if (existing_monomer_ap ==
+                    ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)) {
+                    return ap_model_name_for(NASugarAP::THREE_PRIME);
+                } else if (existing_monomer_ap ==
+                           ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR)) {
+                    return ap_model_name_for(NASugarAP::FIVE_PRIME);
+                }
+            }
+            return ap_model_name_for(NASugarAP::ONE_PRIME);
+        case MonomerType::NA_PHOSPHATE:
+            if (existing_monomer_type == MonomerType::NA_SUGAR &&
+                existing_monomer_ap ==
+                    ap_model_name_for(NASugarAP::THREE_PRIME)) {
+                return ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR);
+            }
+            return ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR);
+        default:
+            Q_UNREACHABLE_RETURN("");
+    }
+}
+
+UnboundMonomericAttachmentPointItem*
+AbstractDrawMonomerOrMonomericConnectionSceneTool::getUnboundAttachmentPointAt(
+    const QPointF& scene_pos,
+    const bool no_default_if_click_should_mutate) const
+{
+    if (m_unbound_ap_items.empty()) {
+        return nullptr;
+    }
+    for (auto* ap_item : m_unbound_ap_items) {
+        if (ap_item->withinHoverArea(scene_pos)) {
+            return ap_item;
+        }
+    }
+    return getDefaultUnboundAttachmentPointForHoveredMonomer(
+        no_default_if_click_should_mutate);
+}
+
+std::tuple<const RDKit::Atom*, MonomerType>
+get_monomer_and_type(const AbstractMonomerItem* const monomer_item)
+{
+    auto* monomer = monomer_item->getAtom();
+    auto monomer_type = get_monomer_type(monomer);
+    return {monomer, monomer_type};
+}
+
+UnboundMonomericAttachmentPointItem*
+AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    getUnboundDragEndAttachmentPointAt(const QPointF& scene_pos) const
+{
+    if (m_drag_end_unbound_ap_items.empty()) {
+        return nullptr;
+    }
+    for (auto* ap_item : m_drag_end_unbound_ap_items) {
+        if (ap_item->withinHoverArea(scene_pos)) {
+            return ap_item;
+        }
+    }
+
+    // get the monomer type for the start and end monomers
+    auto get_drag_monomer_type =
+        [this](const AbstractMonomerItem* const monomer_item) {
+            if (monomer_item == nullptr) {
+                return m_monomer_type;
+            }
+            auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
+            return monomer_type;
+        };
+    auto drag_start_monomer_type =
+        get_drag_monomer_type(m_drag_start_monomer_item);
+    auto drag_end_monomer_type = get_drag_monomer_type(m_drag_end_monomer_item);
+
+    // if the user is hovered over the monomer itself (not an attachment point)
+    // and the "correct" attachment point is available (e.g. N terminus when we
+    // dragged from a C terminus), use that one
+    auto ideal_ap_model_name = get_attachment_point_for_new_monomer(
+        drag_start_monomer_type, m_drag_start_ap_model_name,
+        drag_end_monomer_type);
+    for (auto* ap_item : m_drag_end_unbound_ap_items) {
+        if (ap_item->getAttachmentPoint().model_name == ideal_ap_model_name) {
+            return ap_item;
+        }
+    }
+
+    // if the correct attachment point isn't available then there's probably no
+    // good option, so use whatever we would've defaulted if we'd started the
+    // drag at this monomer.
+    return get_default_attachment_point(drag_end_monomer_type,
+                                        drag_start_monomer_type,
+                                        m_drag_end_unbound_ap_items);
+}
+
+std::tuple<const RDKit::Atom*, MonomerType>
+AbstractDrawMonomerOrMonomericConnectionSceneTool::getHoveredMonomerAndType()
+    const
+{
+    if (!item_matches_type_flag(m_hovered_monomeric_item,
+                                InteractiveItemFlag::MONOMER)) {
+        throw std::runtime_error("No hovered monomer");
+    }
+    const auto* monomer_item =
+        static_cast<const AbstractMonomerItem*>(m_hovered_monomeric_item);
+    return get_monomer_and_type(monomer_item);
+}
+
+UnboundMonomericAttachmentPointItem*
+AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    getDefaultUnboundAttachmentPointForHoveredMonomer(
+        const bool no_default_if_click_should_mutate) const
+{
+    auto [monomer, monomer_type] = getHoveredMonomerAndType();
+    if (no_default_if_click_should_mutate &&
+        clickShouldMutate(monomer, monomer_type)) {
+        return nullptr;
+    }
+    return get_default_attachment_point(monomer_type, m_monomer_type,
+                                        m_unbound_ap_items);
+}
+
+bool AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    shouldShowPredictiveHighlighting() const
+{
+
+    if (m_hovered_monomeric_item == nullptr ||
+        !item_matches_type_flag(m_hovered_monomeric_item,
+                                InteractiveItemFlag::MONOMER)) {
+        return false;
+    }
+    auto [monomer, monomer_type] = getHoveredMonomerAndType();
+    if (clickShouldMutate(monomer, monomer_type)) {
+        return true;
+    }
+    return get_default_attachment_point(monomer_type, m_monomer_type,
+                                        m_unbound_ap_items) != nullptr;
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::onMouseMove(
+    QGraphicsSceneMouseEvent* const event)
+{
+    // the base class call updates m_hovered_monomeric_item and the attachment
+    // point labels
+    auto prev_hovered_monomeric_item = m_hovered_monomeric_item;
+    AbstractMonomerSceneTool::onMouseMove(event);
+    if (m_mouse_pressed) {
+        // drag logic is handled in onDragMove
+        return;
+    }
+    QPointF scene_pos = event->scenePos();
+
+    if (m_hovered_monomeric_item != prev_hovered_monomeric_item) {
+        if (shouldShowPredictiveHighlighting()) {
+            m_predictive_highlighting_item.highlightItem(
+                m_hovered_monomeric_item);
+        } else {
+            m_predictive_highlighting_item.clearHighlightingPath();
+        }
+    }
+
+    auto* hovered_ap_item = getUnboundAttachmentPointAt(scene_pos, true);
+    if (hovered_ap_item != m_hovered_ap_item) {
+        // update which attachment point is hovered
+        m_hovered_ap_item = hovered_ap_item;
+        updateHoveredUnboundAP(hovered_ap_item);
+    }
+
+    // we want to show either the hint fragment or the cursor hint, but not both
+    bool drew_hint_fragment = hovered_ap_item != nullptr;
+    setCursorHintShown(!drew_hint_fragment);
+}
+
+static RDGeom::Point3D get_coords_for_monomer(const RDKit::Atom* const monomer)
+{
+    auto& conf = monomer->getOwningMol().getConformer();
+    return conf.getAtomPos(monomer->getIdx());
+}
+
+RDGeom::Point3D
+get_default_coords_for_bound_monomer(const RDKit::Atom* const monomer,
+                                     const Direction dir)
+{
+    auto monomer_pos = get_coords_for_monomer(monomer);
+    return get_default_coords_for_bound_monomer(monomer_pos, dir);
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::createHintFragmentItem(
+    HintFragmentMonomerInfo& monomer_one_info,
+    HintFragmentMonomerInfo& monomer_two_info)
+{
+    auto frag = std::make_shared<RDKit::RWMol>();
+
+    // create the two monomers
+    auto monomer_one_idx =
+        frag->addAtom(monomer_one_info.monomer.release(), true, true);
+    auto monomer_two_idx =
+        frag->addAtom(monomer_two_info.monomer.release(), true, true);
+    set_all_atoms_monomeric(*frag);
+    // create the connection between them
+    auto bond_index_to_label = add_monomer_connection(
+        *frag, monomer_one_idx, monomer_one_info.ap_model_name, monomer_two_idx,
+        monomer_two_info.ap_model_name);
+
+    // Add a conformer with the atom coordinates
+    auto* frag_conf = new RDKit::Conformer(frag->getNumAtoms());
+    frag_conf->set3D(false);
+    frag_conf->setAtomPos(monomer_one_idx, monomer_one_info.pos);
+    frag_conf->setAtomPos(monomer_two_idx, monomer_two_info.pos);
+    frag->addConformer(frag_conf, true);
+
+    // hide the monomers that already exist in the Scene
+    std::vector<size_t> atom_indices_to_hide;
+    if (monomer_one_info.atom_idx >= 0) {
+        atom_indices_to_hide.push_back(monomer_one_idx);
+    }
+    if (monomer_two_info.atom_idx >= 0) {
+        atom_indices_to_hide.push_back(monomer_two_idx);
+    }
+
+    m_hint_fragment_item = new MonomerHintFragmentItem(
+        frag, m_bolded_fonts, atom_indices_to_hide, bond_index_to_label,
+        m_monomer_background_color);
+    m_scene->addItem(m_hint_fragment_item);
+}
+
+std::string AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    getDefaultDragStartAPModelName() const
+{
+    return m_monomer_type == MonomerType::NA_BASE
+               ? NA_BASE_AP_PAIR
+               : ap_model_name_for(PeptideAP::C);
+}
+
+HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    createHintFragmentMonomerInfoForHintFromEmptySpace(
+        const QPointF& scene_pos) const
+{
+    auto chain_id = rdkit_extensions::toString(m_chain_type) + "1";
+    auto monomer =
+        rdkit_extensions::makeMonomer(m_res_name, chain_id, 1, false);
+    auto monomer_pos = to_mol_xy(scene_pos);
+    auto linkage_start = getDefaultDragStartAPModelName();
+    // returned monomer is owned by the calling scope
+    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type,
+                                   monomer_pos, linkage_start,
+                                   NEW_MONOMER_FROM_DRAG};
+}
+
+HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+        const AbstractMonomerItem* const monomer_item,
+        const std::string& ap_model_name) const
+{
+    auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
+    // returned monomer is owned by the calling scope
+    auto copy_of_monomer = std::make_unique<RDKit::Atom>(*monomer);
+    auto monomer_pos = get_coords_for_monomer(monomer);
+    auto monomer_idx = static_cast<int>(monomer->getIdx());
+    return HintFragmentMonomerInfo{std::move(copy_of_monomer), monomer_type,
+                                   monomer_pos, ap_model_name, monomer_idx};
+}
+
+HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+        const AbstractMonomerItem* const monomer_item,
+        const UnboundMonomericAttachmentPointItem* const ap_item) const
+{
+    auto ap_model_name = ap_item->getAttachmentPoint().model_name;
+    return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+        monomer_item, ap_model_name);
+}
+
+HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    createHintFragmentMonomerInfoForHintToDirection(
+        const HintFragmentMonomerInfo& start_monomer_info,
+        const Direction direction) const
+{
+    auto pos =
+        get_default_coords_for_bound_monomer(start_monomer_info.pos, direction);
+    // We'll determine the correct values for chain id and residue number
+    // when/if the structure is actually added to MolModel. For the hint,
+    // though, just generate something reasonable looking.
+    auto chain_id = rdkit_extensions::toString(m_chain_type) + "1";
+    auto res_num = 2;
+    // returned monomer is owned by the calling scope
+    auto monomer =
+        rdkit_extensions::makeMonomer(m_res_name, chain_id, res_num, false);
+    auto ap_model_name = get_attachment_point_for_new_monomer(
+        start_monomer_info.monomer_type, start_monomer_info.ap_model_name,
+        m_monomer_type);
+    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type, pos,
+                                   ap_model_name, NEW_MONOMER_FROM_DRAG};
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragStart(
+    QGraphicsSceneMouseEvent* const event)
+{
+    AbstractMonomerSceneTool::onLeftButtonDragStart(event);
+    m_drag_start_monomer_item = getTopMonomerItemAt(m_mouse_press_scene_pos);
+    if (m_drag_start_monomer_item == nullptr) {
+        m_drag_start_ap_model_name = getDefaultDragStartAPModelName();
+    } else {
+        auto ap_item =
+            getUnboundAttachmentPointAt(m_mouse_press_scene_pos, false);
+        if (ap_item == nullptr) {
+            // this monomer has no available attachment points. In this
+            // scenario, createDragHint will return false below and we'll ignore
+            // the drag.
+            m_drag_start_ap_model_name = "";
+        } else {
+            m_drag_start_ap_model_name =
+                ap_item->getAttachmentPoint().model_name;
+        }
+    }
+    // clear the attachment point labels. Note that this must happen *after* the
+    // getUnboundAttachmentPointAt call, since that method requires the
+    // attachment points to be in the Scene
+    clearAttachmentPointsLabelsAndHintFragmentItem();
+
+    // since the drag just started, we can safely assume that we're not over a
+    // different monomer than m_drag_start_monomer_item, which means we want a
+    // drag to direction, not to another's monomer attachment point
+    // auto dir = getDragDirection(event->scenePos());
+    auto [drag_end_info, _] = getDragEndInfo(event->scenePos());
+    // TODO: this is why drags aren't working for the connection tool, since the
+    // connection tool returns false for drags to a direction
+    auto handled = createDragHintIfDragStartValid(drag_end_info);
+    if (handled) {
+        // hide the cursor hint while the hint structure is shown. Note that the
+        // cursor hint will have already been hidden if we started this drag
+        // from a monomer, since hovering over a monomer hides the cursor hint
+        // (since it shows the hint structure).  If this drag started from empty
+        // space, though, then this call is necessary to hide the cursor hint.
+        setCursorHintShown(false);
+    } else {
+        m_drag_start_monomer_item = nullptr;
+    }
+    m_drag_ignored = !handled;
+}
+
+bool AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    createDragHintIfDragStartValid(const DragEndInfo& drag_end_info)
+{
+    clearHintFragmentItem();
+    auto hint_start_monomer_info = getHintFragmentMonomerInfoForDragStart();
+    if (!hint_start_monomer_info.has_value()) {
+        return false;
+    }
+    auto hint_end_monomer_info = getHintFragmentMonomerInfoForDragEnd(
+        *hint_start_monomer_info, drag_end_info);
+    if (!hint_end_monomer_info.has_value()) {
+        return false;
+    }
+    createHintFragmentItem(*hint_start_monomer_info, *hint_end_monomer_info);
+
+    return true;
+}
+
+std::pair<DragEndInfo, AbstractMonomerItem*>
+AbstractDrawMonomerOrMonomericConnectionSceneTool::getDragEndInfo(
+    const QPointF& scene_pos)
+{
+    auto* hovered_monomer_item = getTopMonomerItemAt(scene_pos);
+    if (hovered_monomer_item == m_drag_start_monomer_item) {
+        // we can't drag from a monomer to itself
+        hovered_monomer_item = nullptr;
+    }
+    UnboundMonomericAttachmentPointItem* drag_end_ap_item =
+        (hovered_monomer_item == nullptr)
+            ? nullptr
+            : getUnboundDragEndAttachmentPointAt(scene_pos);
+
+    // if we're dragging between two existing monomers, make sure that we'd be
+    // able to actually add a connection between them. Any pair of monomers can
+    // have at most one standard backbone connection and one custom connection
+    // (i.e. not a standard backbone connection) between them, since our RDKit
+    // monomer format currently doesn't support more than that
+    if (m_drag_start_monomer_item != nullptr && drag_end_ap_item != nullptr) {
+        auto* monomer_start = m_drag_start_monomer_item->getAtom();
+        auto* monomer_end = hovered_monomer_item->getAtom();
+        auto* connection = m_mol_model->getMol()->getBondBetweenAtoms(
+            monomer_start->getIdx(), monomer_end->getIdx());
+        if (connection != nullptr) {
+            auto ap_name_end =
+                drag_end_ap_item->getAttachmentPoint().model_name;
+            auto [linkage, flipped] =
+                build_linkage_string(m_drag_start_ap_model_name, ap_name_end);
+            bool is_custom_bond =
+                get_is_custom_bond(monomer_start, monomer_end, linkage);
+            if (is_custom_bond && connection->hasProp(CUSTOM_BOND)) {
+                // this would be a custom connection (i.e. not a standard
+                // backbone connection) and this monomer pair already has one
+                drag_end_ap_item = nullptr;
+            } else if (!is_custom_bond &&
+                       (!connection->hasProp(CUSTOM_BOND) ||
+                        contains_two_monomer_linkages(connection))) {
+                // this would be a standard backbone connection and this monomer
+                // pair already has one (presumably in the opposite direction,
+                // since otherwise the attachment points would have already been
+                // bound)
+                drag_end_ap_item = nullptr;
+            }
+        }
+    }
+
+    DragEndInfo drag_end_info;
+    if (drag_end_ap_item == nullptr) {
+        // there's no available attachment point at the cursor (or there is one
+        // but we can't use it because this pair of monomers already has that
+        // type of connection), so we display the drag hint in a direction
+        drag_end_info = getDragEndInfoForNonMonomerPos(scene_pos);
+    } else {
+        drag_end_info = std::make_pair(hovered_monomer_item, drag_end_ap_item);
+    }
+    return {drag_end_info, hovered_monomer_item};
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragMove(
+    QGraphicsSceneMouseEvent* const event)
+{
+    AbstractMonomerSceneTool::onLeftButtonDragMove(event);
+    if (m_drag_ignored) {
+        return;
+    }
+    auto [drag_end_info, hovered_monomer_item] =
+        getDragEndInfo(event->scenePos());
+
+    if (hovered_monomer_item != m_drag_end_monomer_item) {
+        if (m_drag_end_monomer_item) {
+            clearDragEndAttachmentPointsLabels();
+        }
+        m_drag_end_monomer_item = hovered_monomer_item;
+        if (hovered_monomer_item != nullptr) {
+            labelAttachmentPointsOnDragEndMonomer(
+                hovered_monomer_item->getAtom(), hovered_monomer_item);
+        }
+    }
+
+    if (drag_end_info != m_drag_end_info) {
+        m_drag_end_info = drag_end_info;
+        // we know the drag start was valid, since otherwise m_drag_ignored
+        // would have been true
+        createDragHintIfDragStartValid(drag_end_info);
+
+        // update which unbound attachment point is highlighted
+        if (std::holds_alternative<MonomerAndAPItems>(drag_end_info)) {
+            auto active_ap_item =
+                std::get<MonomerAndAPItems>(drag_end_info).second;
+            for (auto* ap_item : m_drag_end_unbound_ap_items) {
+                auto color = ap_item == active_ap_item
+                                 ? STRUCTURE_HINT_COLOR
+                                 : m_drag_end_inactive_ap_color;
+                ap_item->setColor(color);
+            }
+        }
+    }
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragRelease(
+    QGraphicsSceneMouseEvent* const event)
+{
+    AbstractMonomerSceneTool::onLeftButtonDragRelease(event);
+    if (m_drag_ignored) {
+        return;
+    }
+
+    // we need to figure out what attachment point we're over before we delete
+    // the attachment point graphics items
+    auto hint_start_monomer_info = getHintFragmentMonomerInfoForDragStart();
+    auto [drag_end_info, hovered_monomer_item] =
+        getDragEndInfo(event->scenePos());
+    // we know that hint_start_monomer_info can't be std::nullopt, since
+    // otherwise m_drag_ignored would be true and we would've returned already
+    auto hint_end_monomer_info = getHintFragmentMonomerInfoForDragEnd(
+        *hint_start_monomer_info, drag_end_info);
+
+    // delete the attachment point graphics items before we modify the structure
+    // so that we don't have to worry about monomer graphics items being deleted
+    // and automatically destroying their children
+    clearAttachmentPointsLabelsAndHintFragmentItem();
+    clearDragEndAttachmentPointsLabels();
+    m_drag_start_monomer_item = nullptr;
+    m_drag_start_ap_model_name.clear();
+    m_drag_end_monomer_item = nullptr;
+    m_drag_end_info = std::monostate{};
+
+    // now that everything is cleaned up, we can actually add the monomers and
+    // connection to MolModel, assuming the drag end represents a valid
+    // structure
+    if (hint_end_monomer_info.has_value()) {
+        addDragStructureToMolModel(*hint_start_monomer_info,
+                                   *hint_end_monomer_info);
+    }
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    addDragStructureToMolModel(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const HintFragmentMonomerInfo& hint_end_monomer_info)
+{
+    auto add_monomer_to_mol_model_if_new =
+        [this](const HintFragmentMonomerInfo& monomer_info) {
+            if (monomer_info.atom_idx >= 0) {
+                // the monomer already exists in MolModel
+                return static_cast<unsigned int>(monomer_info.atom_idx);
+            } else {
+                auto monomer_idx = m_mol_model->getMol()->getNumAtoms();
+                m_mol_model->addMonomer(m_res_name, m_chain_type,
+                                        monomer_info.pos);
+                return monomer_idx;
+            }
+        };
+
+    auto undo_raii = m_mol_model->createUndoMacro("Add monomeric connection");
+    auto start_monomer_idx =
+        add_monomer_to_mol_model_if_new(hint_start_monomer_info);
+    auto end_monomer_idx =
+        add_monomer_to_mol_model_if_new(hint_end_monomer_info);
+    auto mol = m_mol_model->getMol();
+    m_mol_model->addMonomericConnection(mol->getAtomWithIdx(start_monomer_idx),
+                                        hint_start_monomer_info.ap_model_name,
+                                        mol->getAtomWithIdx(end_monomer_idx),
+                                        hint_end_monomer_info.ap_model_name);
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    labelAttachmentPointsOnDragEndMonomer(
+        const RDKit::Atom* const monomer,
+        AbstractMonomerItem* const monomer_item)
+{
+    labelUnboundAttachmentPointsOnMonomer(
+        monomer, monomer_item, m_drag_end_attachment_point_labels_group,
+        m_drag_end_unbound_ap_items);
+}
+
+void AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    clearDragEndAttachmentPointsLabels()
+{
+    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
+    delete_all_unbound_ap_items(m_drag_end_unbound_ap_items);
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
@@ -1,0 +1,411 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <rdkit/Geometry/point.h>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/molviewer/constants.h"
+#include "schrodinger/sketcher/molviewer/fonts.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
+#include "schrodinger/sketcher/tool/abstract_monomer_scene_tool.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
+namespace RDKit
+{
+class Atom;
+class Bond;
+} // namespace RDKit
+
+namespace schrodinger
+{
+
+namespace rdkit_extensions
+{
+enum class ChainType;
+enum class Direction;
+} // namespace rdkit_extensions
+
+namespace sketcher
+{
+
+class MonomerHintFragmentItem;
+class UnboundMonomericAttachmentPointItem;
+class MonomerConnectorItem;
+
+using MonomerAndAPItems =
+    std::pair<AbstractMonomerItem*, UnboundMonomericAttachmentPointItem*>;
+using DragEndInfo = std::variant<std::monostate, rdkit_extensions::Direction,
+                                 QPointF, MonomerAndAPItems>;
+
+/**
+ * Information about one monomer of the hint structure fragment (i.e. the blue
+ * structure that shows up when the user hovers over a monomer or
+ * click-and-drags from a monomer)
+ */
+struct HintFragmentMonomerInfo {
+    std::unique_ptr<RDKit::Atom> monomer;
+    MonomerType monomer_type;
+    RDGeom::Point3D pos;
+    // the model name of this monomer's attachment point that's connected to the
+    // bond (e.g. "R2", not "C")
+    std::string ap_model_name;
+    // the atom index for this monomer in the MolModel molecule. Will be
+    // NEW_MONOMER_FROM_DRAG if the monomer is not present in MolModel.
+    int atom_idx;
+};
+
+constexpr int NEW_MONOMER_FROM_DRAG = -1;
+constexpr int NEW_MONOMER_FROM_INVALID_DRAG = -2;
+
+/**
+ * Return the default unbound attachment point; that is, the attachment point
+ * that should be selected when the user hovers over a monomer.
+ * @param hovered_type The type of monomer being hovered over
+ * @param tool_type  The type of monomer that would be drawn by the active scene
+ * tool
+ * @param unbound_ap_items A list of all graphics items representing unbound
+ * attachment points of the hovered monomer
+ */
+SKETCHER_API UnboundMonomericAttachmentPointItem* get_default_attachment_point(
+    const MonomerType hovered_type, const MonomerType tool_type,
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
+
+/**
+ * When adding a new monomer bound to an existing monomer, determine the
+ * appropriate attach point to use for the new-monomer-end of the connection.
+ */
+SKETCHER_API std::string
+get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
+                                     const std::string_view existing_monomer_ap,
+                                     const MonomerType new_monomer_type);
+
+/**
+ * @return the monomer represented by the given graphics item, along with its
+ * monomer type
+ */
+SKETCHER_API std::tuple<const RDKit::Atom*, MonomerType>
+get_monomer_and_type(const AbstractMonomerItem* const monomer_item);
+
+/**
+ * @overload takes a monomer instead of monomer coordinates
+ */
+SKETCHER_API RDGeom::Point3D
+get_default_coords_for_bound_monomer(const RDKit::Atom* const monomer,
+                                     const rdkit_extensions::Direction dir);
+
+/**
+ * @return the unbound attachment point graphics item representing the
+ * attachment point with the "best" number. "Best" is defined using the
+ * preferred_order list, with earlier numbers in the list preferred over later
+ * numbers. Will return nullptr if no attachment points on the preferred_order
+ * list are found.
+ */
+[[nodiscard]] SKETCHER_API UnboundMonomericAttachmentPointItem*
+find_preferred_attachment_point_by_num(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
+    const std::vector<int>& preferred_order);
+
+/**
+ * Return the unbound attachment point graphics item that represents the
+ * attachment point with the lowest number. An attachment points with a custom
+ * name will be returned only if there are no numbered attachment point.
+ * @param unbound_ap_items The non-empty list of unbound attachment point
+ * graphics item
+ */
+[[nodiscard]] SKETCHER_API UnboundMonomericAttachmentPointItem*
+find_min_attachment_point_by_num(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
+
+/**
+ * @return the unbound attachment point graphics item representing an attachment
+ * point with the given name. Will return nullptr if no such attachment point is
+ * found.
+ */
+[[nodiscard]] SKETCHER_API UnboundMonomericAttachmentPointItem*
+find_attachment_point_with_name(
+    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
+    const std::string_view name);
+
+/**
+ * An abstract base class for scene tools that draw a monomer or a monomeric
+ * connection. This class implements the common behavior for hovering over
+ * monomers, drawing hint fragments, and click-and-drag operations. Subclasses
+ * must implement getHintFragmentMonomerInfoForDragStart,
+ * getHintFragmentMonomerInfoForDragEnd, and clickShouldMutate to specify the
+ * tool-specific behavior.
+ */
+class SKETCHER_API AbstractDrawMonomerOrMonomericConnectionSceneTool
+    : public AbstractMonomerSceneTool
+{
+  public:
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(
+        const std::string& res_name,
+        const rdkit_extensions::ChainType chain_type, const Fonts& fonts,
+        Scene* scene, MolModel* mol_model);
+    virtual ~AbstractDrawMonomerOrMonomericConnectionSceneTool();
+
+    // Reimplemented AbstractSceneTool methods
+    std::vector<QGraphicsItem*> getGraphicsItems() override;
+    void onStructureUpdated() override;
+    void onMouseMove(QGraphicsSceneMouseEvent* const event) override;
+    void onLeftButtonDragStart(QGraphicsSceneMouseEvent* const event) override;
+    void onLeftButtonDragMove(QGraphicsSceneMouseEvent* const event) override;
+    void
+    onLeftButtonDragRelease(QGraphicsSceneMouseEvent* const event) override;
+    void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
+
+  protected:
+    std::string m_res_name;
+    rdkit_extensions::ChainType m_chain_type =
+        rdkit_extensions::ChainType::CHEM;
+    MonomerType m_monomer_type;
+    Fonts m_bolded_fonts;
+
+    bool m_drag_ignored;
+    AbstractMonomerItem* m_drag_start_monomer_item = nullptr;
+    std::string m_drag_start_ap_model_name;
+    AbstractMonomerItem* m_drag_end_monomer_item = nullptr;
+    DragEndInfo m_drag_end_info;
+    QGraphicsItemGroup m_drag_end_attachment_point_labels_group;
+    std::vector<UnboundMonomericAttachmentPointItem*>
+        m_drag_end_unbound_ap_items;
+    QColor m_drag_end_inactive_ap_color;
+
+    /**
+     * Label all attachment points on the given monomer at the end of the
+     * current click-and-drag operation
+     */
+    void labelAttachmentPointsOnDragEndMonomer(
+        const RDKit::Atom* const monomer,
+        AbstractMonomerItem* const monomer_item);
+
+    /**
+     * Clear all attachment point labels drawn on the existing monomer at the
+     * end of the current click-and-drag operation. Note that this method *does
+     * not* clear the hint fragment item.
+     */
+    void clearDragEndAttachmentPointsLabels();
+
+    /**
+     * Return the unbound attachment point graphics item that should be "active"
+     * (i.e. that we'd draw a connection for if the user clicked) for the given
+     * coordinates. If the coordinates are over an unbound attachment point
+     * item, that item will be returned. If the coordinates are over the
+     * monomer, then the default unbound attachment point will be returned,
+     * assuming one exists for the current tool. If no default attachment point
+     * exists (e.g. if the tool and the hovered monomer are of different
+     * molecule types), then nullptr will be returned.
+     * @param scene_pos the coordinates to check
+     * @param no_default_if_click_should_mutate If true, this function will
+     * return nullptr if scene_pos is over the monomer itself and clicking on
+     * the monomer should trigger a mutation (e.g. if the user has the alanine
+     * tool selected and is hovering over a proline).  If false, this function
+     * will return the default unbound attachment point in this scenario,
+     * assuming one exists. (This value should normally be true if the user is
+     * hovering over or has clicked on the monomer, and false if the user has
+     * started a drag from the monomer.)
+     *
+     * @note This method only returns accurate results for the currently hovered
+     * monomer, and assumes that the unbound attachment point graphics items
+     * have already been drawn for this monomer.
+     */
+    UnboundMonomericAttachmentPointItem* getUnboundAttachmentPointAt(
+        const QPointF& scene_pos,
+        const bool no_default_if_click_should_mutate) const;
+
+    /**
+     * Return the unbound attachment point graphics item that should be "active"
+     * (i.e. that we'd draw a connection for if the user released the mouse
+     * button) for the given coordinates, assuming that the user is in the
+     * middle of a click-and-drag.  If the coordinates are over the monomer,
+     * then the default unbound attachment point will be returned based on the
+     * monomer and attachment point that the drag was started from, assuming one
+     * exists.
+     */
+    UnboundMonomericAttachmentPointItem*
+    getUnboundDragEndAttachmentPointAt(const QPointF& scene_pos) const;
+
+    /**
+     * @return the unbound attachment point that should be active when the user
+     * is hovering over the monomer itself
+     * @param no_default_if_click_should_mutate If true, this function will
+     * return nullptr if clicking on the monomer should trigger a mutation (e.g.
+     * if the user has the alanine tool selected and is hovering over a
+     * proline).  If false, this function will return the default unbound
+     * attachment point in this scenario, assuming one exists. (This value
+     * should normally be true if the user is hovering over or has clicked on
+     * the monomer, and false if the user has started a drag from the monomer.)
+     */
+    virtual UnboundMonomericAttachmentPointItem*
+    getDefaultUnboundAttachmentPointForHoveredMonomer(
+        const bool no_default_if_click_should_mutate) const;
+
+    std::tuple<const RDKit::Atom*, MonomerType>
+    getHoveredMonomerAndType() const;
+
+    /**
+     * @return whether this tool should show the predictive highlighting outline
+     * for the currently hovered monomer.  The highlighting is shown if the
+     * hovered monomer can be mutated (i.e. its the same monomer type as this
+     * tool but a different residue name) or if there is a reasonable way to
+     * connect this tool's monomer to the hovered monomer (an unreasonable
+     * connection would be, e.g., connecting a nucleic acid base directly to a
+     * phosphate with no intervening sugar.)
+     */
+    bool shouldShowPredictiveHighlighting() const;
+
+    /**
+     * Whether clicking on the specified monomer should mutate that monomer. We
+     * only mutate monomers that are the same monomer type as this tool but have
+     * a different residue name.
+     */
+    virtual bool clickShouldMutate(const RDKit::Atom* monomer,
+                                   const MonomerType monomer_type) const = 0;
+
+    /**
+     * Create a hint fragment containing the two specified monomers and the
+     * connection between them, then add this hint fragment to the scene. Note
+     * that this function will transfer ownership of the monomers themselves to
+     * RDKit.
+     */
+    virtual void createHintFragmentItem(HintFragmentMonomerInfo& monomer_one,
+                                        HintFragmentMonomerInfo& monomer_two);
+
+    /**
+     * If the user has started a "valid" click-and-drag operation, create the
+     * drag hint and return true. Otherwise, return false. The click-and-drag
+     * will be valid unless one of the following happened:
+     *  - the user tried to start a drag from an existing monomer that has no
+     *    available attachment points
+     *  - the user tried to start a drag from empty space while using a nucleic
+     *    acid phosphate or sugar tool (It doesn't make any biological sense to
+     *    create a dimer of those, so we disallow drags from empty space.)
+     * @return
+     */
+    bool createDragHintIfDragStartValid(const DragEndInfo& drag_end_info);
+
+    /**
+     * @return the attachment point to use if user starts a drag from empty
+     * space. We only allow drags from empty space for peptides and nucleic acid
+     * bases, so this function is only valid for those monomer types. (A drag
+     * from empty space normally creates two monomers of the same type, and it
+     * doesn't make biological sense to have a dimer of nucleic acid sugars or
+     * phosphates.)
+     */
+    std::string getDefaultDragStartAPModelName() const;
+
+    /**
+     * Create a HintFragmentMonomerInfo object describing a new monomer at the
+     * given coordinates. Note that the returned monomer is owned by the calling
+     * scope.
+     */
+    HintFragmentMonomerInfo createHintFragmentMonomerInfoForHintFromEmptySpace(
+        const QPointF& scene_pos) const;
+
+    /**
+     * Create a HintFragmentMonomerInfo object describing the existing monomer
+     * and attachment point. Note that the returned monomer is owned by the
+     * calling scope.
+     */
+    HintFragmentMonomerInfo
+    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+        const AbstractMonomerItem* const monomer_item,
+        const std::string& ap_model_name) const;
+
+    /**
+     * @overload takes a graphics item for the attachment point in place of the
+     * model name
+     */
+    HintFragmentMonomerInfo
+    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+        const AbstractMonomerItem* const monomer_item,
+        const UnboundMonomericAttachmentPointItem* const ap_item) const;
+
+    /**
+     * Create a HintFragmentMonomerInfo object describing a new monomer at the
+     * given coordinates. Note that the returned monomer is owned by the calling
+     * scope.
+     */
+    HintFragmentMonomerInfo createHintFragmentMonomerInfoForHintToDirection(
+        const HintFragmentMonomerInfo& start_monomer_info,
+        const rdkit_extensions::Direction direction) const;
+
+    /**
+     * Determine whether the end of current click-and-drag operation is over an
+     * existing monomer or not. If not, return the direction of the drag.
+     * @param scene_pos The scene coordinates representing the end of the
+     * click-and-drag.
+     * @return If scene_pos is over an existing monomer, returns a pair of
+     *   - a pair of pointers to the graphics items representing the monomer and
+     *     the relevant attachment point. The second value will be nullptr if
+     * the monomer does not have any available unbound attachment points.
+     *   - a pointer to the monomer's graphics item (i.e. the first pointer of
+     *     the pair)
+     * If scene_pos is not over an existing monomer, returns a pair of
+     *   - the `Direction` enum value representing the direction of the
+     *     drag
+     *   - nullptr
+     */
+    std::pair<DragEndInfo, AbstractMonomerItem*>
+    getDragEndInfo(const QPointF& scene_pos);
+
+    virtual void addDragStructureToMolModel(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const HintFragmentMonomerInfo& hint_end_monomer_info);
+
+    /**
+     * If the user has began a "valid" click-and-drag, create and return the
+     * HintFragmentMonomerInfo object describing the starting location/monomer
+     * of the drag. Otherwise, return std::nullopt. See the
+     * createDragHintIfDragStartValid docstring for an explanation of valid
+     * versus invalid click-and-drags.
+     */
+    virtual std::optional<HintFragmentMonomerInfo>
+    getHintFragmentMonomerInfoForDragStart() = 0;
+
+    /**
+     * Create and return the HintFragmentMonomerInfo object describing the end
+     * of the current click-and-drag operation, or std::nullopt if the
+     * click-and-drag cannot be completed.
+     */
+    virtual std::optional<HintFragmentMonomerInfo>
+    getHintFragmentMonomerInfoForDragEnd(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const DragEndInfo& drag_end_info) = 0;
+
+    /**
+     * @return the direction of the specified position relative to the start of
+     * the current click-and-drag operation
+     */
+    rdkit_extensions::Direction
+    getDragDirection(const QPointF& cur_scene_pos) const;
+
+    /**
+     * Update the graphics items representing unbound attachment points for a
+     * monomer when the user hovers over the monomer or its attachment points.
+     * @param hovered_ap_item the attachment point that the user is currently
+     * hovering over, or the default attachment point if the user is hovering
+     * over the monomer itself. May be nullptr if there are no unbound
+     * attachment points.
+     */
+    virtual void updateHoveredUnboundAP(
+        UnboundMonomericAttachmentPointItem* hovered_ap_item) = 0;
+
+    /**
+     * @return the DragEndInfo for the specified position, which does *not*
+     * correspond to a monomer or an attachment point.
+     */
+    virtual DragEndInfo
+    getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const = 0;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
@@ -96,7 +96,7 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
      * Remove the hint fragment item from the scene, then destroy it as well as
      * the RDKit structure object it represents.
      */
-    void clearHintFragmentItem();
+    virtual void clearHintFragmentItem();
 
     /**
      * Determine whether the specified graphics item is part of this scene

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -1,34 +1,17 @@
 #include "schrodinger/sketcher/tool/draw_monomer_scene_tool.h"
 
-#include <algorithm>
-#include <cmath>
-#include <memory>
-#include <vector>
+#include <optional>
+#include <utility>
+#include <variant>
 
-#include <QtAssert>
-#include <QtMath>
-#include <QGraphicsItem>
-#include <QGraphicsSimpleTextItem>
-#include <QPainterPath>
-#include <QPen>
+#include <QGraphicsSceneMouseEvent>
 
 #include <rdkit/Geometry/point.h>
-#include <rdkit/GraphMol/Conformer.h>
 #include <rdkit/GraphMol/ROMol.h>
-#include <rdkit/GraphMol/RWMol.h>
 
-#include "schrodinger/rdkit_extensions/helm.h"
-#include "schrodinger/rdkit_extensions/monomer_directions.h"
-#include "schrodinger/rdkit_extensions/monomer_mol.h"
-#include "schrodinger/sketcher/molviewer/abstract_graphics_item.h"
 #include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/coord_utils.h"
-#include "schrodinger/sketcher/molviewer/monomer_attachment_point_labels.h"
-#include "schrodinger/sketcher/molviewer/monomer_connector_item.h"
-#include "schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h"
-#include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/molviewer/scene.h"
-#include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
 
 namespace schrodinger
@@ -38,370 +21,12 @@ namespace sketcher
 
 using rdkit_extensions::Direction;
 
-/**
- * Information about one monomer of the hint structure fragment (i.e. the blue
- * structure that shows up when the user hovers over a monomer or
- * click-and-drags from a monomer)
- */
-struct HintFragmentMonomerInfo {
-    std::unique_ptr<RDKit::Atom> monomer;
-    MonomerType monomer_type;
-    RDGeom::Point3D pos;
-    // the model name of this monomer's attachment point that's connected to the
-    // bond (e.g. "R2", not "C")
-    std::string ap_model_name;
-    // the atom index for this monomer in the MolModel molecule. Will be
-    // NEW_MONOMER_FROM_DRAG if the monomer is not present in MolModel.
-    int atom_idx;
-};
-
-constexpr int NEW_MONOMER_FROM_DRAG = -1;
-
 DrawMonomerSceneTool::DrawMonomerSceneTool(
     const std::string& res_name, const rdkit_extensions::ChainType chain_type,
     const Fonts& fonts, Scene* scene, MolModel* mol_model) :
-    AbstractMonomerSceneTool(fonts, scene, mol_model),
-    m_res_name(res_name),
-    m_chain_type(chain_type),
-    m_bolded_fonts(fonts)
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(res_name, chain_type,
+                                                      fonts, scene, mol_model)
 {
-    // we handle predictive highlighting manually in onMouseMove, so we disable
-    // StandardSceneToolsBase's predictive highlighting
-    m_highlight_types = InteractiveItemFlag::NONE;
-    // make sure that the cursor hint font is more easily readable at small
-    // size. (Note that m_bolded_fonts is a copy of the Scene's fonts, so this
-    // change won't affect anything else.)
-    m_bolded_fonts.m_main_label_font.setBold(true);
-    m_bolded_fonts.updateFontMetrics();
-    if (chain_type == rdkit_extensions::ChainType::PEPTIDE) {
-        m_monomer_type = MonomerType::PEPTIDE;
-    } else if (chain_type == rdkit_extensions::ChainType::CHEM) {
-        m_monomer_type = MonomerType::CHEM;
-    } else {
-        m_monomer_type = get_na_monomer_type_from_res_name(res_name);
-    }
-}
-
-DrawMonomerSceneTool::~DrawMonomerSceneTool()
-{
-    // explicitly erase any drag end attachment point labels. Without this, the
-    // bound attachment point labels would be deleted regardless when
-    // m_drag_end_attachment_point_labels_group is destroyed, but the unbound
-    // attachment point labels are parented to their monomer, so they would
-    // outlive the scene tool without this call.
-    clearDragEndAttachmentPointsLabels();
-}
-
-void DrawMonomerSceneTool::onStructureUpdated()
-{
-    AbstractMonomerSceneTool::onStructureUpdated();
-    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
-    // any drag-end attachment point graphics items have already been deleted in
-    // response to their parent monomer graphics item being deleted due to the
-    // structure update. We're just clear the stale pointers here
-    m_drag_end_unbound_ap_items.clear();
-    m_drag_start_monomer_item = nullptr;
-    m_drag_end_monomer_item = nullptr;
-}
-
-std::vector<QGraphicsItem*> DrawMonomerSceneTool::getGraphicsItems()
-{
-    auto items = AbstractMonomerSceneTool::getGraphicsItems();
-    items.push_back(&m_drag_end_attachment_point_labels_group);
-    return items;
-}
-
-void DrawMonomerSceneTool::updateColorsAfterBackgroundColorChange(
-    bool is_dark_mode)
-{
-    AbstractMonomerSceneTool::updateColorsAfterBackgroundColorChange(
-        is_dark_mode);
-    m_monomer_background_color =
-        is_dark_mode ? DARK_BACKGROUND_COLOR : LIGHT_BACKGROUND_COLOR;
-    m_drag_end_inactive_ap_color =
-        is_dark_mode ? DRAG_END_INACTIVE_AP_DARK_BG : DRAG_END_INACTIVE_AP;
-}
-
-/**
- * @return the unbound attachment point graphics item representing the
- * attachment point with the "best" number. "Best" is defined using the
- * preferred_order list, with earlier numbers in the list preferred over later
- * numbers. Will return nullptr if no attachment points on the preferred_order
- * list are found.
- */
-[[nodiscard]] static UnboundMonomericAttachmentPointItem*
-find_preferred_attachment_point_by_num(
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
-    const std::vector<int>& preferred_order)
-{
-    auto index_of = [&preferred_order](const auto* ap_item) {
-        auto it = std::ranges::find(preferred_order,
-                                    ap_item->getAttachmentPoint().num);
-        auto dist = std::distance(preferred_order.begin(), it);
-        // we know that dist is positive
-        return static_cast<std::size_t>(dist);
-    };
-    auto min_it = std::ranges::min_element(
-        unbound_ap_items,
-        [&index_of](const auto* ap_item_left, const auto* ap_item_right) {
-            return index_of(ap_item_left) < index_of(ap_item_right);
-        });
-    // make sure that the attachment point we found is actually on the
-    // preferred_order list
-    if (index_of(*min_it) < preferred_order.size()) {
-        return *min_it;
-    }
-    return nullptr;
-}
-
-/**
- * Return the unbound attachment point graphics item that represents the
- * attachment point with the lowest number. An attachment points with a custom
- * name will be returned only if there are no numbered attachment point.
- * @param unbound_ap_items The non-empty list of unbound attachment point
- * graphics item
- */
-[[nodiscard]] static UnboundMonomericAttachmentPointItem*
-find_min_attachment_point_by_num(
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
-{
-    auto min_it = std::ranges::min_element(
-        unbound_ap_items,
-        [](const auto* ap_item_left, const auto* ap_item_right) {
-            auto left_num = ap_item_left->getAttachmentPoint().num;
-            auto right_num = ap_item_right->getAttachmentPoint().num;
-            return right_num < 0 || (left_num >= 0 && left_num < right_num);
-        });
-    return *min_it;
-}
-
-/**
- * @return the unbound attachment point graphics item representing an attachment
- * point with the given name. Will return nullptr if no such attachment point is
- * found.
- */
-[[nodiscard]] static UnboundMonomericAttachmentPointItem*
-find_attachment_point_with_name(
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
-    const std::string_view name)
-{
-    auto it =
-        std::ranges::find_if(unbound_ap_items, [&name](const auto* ap_item) {
-            return (ap_item->getAttachmentPoint().model_name == name);
-        });
-    if (it == unbound_ap_items.end()) {
-        return nullptr;
-    }
-    return *it;
-}
-
-/**
- * @return the unbound attachment point graphics item representing an attachment
- * point with the given number. Will return nullptr if no such attachment point
- * is found.
- */
-[[nodiscard]] static UnboundMonomericAttachmentPointItem*
-find_attachment_point_with_num(
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items,
-    const int num)
-{
-    auto it =
-        std::ranges::find_if(unbound_ap_items, [&num](const auto* ap_item) {
-            return (ap_item->getAttachmentPoint().num == num);
-        });
-    if (it == unbound_ap_items.end()) {
-        return nullptr;
-    }
-    return *it;
-}
-
-UnboundMonomericAttachmentPointItem* get_default_attachment_point(
-    const MonomerType hovered_type, const MonomerType tool_type,
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
-{
-    if (unbound_ap_items.empty()) {
-        return nullptr;
-    } else if (hovered_type == MonomerType::CHEM) {
-        return find_min_attachment_point_by_num(unbound_ap_items);
-    } else if (hovered_type == MonomerType::PEPTIDE) {
-        if (tool_type == MonomerType::PEPTIDE) {
-            return find_preferred_attachment_point_by_num(
-                unbound_ap_items,
-                {PeptideAP::C, PeptideAP::N, PeptideAP::SIDECHAIN});
-        } else if (tool_type == MonomerType::CHEM) {
-            return find_attachment_point_with_num(unbound_ap_items,
-                                                  PeptideAP::SIDECHAIN);
-        }
-    } else if (hovered_type == MonomerType::NA_BASE) {
-        if (tool_type == MonomerType::NA_BASE ||
-            tool_type == MonomerType::CHEM) {
-            return find_attachment_point_with_name(unbound_ap_items,
-                                                   NA_BASE_AP_PAIR);
-        } else if (tool_type == MonomerType::NA_SUGAR) {
-            return find_attachment_point_with_num(unbound_ap_items,
-                                                  NA_BASE_AP_N1_9);
-        }
-    } else if (hovered_type == MonomerType::NA_SUGAR) {
-        if (tool_type == MonomerType::NA_BASE) {
-            return find_attachment_point_with_num(unbound_ap_items,
-                                                  NASugarAP::ONE_PRIME);
-        } else if (tool_type == MonomerType::NA_PHOSPHATE) {
-            return find_preferred_attachment_point_by_num(
-                unbound_ap_items,
-                {NASugarAP::THREE_PRIME, NASugarAP::FIVE_PRIME});
-        }
-    } else if (hovered_type == MonomerType::NA_PHOSPHATE) {
-        if (tool_type == MonomerType::NA_SUGAR) {
-            return find_preferred_attachment_point_by_num(
-                unbound_ap_items,
-                {NAPhosphateAP::TO_NEXT_SUGAR, NAPhosphateAP::TO_PREV_SUGAR});
-        }
-    }
-    return nullptr;
-}
-
-std::string
-get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
-                                     const std::string_view existing_monomer_ap,
-                                     const MonomerType new_monomer_type)
-{
-    switch (new_monomer_type) {
-        case MonomerType::CHEM:
-            return "R1";
-        case MonomerType::PEPTIDE:
-            if (existing_monomer_type == MonomerType::PEPTIDE) {
-                if (existing_monomer_ap == ap_model_name_for(PeptideAP::N)) {
-                    return ap_model_name_for(PeptideAP::C);
-                } else if (existing_monomer_ap ==
-                           ap_model_name_for(PeptideAP::C)) {
-                    return ap_model_name_for(PeptideAP::N);
-                }
-            }
-            return ap_model_name_for(PeptideAP::SIDECHAIN);
-        case MonomerType::NA_BASE:
-            if (existing_monomer_type == MonomerType::NA_SUGAR &&
-                existing_monomer_ap ==
-                    ap_model_name_for(NASugarAP::ONE_PRIME)) {
-                return ap_model_name_for(NA_BASE_AP_N1_9);
-            }
-            return NA_BASE_AP_PAIR;
-        case MonomerType::NA_SUGAR:
-            if (existing_monomer_type == MonomerType::NA_PHOSPHATE) {
-                if (existing_monomer_ap ==
-                    ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR)) {
-                    return ap_model_name_for(NASugarAP::THREE_PRIME);
-                } else if (existing_monomer_ap ==
-                           ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR)) {
-                    return ap_model_name_for(NASugarAP::FIVE_PRIME);
-                }
-            }
-            return ap_model_name_for(NASugarAP::ONE_PRIME);
-        case MonomerType::NA_PHOSPHATE:
-            if (existing_monomer_type == MonomerType::NA_SUGAR &&
-                existing_monomer_ap ==
-                    ap_model_name_for(NASugarAP::THREE_PRIME)) {
-                return ap_model_name_for(NAPhosphateAP::TO_PREV_SUGAR);
-            }
-            return ap_model_name_for(NAPhosphateAP::TO_NEXT_SUGAR);
-        default:
-            Q_UNREACHABLE_RETURN("");
-    }
-}
-
-UnboundMonomericAttachmentPointItem*
-DrawMonomerSceneTool::getUnboundAttachmentPointAt(
-    const QPointF& scene_pos,
-    const bool no_default_if_click_should_mutate) const
-{
-    if (m_unbound_ap_items.empty()) {
-        return nullptr;
-    }
-    for (auto* ap_item : m_unbound_ap_items) {
-        if (ap_item->withinHoverArea(scene_pos)) {
-            return ap_item;
-        }
-    }
-    return getDefaultUnboundAttachmentPointForHoveredMonomer(
-        no_default_if_click_should_mutate);
-}
-
-static std::tuple<const RDKit::Atom*, MonomerType>
-get_monomer_and_type(const AbstractMonomerItem* const monomer_item)
-{
-    auto* monomer = monomer_item->getAtom();
-    auto monomer_type = get_monomer_type(monomer);
-    return {monomer, monomer_type};
-}
-
-UnboundMonomericAttachmentPointItem*
-DrawMonomerSceneTool::getUnboundDragEndAttachmentPointAt(
-    const QPointF& scene_pos) const
-{
-    if (m_drag_end_unbound_ap_items.empty()) {
-        return nullptr;
-    }
-    for (auto* ap_item : m_drag_end_unbound_ap_items) {
-        if (ap_item->withinHoverArea(scene_pos)) {
-            return ap_item;
-        }
-    }
-
-    // get the monomer type for the start and end monomers
-    auto get_drag_monomer_type =
-        [this](const AbstractMonomerItem* const monomer_item) {
-            if (monomer_item == nullptr) {
-                return m_monomer_type;
-            }
-            auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
-            return monomer_type;
-        };
-    auto drag_start_monomer_type =
-        get_drag_monomer_type(m_drag_start_monomer_item);
-    auto drag_end_monomer_type = get_drag_monomer_type(m_drag_end_monomer_item);
-
-    // if the user is hovered over the monomer itself (not an attachment point)
-    // and the "correct" attachment point is available (e.g. N terminus when we
-    // dragged from a C terminus), use that one
-    auto ideal_ap_model_name = get_attachment_point_for_new_monomer(
-        drag_start_monomer_type, m_drag_start_ap_model_name,
-        drag_end_monomer_type);
-    for (auto* ap_item : m_drag_end_unbound_ap_items) {
-        if (ap_item->getAttachmentPoint().model_name == ideal_ap_model_name) {
-            return ap_item;
-        }
-    }
-
-    // if the correct attachment point isn't available then there's probably no
-    // good option, so use whatever we would've defaulted if we'd started the
-    // drag at this monomer.
-    return get_default_attachment_point(drag_end_monomer_type,
-                                        drag_start_monomer_type,
-                                        m_drag_end_unbound_ap_items);
-}
-
-std::tuple<const RDKit::Atom*, MonomerType>
-DrawMonomerSceneTool::getHoveredMonomerAndType() const
-{
-    if (!item_matches_type_flag(m_hovered_monomeric_item,
-                                InteractiveItemFlag::MONOMER)) {
-        throw std::runtime_error("No hovered monomer");
-    }
-    const auto* monomer_item =
-        static_cast<const AbstractMonomerItem*>(m_hovered_monomeric_item);
-    return get_monomer_and_type(monomer_item);
-}
-
-UnboundMonomericAttachmentPointItem*
-DrawMonomerSceneTool::getDefaultUnboundAttachmentPointForHoveredMonomer(
-    const bool no_default_if_click_should_mutate) const
-{
-    auto [monomer, monomer_type] = getHoveredMonomerAndType();
-    if (no_default_if_click_should_mutate &&
-        clickShouldMutate(monomer, monomer_type)) {
-        return nullptr;
-    }
-    return get_default_attachment_point(monomer_type, m_monomer_type,
-                                        m_unbound_ap_items);
 }
 
 bool DrawMonomerSceneTool::clickShouldMutate(
@@ -411,78 +36,17 @@ bool DrawMonomerSceneTool::clickShouldMutate(
             get_monomer_res_name(monomer) != m_res_name);
 }
 
-bool DrawMonomerSceneTool::shouldShowPredictiveHighlighting() const
+void DrawMonomerSceneTool::updateHoveredUnboundAP(
+    UnboundMonomericAttachmentPointItem* hovered_ap_item)
 {
-
-    if (m_hovered_monomeric_item == nullptr ||
-        !item_matches_type_flag(m_hovered_monomeric_item,
-                                InteractiveItemFlag::MONOMER)) {
-        return false;
+    // hide the hovered "nubbin" and draw a hint fragment instead
+    for (auto* ap_item : m_unbound_ap_items) {
+        ap_item->setVisible(hovered_ap_item == nullptr ||
+                            ap_item != hovered_ap_item);
     }
-    auto [monomer, monomer_type] = getHoveredMonomerAndType();
-    if (clickShouldMutate(monomer, monomer_type)) {
-        return true;
-    }
-    return get_default_attachment_point(monomer_type, m_monomer_type,
-                                        m_unbound_ap_items) != nullptr;
+    drawBoundMonomerHintFor(hovered_ap_item);
 }
 
-void DrawMonomerSceneTool::onMouseMove(QGraphicsSceneMouseEvent* const event)
-{
-    // the base class call updates m_hovered_monomeric_item and the attachment
-    // point labels
-    auto prev_hovered_monomeric_item = m_hovered_monomeric_item;
-    AbstractMonomerSceneTool::onMouseMove(event);
-    if (m_mouse_pressed) {
-        // drag logic is handled in onDragMove
-        return;
-    }
-    QPointF scene_pos = event->scenePos();
-
-    if (m_hovered_monomeric_item != prev_hovered_monomeric_item) {
-        if (shouldShowPredictiveHighlighting()) {
-            m_predictive_highlighting_item.highlightItem(
-                m_hovered_monomeric_item);
-        } else {
-            m_predictive_highlighting_item.clearHighlightingPath();
-        }
-    }
-
-    auto* hovered_ap_item = getUnboundAttachmentPointAt(scene_pos, true);
-    if (hovered_ap_item != m_hovered_ap_item) {
-        // update which attachment point is hovered
-        m_hovered_ap_item = hovered_ap_item;
-        // hide the hovered "nubbin" and draw a hint fragment instead
-        for (auto* ap_item : m_unbound_ap_items) {
-            ap_item->setVisible(hovered_ap_item == nullptr ||
-                                ap_item != hovered_ap_item);
-        }
-        drawBoundMonomerHintFor(hovered_ap_item);
-    }
-
-    // we want to show either the hint fragment or the cursor hint, but not both
-    bool drew_hint_fragment = hovered_ap_item != nullptr;
-    setCursorHintShown(!drew_hint_fragment);
-}
-
-static RDGeom::Point3D get_coords_for_monomer(const RDKit::Atom* const monomer)
-{
-    auto& conf = monomer->getOwningMol().getConformer();
-    return conf.getAtomPos(monomer->getIdx());
-}
-
-/**
- * @overload takes a monomer instead of monomer coordinates
- */
-static RDGeom::Point3D
-get_default_coords_for_bound_monomer(const RDKit::Atom* const monomer,
-                                     const Direction dir)
-{
-    auto monomer_pos = get_coords_for_monomer(monomer);
-    return get_default_coords_for_bound_monomer(monomer_pos, dir);
-}
-
-// should only be called when hovering over a monomer
 void DrawMonomerSceneTool::drawBoundMonomerHintFor(
     UnboundMonomericAttachmentPointItem* const ap_item)
 {
@@ -499,113 +63,6 @@ void DrawMonomerSceneTool::drawBoundMonomerHintFor(
     auto new_monomer_info = createHintFragmentMonomerInfoForHintToDirection(
         hovered_monomer_info, direction);
     createHintFragmentItem(hovered_monomer_info, new_monomer_info);
-}
-
-void DrawMonomerSceneTool::createHintFragmentItem(
-    HintFragmentMonomerInfo& monomer_one_info,
-    HintFragmentMonomerInfo& monomer_two_info)
-{
-    auto frag = std::make_shared<RDKit::RWMol>();
-
-    // create the two monomers
-    auto monomer_one_idx =
-        frag->addAtom(monomer_one_info.monomer.release(), true, true);
-    auto monomer_two_idx =
-        frag->addAtom(monomer_two_info.monomer.release(), true, true);
-    set_all_atoms_monomeric(*frag);
-    // create the connection between them
-    auto bond_index_to_label = add_monomer_connection(
-        *frag, monomer_one_idx, monomer_one_info.ap_model_name, monomer_two_idx,
-        monomer_two_info.ap_model_name);
-
-    // Add a conformer with the atom coordinates
-    auto* frag_conf = new RDKit::Conformer(frag->getNumAtoms());
-    frag_conf->set3D(false);
-    frag_conf->setAtomPos(monomer_one_idx, monomer_one_info.pos);
-    frag_conf->setAtomPos(monomer_two_idx, monomer_two_info.pos);
-    frag->addConformer(frag_conf, true);
-
-    // hide the monomers that already exist in the Scene
-    std::vector<size_t> atom_indices_to_hide;
-    if (monomer_one_info.atom_idx >= 0) {
-        atom_indices_to_hide.push_back(monomer_one_idx);
-    }
-    if (monomer_two_info.atom_idx >= 0) {
-        atom_indices_to_hide.push_back(monomer_two_idx);
-    }
-
-    m_hint_fragment_item = new MonomerHintFragmentItem(
-        frag, m_bolded_fonts, atom_indices_to_hide, bond_index_to_label,
-        m_monomer_background_color);
-    m_scene->addItem(m_hint_fragment_item);
-}
-
-std::string DrawMonomerSceneTool::getDefaultDragStartAPModelName() const
-{
-    return m_monomer_type == MonomerType::NA_BASE
-               ? NA_BASE_AP_PAIR
-               : ap_model_name_for(PeptideAP::C);
-}
-
-HintFragmentMonomerInfo
-DrawMonomerSceneTool::createHintFragmentMonomerInfoForHintFromEmptySpace(
-    const QPointF& scene_pos) const
-{
-    auto chain_id = rdkit_extensions::toString(m_chain_type) + "1";
-    auto monomer =
-        rdkit_extensions::makeMonomer(m_res_name, chain_id, 1, false);
-    auto monomer_pos = to_mol_xy(scene_pos);
-    auto linkage_start = getDefaultDragStartAPModelName();
-    // returned monomer is owned by the calling scope
-    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type,
-                                   monomer_pos, linkage_start,
-                                   NEW_MONOMER_FROM_DRAG};
-}
-
-HintFragmentMonomerInfo DrawMonomerSceneTool::
-    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-        const AbstractMonomerItem* const monomer_item,
-        const std::string& ap_model_name) const
-{
-    auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
-    // returned monomer is owned by the calling scope
-    auto copy_of_monomer = std::make_unique<RDKit::Atom>(*monomer);
-    auto monomer_pos = get_coords_for_monomer(monomer);
-    auto monomer_idx = static_cast<int>(monomer->getIdx());
-    return HintFragmentMonomerInfo{std::move(copy_of_monomer), monomer_type,
-                                   monomer_pos, ap_model_name, monomer_idx};
-}
-
-HintFragmentMonomerInfo DrawMonomerSceneTool::
-    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-        const AbstractMonomerItem* const monomer_item,
-        const UnboundMonomericAttachmentPointItem* const ap_item) const
-{
-    auto ap_model_name = ap_item->getAttachmentPoint().model_name;
-    return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-        monomer_item, ap_model_name);
-}
-
-HintFragmentMonomerInfo
-DrawMonomerSceneTool::createHintFragmentMonomerInfoForHintToDirection(
-    const HintFragmentMonomerInfo& start_monomer_info,
-    const Direction direction) const
-{
-    auto pos =
-        get_default_coords_for_bound_monomer(start_monomer_info.pos, direction);
-    // We'll determine the correct values for chain id and residue number
-    // when/if the structure is actually added to MolModel. For the hint,
-    // though, just generate something reasonable looking.
-    auto chain_id = rdkit_extensions::toString(m_chain_type) + "1";
-    auto res_num = 2;
-    // returned monomer is owned by the calling scope
-    auto monomer =
-        rdkit_extensions::makeMonomer(m_res_name, chain_id, res_num, false);
-    auto ap_model_name = get_attachment_point_for_new_monomer(
-        start_monomer_info.monomer_type, start_monomer_info.ap_model_name,
-        m_monomer_type);
-    return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type, pos,
-                                   ap_model_name, NEW_MONOMER_FROM_DRAG};
 }
 
 void DrawMonomerSceneTool::onLeftButtonClick(
@@ -652,65 +109,6 @@ void DrawMonomerSceneTool::onLeftButtonClick(
     }
 }
 
-void DrawMonomerSceneTool::onLeftButtonDragStart(
-    QGraphicsSceneMouseEvent* const event)
-{
-    AbstractMonomerSceneTool::onLeftButtonDragStart(event);
-    m_drag_start_monomer_item = getTopMonomerItemAt(m_mouse_press_scene_pos);
-    if (m_drag_start_monomer_item == nullptr) {
-        m_drag_start_ap_model_name = getDefaultDragStartAPModelName();
-    } else {
-        auto ap_item =
-            getUnboundAttachmentPointAt(m_mouse_press_scene_pos, false);
-        if (ap_item == nullptr) {
-            // this monomer has no available attachment points. In this
-            // scenario, createDragHint will return false below and we'll ignore
-            // the drag.
-            m_drag_start_ap_model_name = "";
-        } else {
-            m_drag_start_ap_model_name =
-                ap_item->getAttachmentPoint().model_name;
-        }
-    }
-    // clear the attachment point labels. Note that this must happen *after* the
-    // getUnboundAttachmentPointAt call, since that method requires the
-    // attachment points to be in the Scene
-    clearAttachmentPointsLabelsAndHintFragmentItem();
-
-    // since the drag just started, we can safely assume that we're not over a
-    // different monomer than m_drag_start_monomer_item, which means we want a
-    // drag to direction, not to another's monomer attachment point
-    auto dir = getDragDirection(event->scenePos());
-    auto handled = createDragHintIfDragStartValid(dir);
-    if (handled) {
-        // hide the cursor hint while the hint structure is shown. Note that the
-        // cursor hint will have already been hidden if we started this drag
-        // from a monomer, since hovering over a monomer hides the cursor hint
-        // (since it shows the hint structure).  If this drag started from empty
-        // space, though, then this call is necessary to hide the cursor hint.
-        setCursorHintShown(false);
-    } else {
-        m_drag_start_monomer_item = nullptr;
-    }
-    m_drag_ignored = !handled;
-}
-
-bool DrawMonomerSceneTool::createDragHintIfDragStartValid(
-    const DragEndInfo& drag_end_info)
-{
-    clearHintFragmentItem();
-    auto hint_start_monomer_info = getHintFragmentMonomerInfoForDragStart();
-    if (!hint_start_monomer_info.has_value()) {
-        return false;
-    }
-    HintFragmentMonomerInfo hint_end_monomer_info =
-        getHintFragmentMonomerInfoForDragEnd(*hint_start_monomer_info,
-                                             drag_end_info);
-    createHintFragmentItem(*hint_start_monomer_info, hint_end_monomer_info);
-
-    return true;
-}
-
 std::optional<HintFragmentMonomerInfo>
 DrawMonomerSceneTool::getHintFragmentMonomerInfoForDragStart()
 {
@@ -738,7 +136,7 @@ DrawMonomerSceneTool::getHintFragmentMonomerInfoForDragStart()
     }
 }
 
-HintFragmentMonomerInfo
+std::optional<HintFragmentMonomerInfo>
 DrawMonomerSceneTool::getHintFragmentMonomerInfoForDragEnd(
     const HintFragmentMonomerInfo& hint_start_monomer_info,
     const DragEndInfo& drag_end_info)
@@ -755,67 +153,8 @@ DrawMonomerSceneTool::getHintFragmentMonomerInfoForDragEnd(
     }
 }
 
-std::pair<DragEndInfo, AbstractMonomerItem*>
-DrawMonomerSceneTool::getDragEndInfo(const QPointF& scene_pos)
-{
-    auto* hovered_monomer_item = getTopMonomerItemAt(scene_pos);
-    if (hovered_monomer_item == m_drag_start_monomer_item) {
-        // we can't drag from a monomer to itself
-        hovered_monomer_item = nullptr;
-    }
-    UnboundMonomericAttachmentPointItem* drag_end_ap_item =
-        (hovered_monomer_item == nullptr)
-            ? nullptr
-            : getUnboundDragEndAttachmentPointAt(scene_pos);
-
-    // if we're dragging between two existing monomers, make sure that we'd be
-    // able to actually add a connection between them. Any pair of monomers can
-    // have at most one standard backbone connection and one custom connection
-    // (i.e. not a standard backbone connection) between them, since our RDKit
-    // monomer format currently doesn't support more than that
-    if (m_drag_start_monomer_item != nullptr && drag_end_ap_item != nullptr) {
-        auto* monomer_start = m_drag_start_monomer_item->getAtom();
-        auto* monomer_end = hovered_monomer_item->getAtom();
-        auto* connection = m_mol_model->getMol()->getBondBetweenAtoms(
-            monomer_start->getIdx(), monomer_end->getIdx());
-        if (connection != nullptr) {
-            auto ap_name_end =
-                drag_end_ap_item->getAttachmentPoint().model_name;
-            auto [linkage, flipped] =
-                build_linkage_string(m_drag_start_ap_model_name, ap_name_end);
-            bool is_custom_bond =
-                get_is_custom_bond(monomer_start, monomer_end, linkage);
-            if (is_custom_bond && connection->hasProp(CUSTOM_BOND)) {
-                // this would be a custom connection (i.e. not a standard
-                // backbone connection) and this monomer pair already has one
-                drag_end_ap_item = nullptr;
-            } else if (!is_custom_bond &&
-                       (!connection->hasProp(CUSTOM_BOND) ||
-                        contains_two_monomer_linkages(connection))) {
-                // this would be a standard backbone connection and this monomer
-                // pair already has one (presumably in the opposite direction,
-                // since otherwise the attachment points would have already been
-                // bound)
-                drag_end_ap_item = nullptr;
-            }
-        }
-    }
-
-    DragEndInfo direction_or_attachment_point;
-    if (drag_end_ap_item == nullptr) {
-        // there's no available attachment point at the cursor (or there is one
-        // but we can't use it because this pair of monomers already has that
-        // type of connection), so we display the drag hint in a direction
-        direction_or_attachment_point = getDragDirection(scene_pos);
-    } else {
-        direction_or_attachment_point =
-            std::make_pair(hovered_monomer_item, drag_end_ap_item);
-    }
-    return {direction_or_attachment_point, hovered_monomer_item};
-}
-
-Direction
-DrawMonomerSceneTool::getDragDirection(const QPointF& cur_scene_pos) const
+DragEndInfo DrawMonomerSceneTool::getDragEndInfoForNonMonomerPos(
+    const QPointF& cur_scene_pos) const
 {
     const qreal dx = cur_scene_pos.x() - m_mouse_press_scene_pos.x();
     const qreal dy = cur_scene_pos.y() - m_mouse_press_scene_pos.y();
@@ -839,109 +178,6 @@ DrawMonomerSceneTool::getDragDirection(const QPointF& cur_scene_pos) const
     }
 }
 
-void DrawMonomerSceneTool::onLeftButtonDragMove(
-    QGraphicsSceneMouseEvent* const event)
-{
-    AbstractMonomerSceneTool::onLeftButtonDragMove(event);
-    if (m_drag_ignored) {
-        return;
-    }
-    auto [drag_end_info, hovered_monomer_item] =
-        getDragEndInfo(event->scenePos());
-
-    if (hovered_monomer_item != m_drag_end_monomer_item) {
-        if (m_drag_end_monomer_item) {
-            clearDragEndAttachmentPointsLabels();
-        }
-        m_drag_end_monomer_item = hovered_monomer_item;
-        if (hovered_monomer_item != nullptr) {
-            labelAttachmentPointsOnDragEndMonomer(
-                hovered_monomer_item->getAtom(), hovered_monomer_item);
-        }
-    }
-
-    if (drag_end_info != m_drag_end_info) {
-        m_drag_end_info = drag_end_info;
-        // we know the drag start was valid, since otherwise m_drag_ignored
-        // would have been true
-        createDragHintIfDragStartValid(drag_end_info);
-
-        // update which unbound attachment point is highlighted
-        if (std::holds_alternative<MonomerAndAPItems>(drag_end_info)) {
-            auto active_ap_item =
-                std::get<MonomerAndAPItems>(drag_end_info).second;
-            for (auto* ap_item : m_drag_end_unbound_ap_items) {
-                auto color = ap_item == active_ap_item
-                                 ? STRUCTURE_HINT_COLOR
-                                 : m_drag_end_inactive_ap_color;
-                ap_item->setColor(color);
-            }
-        }
-    }
-}
-
-void DrawMonomerSceneTool::onLeftButtonDragRelease(
-    QGraphicsSceneMouseEvent* const event)
-{
-    AbstractMonomerSceneTool::onLeftButtonDragRelease(event);
-    if (m_drag_ignored) {
-        return;
-    }
-
-    // we need to figure out what attachment point we're over before we delete
-    // the attachment point graphics items
-    auto hint_start_monomer_info = getHintFragmentMonomerInfoForDragStart();
-    auto [drag_end_info, hovered_monomer_item] =
-        getDragEndInfo(event->scenePos());
-    // we know that hint_start_monomer_info can't be std::nullopt, since
-    // otherwise m_drag_ignored would be true and we would've returned already
-    auto hint_end_monomer_info = getHintFragmentMonomerInfoForDragEnd(
-        *hint_start_monomer_info, drag_end_info);
-
-    // delete the attachment point graphics items before we modify the structure
-    // so that we don't have to worry about monomer graphics items being deleted
-    // and automatically destroying their children
-    clearAttachmentPointsLabelsAndHintFragmentItem();
-    clearDragEndAttachmentPointsLabels();
-    m_drag_start_monomer_item = nullptr;
-    m_drag_start_ap_model_name.clear();
-    m_drag_end_monomer_item = nullptr;
-    m_drag_end_info = std::monostate{};
-
-    // now that everything is cleaned up, we can actually add the monomers and
-    // connection to MolModel
-    addDragStructureToMolModel(*hint_start_monomer_info, hint_end_monomer_info);
-}
-
-void DrawMonomerSceneTool::addDragStructureToMolModel(
-    const HintFragmentMonomerInfo& hint_start_monomer_info,
-    const HintFragmentMonomerInfo& hint_end_monomer_info)
-{
-    auto add_monomer_to_mol_model_if_new =
-        [this](const HintFragmentMonomerInfo& monomer_info) {
-            if (monomer_info.atom_idx >= 0) {
-                // the monomer already exists in MolModel
-                return static_cast<unsigned int>(monomer_info.atom_idx);
-            } else {
-                auto monomer_idx = m_mol_model->getMol()->getNumAtoms();
-                m_mol_model->addMonomer(m_res_name, m_chain_type,
-                                        monomer_info.pos);
-                return monomer_idx;
-            }
-        };
-
-    auto undo_raii = m_mol_model->createUndoMacro("Add monomeric connection");
-    auto start_monomer_idx =
-        add_monomer_to_mol_model_if_new(hint_start_monomer_info);
-    auto end_monomer_idx =
-        add_monomer_to_mol_model_if_new(hint_end_monomer_info);
-    auto mol = m_mol_model->getMol();
-    m_mol_model->addMonomericConnection(mol->getAtomWithIdx(start_monomer_idx),
-                                        hint_start_monomer_info.ap_model_name,
-                                        mol->getAtomWithIdx(end_monomer_idx),
-                                        hint_end_monomer_info.ap_model_name);
-}
-
 QPixmap DrawMonomerSceneTool::createDefaultCursorPixmap() const
 {
     // the specific number used here (the "1") doesn't matter - we just need any
@@ -959,20 +195,6 @@ QPixmap DrawMonomerSceneTool::createDefaultCursorPixmap() const
     auto min_scene_size =
         CURSOR_HINT_IMAGE_SIZE * MONOMER_CURSOR_HINT_MIN_SCENE_SIZE_SCALE;
     return cursor_hint_from_graphics_item(monomer_item.get(), min_scene_size);
-}
-
-void DrawMonomerSceneTool::labelAttachmentPointsOnDragEndMonomer(
-    const RDKit::Atom* const monomer, AbstractMonomerItem* const monomer_item)
-{
-    labelUnboundAttachmentPointsOnMonomer(
-        monomer, monomer_item, m_drag_end_attachment_point_labels_group,
-        m_drag_end_unbound_ap_items);
-}
-
-void DrawMonomerSceneTool::clearDragEndAttachmentPointsLabels()
-{
-    clear_graphics_item_group(m_drag_end_attachment_point_labels_group);
-    delete_all_unbound_ap_items(m_drag_end_unbound_ap_items);
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -1,28 +1,16 @@
 #pragma once
 
+#include <optional>
 #include <string>
-#include <tuple>
-#include <utility>
-#include <variant>
 
 #include "schrodinger/sketcher/definitions.h"
-#include "schrodinger/sketcher/model/sketcher_model.h"
-#include "schrodinger/sketcher/molviewer/constants.h"
-#include "schrodinger/sketcher/molviewer/fonts.h"
 #include "schrodinger/sketcher/molviewer/monomer_constants.h"
-#include "schrodinger/sketcher/tool/abstract_monomer_scene_tool.h"
-#include "schrodinger/sketcher/rdkit/monomeric.h"
+#include "schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h"
 
 namespace RDKit
 {
 class Atom;
-class Bond;
 } // namespace RDKit
-
-namespace RDGeom
-{
-class Point3D;
-} // namespace RDGeom
 
 namespace schrodinger
 {
@@ -30,173 +18,39 @@ namespace schrodinger
 namespace rdkit_extensions
 {
 enum class ChainType;
-enum class Direction;
 } // namespace rdkit_extensions
 
 namespace sketcher
 {
 
-class MonomerHintFragmentItem;
-class UnboundMonomericAttachmentPointItem;
 struct HintFragmentMonomerInfo;
-class MonomerConnectorItem;
-
-using MonomerAndAPItems =
-    std::pair<AbstractMonomerItem*, UnboundMonomericAttachmentPointItem*>;
-using DragEndInfo = std::variant<std::monostate, rdkit_extensions::Direction,
-                                 MonomerAndAPItems>;
-
-/**
- * Return the default unbound attachment point; that is, the attachment point
- * that should be selected when the user hovers over a monomer.
- * @param hovered_type The type of monomer being hovered over
- * @param tool_type  The type of monomer that would be drawn by the active scene
- * tool
- * @param unbound_ap_items A list of all graphics items representing unbound
- * attachment points of the hovered monomer
- */
-SKETCHER_API UnboundMonomericAttachmentPointItem* get_default_attachment_point(
-    const MonomerType hovered_type, const MonomerType tool_type,
-    const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
-
-/**
- * When adding a new monomer bound to an existing monomer, determine the
- * appropriate attach point to use for the new-monomer-end of the connection.
- */
-SKETCHER_API std::string
-get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
-                                     const std::string_view existing_monomer_ap,
-                                     const MonomerType new_monomer_type);
 
 /**
  * A scene tools that draws a monomer
  */
-class SKETCHER_API DrawMonomerSceneTool : public AbstractMonomerSceneTool
+class SKETCHER_API DrawMonomerSceneTool
+    : public AbstractDrawMonomerOrMonomericConnectionSceneTool
 {
   public:
     DrawMonomerSceneTool(const std::string& res_name,
                          const rdkit_extensions::ChainType chain_type,
                          const Fonts& fonts, Scene* scene, MolModel* mol_model);
-    virtual ~DrawMonomerSceneTool();
 
-    // Reimplemented AbstractSceneTool methods
-    std::vector<QGraphicsItem*> getGraphicsItems() override;
-    void onStructureUpdated() override;
-    void onMouseMove(QGraphicsSceneMouseEvent* const event) override;
+    // Reimplemented AbstractSceneTool method
     void onLeftButtonClick(QGraphicsSceneMouseEvent* const event) override;
-    void onLeftButtonDragStart(QGraphicsSceneMouseEvent* const event) override;
-    void onLeftButtonDragMove(QGraphicsSceneMouseEvent* const event) override;
-    void
-    onLeftButtonDragRelease(QGraphicsSceneMouseEvent* const event) override;
-    void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
 
   protected:
-    std::string m_res_name;
-    rdkit_extensions::ChainType m_chain_type;
-    MonomerType m_monomer_type;
-    Fonts m_bolded_fonts;
-
-    bool m_drag_ignored;
-    AbstractMonomerItem* m_drag_start_monomer_item = nullptr;
-    std::string m_drag_start_ap_model_name;
-    AbstractMonomerItem* m_drag_end_monomer_item = nullptr;
-    DragEndInfo m_drag_end_info;
-    QGraphicsItemGroup m_drag_end_attachment_point_labels_group;
-    std::vector<UnboundMonomericAttachmentPointItem*>
-        m_drag_end_unbound_ap_items;
-    QColor m_drag_end_inactive_ap_color;
-
+    // Reimplemented AbstractSceneTool method
     QPixmap createDefaultCursorPixmap() const override;
 
     /**
-     * Label all attachment points on the given monomer at the end of the
-     * current click-and-drag operation
-     */
-    void labelAttachmentPointsOnDragEndMonomer(
-        const RDKit::Atom* const monomer,
-        AbstractMonomerItem* const monomer_item);
-
-    /**
-     * Clear all attachment point labels drawn on the existing monomer at the
-     * end of the current click-and-drag operation. Note that this method *does
-     * not* clear the hint fragment item.
-     */
-    void clearDragEndAttachmentPointsLabels();
-
-    /**
-     * Return the unbound attachment point graphics item that should be "active"
-     * (i.e. that we'd draw a connection for if the user clicked) for the given
-     * coordinates. If the coordinates are over an unbound attachment point
-     * item, that item will be returned. If the coordinates are over the
-     * monomer, then the default unbound attachment point will be returned,
-     * assuming one exists for the current tool. If no default attachment point
-     * exists (e.g. if the tool and the hovered monomer are of different
-     * molecule types), then nullptr will be returned.
-     * @param scene_pos the coordinates to check
-     * @param no_default_if_click_should_mutate If true, this function will
-     * return nullptr if scene_pos is over the monomer itself and clicking on
-     * the monomer should trigger a mutation (e.g. if the user has the alanine
-     * tool selected and is hovering over a proline).  If false, this function
-     * will return the default unbound attachment point in this scenario,
-     * assuming one exists. (This value should normally be true if the user is
-     * hovering over or has clicked on the monomer, and false if the user has
-     * started a drag from the monomer.)
-     *
-     * @note This method only returns accurate results for the currently hovered
-     * monomer, and assumes that the unbound attachment point graphics items
-     * have already been drawn for this monomer.
-     */
-    UnboundMonomericAttachmentPointItem* getUnboundAttachmentPointAt(
-        const QPointF& scene_pos,
-        const bool no_default_if_click_should_mutate) const;
-
-    /**
-     * Return the unbound attachment point graphics item that should be "active"
-     * (i.e. that we'd draw a connection for if the user released the mouse
-     * button) for the given coordinates, assuming that the user is in the
-     * middle of a click-and-drag.  If the coordinates are over the monomer,
-     * then the default unbound attachment point will be returned based on the
-     * monomer and attachment point that the drag was started from, assuming one
-     * exists.
-     */
-    UnboundMonomericAttachmentPointItem*
-    getUnboundDragEndAttachmentPointAt(const QPointF& scene_pos) const;
-
-    /**
-     * @return the unbound attachment point that should be active when the user
-     * is hovering over the monomer itself
-     * @param no_default_if_click_should_mutate If true, this function will
-     * return nullptr if clicking on the monomer should trigger a mutation (e.g.
-     * if the user has the alanine tool selected and is hovering over a
-     * proline).  If false, this function will return the default unbound
-     * attachment point in this scenario, assuming one exists. (This value
-     * should normally be true if the user is hovering over or has clicked on
-     * the monomer, and false if the user has started a drag from the monomer.)
-     */
-    UnboundMonomericAttachmentPointItem*
-    getDefaultUnboundAttachmentPointForHoveredMonomer(
-        const bool no_default_if_click_should_mutate) const;
-
-    /**
      * Draw a hint structure showing a monomer bound to the specified attachment
-     * point
+     * point.
      */
     void
     drawBoundMonomerHintFor(UnboundMonomericAttachmentPointItem* const ap_item);
 
-    std::tuple<const RDKit::Atom*, MonomerType>
-    getHoveredMonomerAndType() const;
-
-    /**
-     * @return whether this tool should show the predictive highlighting outline
-     * for the currently hovered monomer.  The highlighting is shown if the
-     * hovered monomer can be mutated (i.e. its the same monomer type as this
-     * tool but a different residue name) or if there is a reasonable way to
-     * connect this tool's monomer to the hovered monomer (an unreasonable
-     * connection would be, e.g., connecting a nucleic acid base directly to a
-     * phosphate with no intervening sugar.)
-     */
-    bool shouldShowPredictiveHighlighting() const;
+    // Reimplemented AbstractDrawMonomerOrMonomericConnectionSceneTool methods
 
     /**
      * Whether clicking on the specified monomer should mutate that monomer. We
@@ -204,123 +58,20 @@ class SKETCHER_API DrawMonomerSceneTool : public AbstractMonomerSceneTool
      * a different residue name.
      */
     bool clickShouldMutate(const RDKit::Atom* monomer,
-                           const MonomerType monomer_type) const;
+                           const MonomerType monomer_type) const override;
 
-    /**
-     * Create a hint fragment containing the two specified monomers and the
-     * connection between them, then add this hint fragment to the scene. Note
-     * that this function will transfer ownership of the monomers themselves to
-     * RDKit.
-     */
-    void createHintFragmentItem(HintFragmentMonomerInfo& monomer_one,
-                                HintFragmentMonomerInfo& monomer_two);
-
-    /**
-     * If the user has started a "valid" click-and-drag operation, create the
-     * drag hint and return true. Otherwise, return false. The click-and-drag
-     * will be valid unless one of the following happened:
-     *  - the user tried to start a drag from an existing monomer that has no
-     *    available attachment points
-     *  - the user tried to start a drag from empty space while using a nucleic
-     *    acid phosphate or sugar tool (It doesn't make any biological sense to
-     *    create a dimer of those, so we disallow drags from empty space.)
-     * @return
-     */
-    bool createDragHintIfDragStartValid(const DragEndInfo& drag_end_info);
-
-    /**
-     * @return the attachment point to use if user starts a drag from empty
-     * space. We only allow drags from empty space for peptides and nucleic acid
-     * bases, so this function is only valid for those monomer types. (A drag
-     * from empty space normally creates two monomers of the same type, and it
-     * doesn't make biological sense to have a dimer of nucleic acid sugars or
-     * phosphates.)
-     */
-    std::string getDefaultDragStartAPModelName() const;
-
-    /**
-     * Create a HintFragmentMonomerInfo object describing a new monomer at the
-     * given coordinates. Note that the returned monomer is owned by the calling
-     * scope.
-     */
-    HintFragmentMonomerInfo createHintFragmentMonomerInfoForHintFromEmptySpace(
-        const QPointF& scene_pos) const;
-
-    /**
-     * Create a HintFragmentMonomerInfo object describing the existing monomer
-     * and attachment point. Note that the returned monomer is owned by the
-     * calling scope.
-     */
-    HintFragmentMonomerInfo
-    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-        const AbstractMonomerItem* const monomer_item,
-        const std::string& ap_model_name) const;
-
-    /**
-     * @overload takes a graphics item for the attachment point in place of the
-     * model name
-     */
-    HintFragmentMonomerInfo
-    createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-        const AbstractMonomerItem* const monomer_item,
-        const UnboundMonomericAttachmentPointItem* const ap_item) const;
-
-    /**
-     * Create a HintFragmentMonomerInfo object describing a new monomer at the
-     * given coordinates. Note that the returned monomer is owned by the calling
-     * scope.
-     */
-    HintFragmentMonomerInfo createHintFragmentMonomerInfoForHintToDirection(
-        const HintFragmentMonomerInfo& start_monomer_info,
-        const rdkit_extensions::Direction direction) const;
-
-    /**
-     * Determine whether the end of current click-and-drag operation is over an
-     * existing monomer or not. If not, return the direction of the drag.
-     * @param scene_pos The scene coordinates representing the end of the
-     * click-and-drag.
-     * @return If scene_pos is over an existing monomer, returns a pair of
-     *   - a pair of pointers to the graphics items representing the monomer and
-     *     the relevant attachment point. The second value will be nullptr if
-     * the monomer does not have any available unbound attachment points.
-     *   - a pointer to the monomer's graphics item (i.e. the first pointer of
-     *     the pair)
-     * If scene_pos is not over an existing monomer, returns a pair of
-     *   - the `Direction` enum value representing the direction of the
-     *     drag
-     *   - nullptr
-     */
-    std::pair<DragEndInfo, AbstractMonomerItem*>
-    getDragEndInfo(const QPointF& scene_pos);
-
-    void addDragStructureToMolModel(
-        const HintFragmentMonomerInfo& hint_start_monomer_info,
-        const HintFragmentMonomerInfo& hint_end_monomer_info);
-
-    /**
-     * If the user has began a "valid" click-and-drag, create and return the
-     * HintFragmentMonomerInfo object describing the starting location/monomer
-     * of the drag. Otherwise, return std::nullopt. See the
-     * createDragHintIfDragStartValid docstring for an explanation of valid
-     * versus invalid click-and-drags.
-     */
     std::optional<HintFragmentMonomerInfo>
-    getHintFragmentMonomerInfoForDragStart();
+    getHintFragmentMonomerInfoForDragStart() override;
 
-    /**
-     * Create and return the HintFragmentMonomerInfo object describing the end
-     * of the current click-and-drag operation.
-     */
-    HintFragmentMonomerInfo getHintFragmentMonomerInfoForDragEnd(
+    std::optional<HintFragmentMonomerInfo> getHintFragmentMonomerInfoForDragEnd(
         const HintFragmentMonomerInfo& hint_start_monomer_info,
-        const DragEndInfo& drag_end_info);
+        const DragEndInfo& drag_end_info) override;
 
-    /**
-     * @return the direction of the specified position relative to the start of
-     * the current click-and-drag operation
-     */
-    rdkit_extensions::Direction
-    getDragDirection(const QPointF& cur_scene_pos) const;
+    void updateHoveredUnboundAP(
+        UnboundMonomericAttachmentPointItem* hovered_ap_item) override;
+
+    DragEndInfo
+    getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const override;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
@@ -1,0 +1,177 @@
+#include "schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h"
+
+#include <optional>
+#include <utility>
+#include <variant>
+
+#include <QGraphicsLineItem>
+
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/scene.h"
+#include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+DrawMonomericConnectionSceneTool::DrawMonomericConnectionSceneTool(
+    const Fonts& fonts, Scene* scene, MolModel* mol_model) :
+    // the residue name and chain type are irrelevant since this tool will never
+    // create a new residue, so just pass dummy values
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(
+        "", rdkit_extensions::ChainType::CHEM, fonts, scene, mol_model)
+{
+}
+
+QPixmap DrawMonomericConnectionSceneTool::createDefaultCursorPixmap() const
+{
+    return cursor_hint_from_svg(":/icons/monomeric_connection.svg");
+}
+
+void DrawMonomericConnectionSceneTool::updateColorsAfterBackgroundColorChange(
+    bool is_dark_mode)
+{
+    AbstractDrawMonomerOrMonomericConnectionSceneTool::
+        updateColorsAfterBackgroundColorChange(is_dark_mode);
+    m_invalid_drag_pen.setColor(is_dark_mode
+                                    ? CONNECTION_TOOL_INVALID_DRAG_COLOR_DARK_BG
+                                    : CONNECTION_TOOL_INVALID_DRAG_COLOR);
+    m_unbound_ap_label_hover_color =
+        is_dark_mode ? CONNECTION_TOOL_AP_LABEL_HOVER_COLOR_DARK_BG
+                     : CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
+}
+
+bool DrawMonomericConnectionSceneTool::clickShouldMutate(
+    const RDKit::Atom* /* monomer */,
+    const MonomerType /* monomer_type */) const
+{
+    return false;
+}
+
+std::optional<HintFragmentMonomerInfo>
+DrawMonomericConnectionSceneTool::getHintFragmentMonomerInfoForDragStart()
+{
+    if (m_drag_start_monomer_item == nullptr) {
+        // the drag started over empty space, so we do nothing (unlike
+        // DrawMonomerSceneTool, which would add a new monomer here)
+        return std::nullopt;
+    } else if (!m_drag_start_ap_model_name.empty()) {
+        // the drag started over a monomer and it has an available attachment
+        // point
+        return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+            m_drag_start_monomer_item, m_drag_start_ap_model_name);
+    } else {
+        // the drag started over a monomer, but that monomer has no available
+        // unbound attachment points so we can't drag from it
+        return std::nullopt;
+    }
+}
+
+std::optional<HintFragmentMonomerInfo>
+DrawMonomericConnectionSceneTool::getHintFragmentMonomerInfoForDragEnd(
+    const HintFragmentMonomerInfo& hint_start_monomer_info,
+    const DragEndInfo& drag_end_info)
+{
+    if (std::holds_alternative<QPointF>(drag_end_info)) {
+        auto end_pos = std::get<QPointF>(drag_end_info);
+        // the MonomerType doesn't matter here (since we're not going to draw an
+        // actual molecule) so we arbitrarily pick CHEM
+        return HintFragmentMonomerInfo{{nullptr},
+                                       MonomerType::CHEM,
+                                       to_mol_xy(end_pos),
+                                       "",
+                                       NEW_MONOMER_FROM_INVALID_DRAG};
+    } else {
+        auto [hovered_monomer_item, drag_end_ap_item] =
+            std::get<MonomerAndAPItems>(drag_end_info);
+        return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+            hovered_monomer_item, drag_end_ap_item);
+    }
+}
+
+void DrawMonomericConnectionSceneTool::updateHoveredUnboundAP(
+    UnboundMonomericAttachmentPointItem* hovered_ap_item)
+{
+    // color the hovered AP black and color all of the others gray
+    for (auto* ap_item : m_unbound_ap_items) {
+        ap_item->setColor(ap_item == hovered_ap_item
+                              ? m_unbound_ap_label_hover_color
+                              : m_unbound_ap_label_color);
+    }
+}
+
+DragEndInfo DrawMonomericConnectionSceneTool::getDragEndInfoForNonMonomerPos(
+    const QPointF& cur_scene_pos) const
+{
+    return cur_scene_pos;
+}
+
+void DrawMonomericConnectionSceneTool::clearHintFragmentItem()
+{
+    AbstractDrawMonomerOrMonomericConnectionSceneTool::clearHintFragmentItem();
+    delete m_invalid_drag_item;
+    m_invalid_drag_item = nullptr;
+}
+
+void DrawMonomericConnectionSceneTool::createHintFragmentItem(
+    HintFragmentMonomerInfo& monomer_one_info,
+    HintFragmentMonomerInfo& monomer_two_info)
+{
+    if (monomer_one_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
+        monomer_two_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
+        AbstractDrawMonomerOrMonomericConnectionSceneTool::
+            createHintFragmentItem(monomer_one_info, monomer_two_info);
+        return;
+    }
+    auto start_qcoords = to_scene_xy(monomer_one_info.pos);
+    auto end_qcoords = to_scene_xy(monomer_two_info.pos);
+    auto* line_item = new QGraphicsLineItem({start_qcoords, end_qcoords});
+    m_invalid_drag_item = line_item;
+    line_item->setPen(m_invalid_drag_pen);
+    m_scene->addItem(line_item);
+    line_item->setVisible(true);
+}
+
+void DrawMonomericConnectionSceneTool::addDragStructureToMolModel(
+    const HintFragmentMonomerInfo& hint_start_monomer_info,
+    const HintFragmentMonomerInfo& hint_end_monomer_info)
+{
+    if (hint_start_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
+        hint_end_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
+        AbstractDrawMonomerOrMonomericConnectionSceneTool::
+            addDragStructureToMolModel(hint_start_monomer_info,
+                                       hint_end_monomer_info);
+    }
+}
+
+UnboundMonomericAttachmentPointItem* DrawMonomericConnectionSceneTool::
+    getDefaultUnboundAttachmentPointForHoveredMonomer(
+        const bool no_default_if_click_should_mutate) const
+{
+    auto [monomer, hovered_type] = getHoveredMonomerAndType();
+    if (m_unbound_ap_items.empty()) {
+        return nullptr;
+    } else if (hovered_type == MonomerType::CHEM) {
+        return find_min_attachment_point_by_num(m_unbound_ap_items);
+    } else if (hovered_type == MonomerType::PEPTIDE) {
+        return find_preferred_attachment_point_by_num(
+            m_unbound_ap_items,
+            {PeptideAP::C, PeptideAP::N, PeptideAP::SIDECHAIN});
+    } else if (hovered_type == MonomerType::NA_BASE) {
+        return find_attachment_point_with_name(m_unbound_ap_items,
+                                               NA_BASE_AP_PAIR);
+    } else if (hovered_type == MonomerType::NA_SUGAR) {
+        return find_preferred_attachment_point_by_num(
+            m_unbound_ap_items,
+            {NASugarAP::THREE_PRIME, NASugarAP::FIVE_PRIME});
+    } else if (hovered_type == MonomerType::NA_PHOSPHATE) {
+        return find_preferred_attachment_point_by_num(
+            m_unbound_ap_items,
+            {NAPhosphateAP::TO_NEXT_SUGAR, NAPhosphateAP::TO_PREV_SUGAR});
+    }
+    return nullptr;
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
+#include "schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h"
+
+class QGraphicsItem;
+
+namespace RDKit
+{
+class Atom;
+} // namespace RDKit
+
+namespace schrodinger
+{
+
+namespace rdkit_extensions
+{
+enum class ChainType;
+} // namespace rdkit_extensions
+
+namespace sketcher
+{
+
+/**
+ * A scene tool that draws connections between monomers or monomeric attachment
+ * points. Note that these connections use the standard attachments points, and
+ * are therefore intended to represent a covalent or disulfide connection
+ * between the monomers. The only exception to this is if a bond involves the
+ * "pair" attachment point of a nucleic acids base, in which case it will
+ * represent a hydrogen bond. To draw hydrogen bonds between other monomers, use
+ * the DrawMonomericHBondSceneTool.
+ */
+class SKETCHER_API DrawMonomericConnectionSceneTool
+    : public AbstractDrawMonomerOrMonomericConnectionSceneTool
+{
+  public:
+    DrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
+                                     MolModel* mol_model);
+
+    // Reimplemented AbstractSceneTool method
+    void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
+
+  protected:
+    QGraphicsItem* m_invalid_drag_item = nullptr;
+    QPen m_invalid_drag_pen = QPen(CONNECTION_TOOL_INVALID_DRAG_COLOR,
+                                   CONNECTION_TOOL_INVALID_DRAG_LINE_WIDTH);
+    QColor m_unbound_ap_label_hover_color =
+        CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
+
+    // Reimplemented AbstractSceneTool method
+    QPixmap createDefaultCursorPixmap() const override;
+
+    // Reimplemented AbstractDrawMonomerOrMonomericConnectionSceneTool methods
+
+    /**
+     * Clicking never mutates a monomer for this tool.
+     */
+    bool clickShouldMutate(const RDKit::Atom* monomer,
+                           const MonomerType monomer_type) const override;
+
+    std::optional<HintFragmentMonomerInfo>
+    getHintFragmentMonomerInfoForDragStart() override;
+
+    std::optional<HintFragmentMonomerInfo> getHintFragmentMonomerInfoForDragEnd(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const DragEndInfo& drag_end_info) override;
+
+    void updateHoveredUnboundAP(
+        UnboundMonomericAttachmentPointItem* hovered_ap_item) override;
+
+    DragEndInfo
+    getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const override;
+
+    void clearHintFragmentItem() override;
+
+    void
+    createHintFragmentItem(HintFragmentMonomerInfo& monomer_one_info,
+                           HintFragmentMonomerInfo& monomer_two_info) override;
+
+    void addDragStructureToMolModel(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const HintFragmentMonomerInfo& hint_end_monomer_info) override;
+
+    UnboundMonomericAttachmentPointItem*
+    getDefaultUnboundAttachmentPointForHoveredMonomer(
+        const bool no_default_if_click_should_mutate) const override;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>100</width>
-    <height>235</height>
+    <height>274</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1221,6 +1221,72 @@
      </widget>
     </widget>
    </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QToolButton" name="covalent_or_disulfide_btn">
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../sketcher.qrc">
+         <normaloff>:/icons/monomeric_connection.svg</normaloff>:/icons/monomeric_connection.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">monomeric_connection_group</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -1240,11 +1306,14 @@
    <header>schrodinger/sketcher/widget/amino_or_nucleic_toggle_button.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../sketcher.qrc"/>
+ </resources>
  <connections/>
  <buttongroups>
   <buttongroup name="nucleic_monomer_group"/>
   <buttongroup name="amino_monomer_group"/>
   <buttongroup name="amino_or_nucleic_group"/>
+  <buttongroup name="monomeric_connection_group"/>
  </buttongroups>
 </ui>

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -188,9 +188,21 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
         modular_btn->showPopupIndicatorOnHover(true);
         m_nucleic_acid_symbol_popups[button] = popup;
     }
+
+    ui->monomeric_connection_group->setId(
+        ui->covalent_or_disulfide_btn,
+        static_cast<int>(MonomericConnectionTool::COVALENT_OR_DISULFIDE));
 }
 
 MonomerToolWidget::~MonomerToolWidget() = default;
+
+void MonomerToolWidget::connectLocalSlots()
+{
+    AbstractDrawToolWidget::connectLocalSlots();
+
+    connect(ui->monomeric_connection_group, &QButtonGroup::idClicked, this,
+            &MonomerToolWidget::onConnectionButtonClicked);
+}
 
 void MonomerToolWidget::setModel(SketcherModel* model)
 {
@@ -250,7 +262,8 @@ void MonomerToolWidget::updateWidgetsEnabled()
 std::unordered_set<QAbstractButton*> MonomerToolWidget::getCheckableButtons()
 {
     auto buttons = AbstractDrawToolWidget::getCheckableButtons();
-    for (auto group : {ui->amino_monomer_group, ui->nucleic_monomer_group}) {
+    for (auto group : {ui->amino_monomer_group, ui->nucleic_monomer_group,
+                       ui->monomeric_connection_group}) {
         for (auto button : group->buttons()) {
             buttons.insert(button);
         }
@@ -266,8 +279,10 @@ void MonomerToolWidget::updateCheckedButton()
     }
     QAbstractButton* amino_button = nullptr;
     QAbstractButton* nucleic_button = nullptr;
+    QAbstractButton* connection_button = nullptr;
     bool has_sel = model->hasActiveSelection();
-    if (model->getDrawTool() == DrawTool::MONOMER) {
+    auto draw_tool = model->getDrawTool();
+    if (draw_tool == DrawTool::MONOMER) {
         if (model->getMonomerToolType() == MonomerToolType::AMINO_ACID) {
             ui->amino_monomer_btn->setChecked(true);
             ui->amino_or_nucleic_stack->setCurrentWidget(ui->amino_page);
@@ -284,9 +299,16 @@ void MonomerToolWidget::updateCheckedButton()
                     m_button_nucleic_acid_bimap.right.at(nucleic_acid);
             }
         }
+    } else if (draw_tool == DrawTool::MONOMERIC_CONNECTION) {
+        auto connection_tool =
+            model->getValueInt(ModelKey::MONOMERIC_CONNECTION_TOOL);
+        connection_button =
+            ui->monomeric_connection_group->button(connection_tool);
     }
     check_button_or_uncheck_group(amino_button, ui->amino_monomer_group);
     check_button_or_uncheck_group(nucleic_button, ui->nucleic_monomer_group);
+    check_button_or_uncheck_group(connection_button,
+                                  ui->monomeric_connection_group);
 
     // Only show the popup indicator arrow on the currently checked button
     for (auto& [btn, popup] : m_amino_acid_symbol_popups) {
@@ -462,6 +484,21 @@ void MonomerToolWidget::onNucleicAcidClicked(QAbstractButton* button)
     }
     ping_or_set_model_value(getModel(), ModelKey::NUCLEIC_ACID_SYMBOL,
                             NucleicAcidMutation{na_tool, symbol});
+}
+
+void MonomerToolWidget::onConnectionButtonClicked(int button_id)
+{
+    auto model = getModel();
+    auto tool = MonomericConnectionTool(button_id);
+    if (!model->hasActiveSelection()) {
+        // update the model
+        std::unordered_map<ModelKey, QVariant> kv_pairs = {
+            {ModelKey::DRAW_TOOL,
+             QVariant::fromValue(DrawTool::MONOMERIC_CONNECTION)},
+            {ModelKey::MONOMERIC_CONNECTION_TOOL, QVariant::fromValue(tool)},
+        };
+        model->setValues(kv_pairs);
+    }
 }
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.h
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.h
@@ -38,6 +38,7 @@ class SKETCHER_API MonomerToolWidget : public AbstractDrawToolWidget
     MonomerToolWidget(QWidget* parent = nullptr);
     ~MonomerToolWidget();
 
+    void connectLocalSlots() override;
     void setModel(SketcherModel* model) override;
     void updateCheckedButton() override;
     void updateWidgetsEnabled() override;
@@ -70,6 +71,11 @@ class SKETCHER_API MonomerToolWidget : public AbstractDrawToolWidget
      * Respond to the user clicking on a specific nucleic acid
      */
     void onNucleicAcidClicked(QAbstractButton* button);
+
+    /**
+     * Respond to the user clicking on a specific monomeric connection button
+     */
+    void onConnectionButtonClicked(int button_id);
 };
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/model/test_sketcher_model.cpp
+++ b/test/schrodinger/sketcher/model/test_sketcher_model.cpp
@@ -85,6 +85,8 @@ BOOST_AUTO_TEST_CASE(get_set_signal)
         {ModelKey::RING_TOOL, QVariant::fromValue(RingTool::CYCLOBUTANE)},
         {ModelKey::ENUMERATION_TOOL,
          QVariant::fromValue(EnumerationTool::EXISTING_RGROUP)},
+        {ModelKey::MONOMERIC_CONNECTION_TOOL,
+         QVariant::fromValue(MonomericConnectionTool::HBOND)},
         {ModelKey::ELEMENT, QVariant::fromValue(Element::N)},
         {ModelKey::ATOM_QUERY, QVariant::fromValue(AtomQuery::Q)},
         {ModelKey::RGROUP_NUMBER, 2u},

--- a/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
@@ -1,0 +1,411 @@
+#define BOOST_TEST_MODULE \
+    test_draw_monomeric_connection_scene_tool_integration_tests
+
+#include <QPointF>
+#include <boost/test/unit_test.hpp>
+
+#include "./test_monomer_integration_tests_common.h"
+#include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/scene_utils.h"
+#include "schrodinger/sketcher/public_constants.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Confirm that clicking in empty space has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_click_empty_space)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool();
+    fix.mouseClick({0, 0});
+    fix.confirmIsEmpty();
+}
+
+/**
+ * Confirm that clicking on an existing monomer has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_click_existing_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto pos = fix.getMonomerPos(0);
+    fix.setMonomericConnectionTool();
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an unbounnd attachment point of an existing monomer
+ * has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_click_attachment_point)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto monomer_pos = fix.getMonomerPos(0);
+    fix.setMonomericConnectionTool();
+    // hover over the monomer to trigger AP label creation
+    fix.mouseMove(monomer_pos);
+
+    // click on the N terminus attachment point
+    fix.mouseMove(monomer_pos);
+    auto n_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseClick(n_ap_pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+
+    // click on the C terminus attachment point
+    fix.mouseMove(monomer_pos);
+    auto c_ap_pos = fix.getAttachmentPointPos(0, "C");
+    fix.mouseClick(c_ap_pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+
+    // click on the side chain attachment point
+    fix.mouseMove(monomer_pos);
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseClick(x_ap_pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer to empty space has no
+ * effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_empty)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.setMonomericConnectionTool();
+
+    // Drag from the monomer to the right
+    auto start_pos = fix.getMonomerPos(0);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from the attachment point of an existing monomer
+ * to empty space has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool();
+
+    // Add initial monomer
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+
+    // hover over the monomer so that the attachment point graphics items are
+    // created
+    auto ala_pos = fix.getMonomerPos(0);
+    fix.mouseMove(ala_pos);
+
+    // Drag from N attachment point to empty space
+    auto start_pos = fix.getAttachmentPointPos(0, "N");
+    auto end_pos = start_pos + QPointF(-100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+
+    // hover over the first monomer so that its attachment point graphics items
+    // are created again
+    fix.mouseMove(end_pos);
+    fix.mouseMove(ala_pos);
+
+    // Drag from C attachment point to empty space
+    start_pos = fix.getAttachmentPointPos(0, "C");
+    end_pos = start_pos + QPointF(100, 100);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+
+    // hover over the first monomer so that its attachment point graphics items
+    // are created again
+    fix.mouseMove(end_pos);
+    fix.mouseMove(ala_pos);
+
+    // Drag from C attachment point to empty space
+    start_pos = fix.getAttachmentPointPos(0, "X");
+    end_pos = start_pos + QPointF(-50, 100);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer to an existing monomer
+ * connects them via the default attachment points
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_monomer_connects_default_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool();
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    auto pos1 = fix.getMonomerPos(0);
+    auto pos2 = fix.getMonomerPos(1);
+    fix.mouseDrag(pos1, pos2);
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from the attachment point of one existing monomer
+ * to the attachment point of another existing monomer connects the monomer via
+ * the specified attachment points.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_ap_to_ap_connects_via_both_aps)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool();
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    auto ala_pos = fix.getMonomerPos(0);
+    auto cys_pos = fix.getMonomerPos(1);
+    fix.mouseMove(ala_pos);
+    auto start_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_pos);
+    fix.mousePress(start_pos);
+    // first, drag to the cysteine to make its attachment points appear
+    fix.mouseMove(cys_pos, Qt::LeftButton);
+    auto end_pos = fix.getAttachmentPointPos(1, "N");
+    fix.mouseMove(end_pos, Qt::LeftButton);
+    fix.mouseRelease(end_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R1-1:R1$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to empty space with a peptide monomer
+ * creates a dimer with a backbone connection
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_empty)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool();
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.confirmIsEmpty();
+}
+
+/**
+ * Confirm that dragging from empty space to an existing monomer has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setMonomericConnectionTool();
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = fix.getMonomerPos(0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a second
+ * standard backbone connection between them (since monomer_mol can't store more
+ * than one standard backbone connection between the same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_second_backbone_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A.A}$$$$V2.0");
+    fix.setMonomericConnectionTool();
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "C");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    fix.verifyHELM("PEPTIDE1{A.A}$$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a second
+ * custom connection (i.e. not a standard backbone connection) between them
+ * (since monomer_mol can't store more than one custom connection between the
+ * same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+    fix.setMonomericConnectionTool();
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "X");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a third
+ * connection between them (since monomer_mol can't store more than two
+ * connections between the same pair of monomers)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_third_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+    fix.setMonomericConnectionTool();
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "N");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "C");
+    fix.mouseMove(end_ap_pos);
+    fix.mouseRelease(end_ap_pos);
+    fix.verifyHELM("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+}
+
+/**
+ * Place a monomer, hover next to it so the tool caches unbound attachment-
+ * point items and a hint fragment, then undo the placement and move the
+ * mouse. The monomer's child AP items get destroyed when the monomer is
+ * removed; without onStructureUpdated() the tool's stale raw pointers cause
+ * a double-free / use-after-free on the next mouse move.
+ */
+BOOST_AUTO_TEST_CASE(test_undo_monomer_after_hint_fragment_no_crash)
+{
+    MonomerToolTestFixture fix;
+
+    // place a monomer
+    auto monomer_pos = QPointF(100, 100);
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseClick(monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+
+    // hover over the monomer so the tool creates unbound AP items
+    fix.setMonomericConnectionTool();
+    fix.mouseMove(monomer_pos);
+
+    // hover over an attachment point so the tool also draws a hint fragment
+    auto c_ap_pos = fix.getAttachmentPointPos(0, "C");
+    fix.mouseMove(c_ap_pos);
+
+    // undo the placement (simulates Ctrl+Z). This destroys the monomer
+    // graphics item and, transitively, its child AP items.
+    auto* undo_stack = fix.m_mol_model->findChild<QUndoStack*>();
+    BOOST_REQUIRE(undo_stack != nullptr);
+    undo_stack->undo();
+    process_qt_events();
+    fix.confirmIsEmpty();
+
+    // moving the mouse a little crashes pre-fix because the tool's cached
+    // m_unbound_ap_items / m_hovered_monomeric_item are dangling
+    fix.mouseMove(c_ap_pos + QPointF(5, 5));
+}
+
+/**
+ * Start a drag from one monomer toward another so the tool caches drag-end AP
+ * items parented to the second monomer, then undo (which destroys the second
+ * monomer) before releasing. The tool's onStructureUpdated() must drop its
+ * stale drag-end pointers without trying to delete them - the items were
+ * already destroyed as Qt children of the now-gone monomer.
+ *
+ * NOTE: catches the bug reliably only under ASan; a plain debug build may
+ * pass even with the bug present if the freed memory hasn't been reused.
+ */
+BOOST_AUTO_TEST_CASE(test_undo_drag_end_monomer_no_crash)
+{
+    MonomerToolTestFixture fix;
+
+    // place two monomers far enough apart that they don't overlap
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseClick(QPointF(100, 100));
+    auto pos_a = fix.getMonomerPos(0);
+    fix.mouseClick(pos_a + QPointF(200, 0));
+    BOOST_REQUIRE(fix.m_mol_model->getMol()->getNumAtoms() == 2);
+    auto pos_b = fix.getMonomerPos(1);
+
+    // start a drag from A's C attachment point
+    fix.setMonomericConnectionTool();
+    fix.mouseMove(pos_a);
+    auto a_c_ap = fix.getAttachmentPointPos(0, "C");
+    fix.mouseMove(a_c_ap);
+    fix.mousePress(a_c_ap);
+
+    // drag over B - this populates m_drag_end_unbound_ap_items, parented to B
+    fix.mouseMove(pos_b, Qt::LeftButton);
+    auto b_n_ap = fix.getAttachmentPointPos(1, "N");
+    fix.mouseMove(b_n_ap, Qt::LeftButton);
+
+    // undo the second click - destroys monomer B and (transitively) the
+    // drag-end AP items parented to it. The structure-update callback runs
+    // synchronously here; pre-fix-extension this hits a double-free inside
+    // clearDragEndAttachmentPointsLabels().
+    auto* undo_stack = fix.m_mol_model->findChild<QUndoStack*>();
+    BOOST_REQUIRE(undo_stack != nullptr);
+    undo_stack->undo();
+    process_qt_events();
+    BOOST_TEST(fix.m_mol_model->getMol()->getNumAtoms() == 1);
+
+    // releasing the drag must not crash either
+    fix.mouseRelease(b_n_ap);
+}
+
+/**
+ * Make sure that dragging from a nucleic acid base's "pair" attachment point to
+ * a peptide monomer doesn't cause a crash.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.setMonomericConnectionTool();
+    auto start_monomer_pos = fix.getMonomerPos(1);
+    auto end_monomer_pos = fix.getMonomerPos(0);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(1, "pair");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    fix.mouseRelease(end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Make sure that dragging to a nucleic acid base's "pair" attachment point from
+ * a peptide monomer doesn't cause a crash (i.e. dragging in the opposite
+ * direction relative to the last test).
+ */
+BOOST_AUTO_TEST_CASE(test_drag_to_na_base_from_peptide)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.setNucleicAcidTool(NucleicAcidTool::A);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseMove(start_monomer_pos);
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    fix.mouseMove(start_ap_pos);
+    fix.mousePress(start_ap_pos);
+    fix.mouseMove(end_monomer_pos);
+    fix.mouseRelease(end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
+++ b/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
@@ -138,6 +138,18 @@ struct MonomerToolTestFixture {
         process_qt_events();
     }
 
+    void setMonomericConnectionTool()
+    {
+        m_sketcher_model->setValues({
+            {ModelKey::DRAW_TOOL,
+             QVariant::fromValue(DrawTool::MONOMERIC_CONNECTION)},
+            {ModelKey::MONOMERIC_CONNECTION_TOOL,
+             QVariant::fromValue(
+                 MonomericConnectionTool::COVALENT_OR_DISULFIDE)},
+        });
+        process_qt_events();
+    }
+
     void importMolText(const std::string& text)
     {
         import_mol_text(m_mol_model, text);


### PR DESCRIPTION
- Linked Case: SKETCH-2779

### Description

This implements a monomer connection scene tool and adds a button to the side bar to activate it.  This tool is basically a limited version of the monomer tool that can only add connections between two existing monomers; it can't add any new monomers.  The only new functionality it has is that it draws a light gray line when the user drags from a monomer to empty space.  Otherwise, it's hard for the user to know that the drag is doing anything.  This (hopefully) makes it clear to the user that they've successfully started a drag, but that their current release location won't actually add anything.  (we don't run into this issue with the monomer tool, since it would draw a connection to a new monomer in this scenario, so that tool doesn't have a "valid drag start but invalid drag end" scenario.)

Note that the diff here has a _lot_ of changed lines, but most of those are because GitHub doesn't do a good job of showing renamed or copied files.  Most of the lines of `draw_monomer_scene_tool.(cpp|h)` have now been moved to `abstract_draw_monomer_or_monomeric_connection_scene_tool.(cpp|h)`, but GitHub is showing these lines as deleted from `draw_monomer_scene_tool.(cpp|h)` and showing `abstract_draw_monomer_or_monomeric_connection_scene_tool.(cpp|h)` as brand new files.  There's no new logic in any of those four files; just some minor refactoring so that most of the code can be reused by the new `DrawMonomericConnectionSceneTool` class. 

### Testing Done

Tested via the desktop app on Windows and added some new tests that mimic the monomer tool integration tests, but for the monomeric connection tool.
