### PR TITLE
SKETCH-2815: Publish React sketcher component as @schrodinger/sketcher/react

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -16,6 +16,11 @@ runs:
         # Move WASM assets into package directory
         mv build/sketcher_app/* wasm/package/dist
 
+        # Compile the React component into dist/react. This must run after the
+        # WASM assets are in place so the build can hash the assembled
+        # wasm_shell.html for the iframe cache-bust (__WASM_HASH__).
+        (cd wasm/package && npm ci && npm run build)
+
         # Set pre-release version in package manifest
         sketcher_version=$(jq -r '.sketcher' version.json)
         tag_name=$(echo $sketcher_version | awk -F . '{print "v"$1"-"$2}')

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ compile_commands.json
 .vscode/
 .venv
 ext_bld
+# node dependencies for the sketcher npm package's React build
+wasm/package/node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         name: prettier
         entry: npx prettier@3.8.3
         language: system
-        files: \.(js|yml|yaml|md|html)$
+        files: \.(js|jsx|ts|tsx|yml|yaml|md|html)$
         args: [--check]
 
       - id: yapf

--- a/wasm/package/package-lock.json
+++ b/wasm/package/package-lock.json
@@ -1,0 +1,727 @@
+{
+    "name": "@schrodinger/sketcher",
+    "version": "<SKETCHER_VERSION>",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@schrodinger/sketcher",
+            "version": "<SKETCHER_VERSION>",
+            "license": "BSD-3-Clause",
+            "devDependencies": {
+                "@rollup/plugin-commonjs": "^20.0.0",
+                "@rollup/plugin-node-resolve": "^13.0.4",
+                "@rollup/plugin-replace": "^5.0.0",
+                "@rollup/plugin-typescript": "^8.5.0",
+                "@types/react": "^16.14.0",
+                "md5-file": "^5.0.0",
+                "rollup": "^2.56.3",
+                "rollup-plugin-peer-deps-external": "^2.2.4",
+                "tslib": "^2.6.0",
+                "type-fest": "^4.23.0",
+                "typescript": "^4.4.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
+            "integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^3.1.0",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.1",
+                "glob": "^7.1.6",
+                "is-reference": "^1.2.1",
+                "magic-string": "^0.25.7",
+                "resolve": "^1.17.0"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.38.3"
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+            "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^3.1.0",
+                "@types/resolve": "1.17.1",
+                "deepmerge": "^4.2.2",
+                "is-builtin-module": "^3.1.0",
+                "is-module": "^1.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.42.0"
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.7.tgz",
+            "integrity": "sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@rollup/plugin-typescript": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
+            "integrity": "sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^3.1.0",
+                "resolve": "^1.17.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0",
+                "tslib": "*",
+                "typescript": ">=3.7.0"
+            },
+            "peerDependenciesMeta": {
+                "tslib": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+            "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "0.0.39",
+                "estree-walker": "^1.0.1",
+                "picomatch": "^2.2.2"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0"
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "26.1.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "16.14.70",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.70.tgz",
+            "integrity": "sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "^0.16",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+            "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+            "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/builtin-modules": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "builtin-modules": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
+        },
+        "node_modules/md5-file": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+            "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "md5-file": "cli.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/react": {
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "2.80.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+            "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-peer-deps-external": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+            "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "rollup": "*"
+            }
+        },
+        "node_modules/sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        }
+    }
+}

--- a/wasm/package/package-lock.json
+++ b/wasm/package/package-lock.json
@@ -13,7 +13,7 @@
                 "@rollup/plugin-node-resolve": "^13.0.4",
                 "@rollup/plugin-replace": "^5.0.0",
                 "@rollup/plugin-typescript": "^8.5.0",
-                "@types/react": "^16.14.0",
+                "@types/react": "^18.0.0",
                 "md5-file": "^5.0.0",
                 "rollup": "^2.56.3",
                 "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -22,7 +22,7 @@
                 "typescript": "^4.4.2"
             },
             "peerDependencies": {
-                "react": "^16.8.0"
+                "react": "^18.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -224,14 +224,13 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "16.14.70",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.70.tgz",
-            "integrity": "sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==",
+            "version": "18.3.31",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
-                "@types/scheduler": "^0.16",
                 "csstype": "^3.2.2"
             }
         },
@@ -244,13 +243,6 @@
             "dependencies": {
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/scheduler": {
-            "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-            "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -522,16 +514,6 @@
                 "node": "*"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -572,39 +554,18 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
         "node_modules/react": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
+                "loose-envify": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.12",

--- a/wasm/package/package.json
+++ b/wasm/package/package.json
@@ -34,14 +34,14 @@
         "build": "rollup -c"
     },
     "peerDependencies": {
-        "react": "^16.8.0"
+        "react": "^18.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-replace": "^5.0.0",
         "@rollup/plugin-typescript": "^8.5.0",
-        "@types/react": "^16.14.0",
+        "@types/react": "^18.0.0",
         "md5-file": "^5.0.0",
         "rollup": "^2.56.3",
         "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/wasm/package/package.json
+++ b/wasm/package/package.json
@@ -10,7 +10,43 @@
         "access": "public",
         "registry": "https://npm.pkg.github.com"
     },
+    "main": "dist/react/index.js",
+    "module": "dist/react/index.es.js",
+    "types": "dist/react/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/react/index.d.ts",
+            "import": "./dist/react/index.es.js",
+            "require": "./dist/react/index.js"
+        },
+        "./react": {
+            "types": "./dist/react/index.d.ts",
+            "import": "./dist/react/index.es.js",
+            "require": "./dist/react/index.js"
+        },
+        "./dist/*": "./dist/*",
+        "./package.json": "./package.json"
+    },
     "files": [
         "dist"
-    ]
+    ],
+    "scripts": {
+        "build": "rollup -c"
+    },
+    "peerDependencies": {
+        "react": "^16.8.0"
+    },
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^20.0.0",
+        "@rollup/plugin-node-resolve": "^13.0.4",
+        "@rollup/plugin-replace": "^5.0.0",
+        "@rollup/plugin-typescript": "^8.5.0",
+        "@types/react": "^16.14.0",
+        "md5-file": "^5.0.0",
+        "rollup": "^2.56.3",
+        "rollup-plugin-peer-deps-external": "^2.2.4",
+        "tslib": "^2.6.0",
+        "type-fest": "^4.23.0",
+        "typescript": "^4.4.2"
+    }
 }

--- a/wasm/package/rollup.config.js
+++ b/wasm/package/rollup.config.js
@@ -1,0 +1,42 @@
+import commonjs from '@rollup/plugin-commonjs';
+import md5file from 'md5-file';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import replace from '@rollup/plugin-replace';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+
+const packageJson = require('./package.json');
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: packageJson.main,
+      format: 'cjs',
+      sourcemap: true,
+    },
+    {
+      file: packageJson.module,
+      format: 'esm',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    // The iframe loads the sketcher shell as `static/wasm_shell.html?cache_bust=<hash>`.
+    // The hash busts the shell itself; it is computed from the already-assembled
+    // WASM asset that the publish flow moves into dist/ before this build runs.
+    replace({
+      preventAssignment: true,
+      __WASM_HASH__: `${md5file.sync('dist/wasm_shell.html')}`,
+    }),
+    peerDepsExternal(),
+    resolve({ extensions: ['.mjs', '.js', '.json', '.node', '.ts', '.tsx'] }),
+    commonjs(),
+    typescript({
+      tsconfig: './tsconfig.json',
+      declaration: true,
+      declarationDir: 'dist/react',
+      outDir: 'dist/react',
+    }),
+  ],
+};

--- a/wasm/package/rollup.config.js
+++ b/wasm/package/rollup.config.js
@@ -9,6 +9,9 @@ const packageJson = require('./package.json');
 
 export default {
   input: 'src/index.ts',
+  // react/jsx-runtime is pulled in by the automatic JSX transform; keep it (and
+  // react) external alongside peerDepsExternal so it is not bundled.
+  external: [/^react($|\/)/],
   output: [
     {
       file: packageJson.main,

--- a/wasm/package/src/Sketcher.tsx
+++ b/wasm/package/src/Sketcher.tsx
@@ -1,0 +1,209 @@
+import type { ComponentProps } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import type { Merge, Tagged } from 'type-fest';
+
+declare global {
+  interface Window {
+    Module?: SketcherWASM;
+  }
+}
+
+export const SketcherImageFormat = {
+  PNG: 'PNG',
+  SVG: 'SVG',
+} as const;
+export type SketcherImageFormat = (typeof SketcherImageFormat)[keyof typeof SketcherImageFormat];
+
+/**
+ * @enum {string}
+ *
+ * NOTE: This mirrors the C++ `Format` enum which is the source of truth -
+ * @see {@link ../../../include/schrodinger/rdkit_extensions/file_format.h}
+ * It is exposed to the WASM module via the `EMSCRIPTEN_BINDINGS` block in
+ * @see {@link ../../../src/app/main.cpp}
+ */
+export const RepresentationFormat = {
+  AUTO_DETECT: 'AUTO_DETECT',
+  RDMOL_BINARY_BASE64: 'RDMOL_BINARY_BASE64',
+  SMILES: 'SMILES',
+  EXTENDED_SMILES: 'EXTENDED_SMILES',
+  SMARTS: 'SMARTS',
+  EXTENDED_SMARTS: 'EXTENDED_SMARTS',
+  MDL_MOLV2000: 'MDL_MOLV2000',
+  MDL_MOLV3000: 'MDL_MOLV3000',
+  MAESTRO: 'MAESTRO',
+  INCHI: 'INCHI',
+  INCHI_KEY: 'INCHI_KEY',
+  PDB: 'PDB',
+  MOL2: 'MOL2',
+  XYZ: 'XYZ',
+  MRV: 'MRV',
+  CDXML: 'CDXML',
+  HELM: 'HELM',
+  FASTA_PEPTIDE: 'FASTA_PEPTIDE',
+  FASTA_DNA: 'FASTA_DNA',
+  FASTA_RNA: 'FASTA_RNA',
+  FASTA: 'FASTA',
+} as const;
+export type RepresentationFormat = (typeof RepresentationFormat)[keyof typeof RepresentationFormat];
+
+// This is what the actual emscripten bound enum looks like, we use a "Tagged"
+// type to prevent misuse of object literals and ensure only a Format is passed
+// to the sketcher methods
+type SketcherWasmFormat = Tagged<{ value: number }, 'SketcherWasmFormat'>;
+type SketcherWasmImageFormat = Tagged<{ value: number }, 'SketcherWasmImageFormat'>;
+
+export type SketcherWASM = {
+  Format: { [K in keyof typeof RepresentationFormat]: SketcherWasmFormat };
+  ImageFormat: { [K in keyof typeof SketcherImageFormat]: SketcherWasmImageFormat };
+  sketcher_import_text: (text: string) => void;
+  sketcher_export_text: (format: SketcherWasmFormat) => string;
+  sketcher_export_image: (format: SketcherWasmImageFormat) => string;
+  sketcher_clear: () => void;
+  sketcher_is_empty: () => boolean;
+  sketcher_has_monomers: () => boolean;
+  sketcher_allow_monomeric: (allowMonomeric: boolean) => void;
+  sketcher_changed_callback?: () => void;
+  getExceptionMessage: (pointer: number) => string[];
+};
+
+export type SketcherRef = {
+  /**
+   * Provides a reference to the instance of the WASM sketcher application
+   */
+  getInstance: () => Promise<SketcherWASM>;
+  sketcherExportStructure: (format: RepresentationFormat) => string | undefined;
+  sketcherImportText: (representation: string, clearSketcher: boolean) => void;
+};
+
+export type SketcherProps = Merge<
+  ComponentProps<'iframe'>,
+  {
+    representation?: string;
+    onChange?: (sketcher: SketcherWASM) => void;
+    onError?: (message: string) => void;
+  }
+>;
+
+const Sketcher = forwardRef<SketcherRef, SketcherProps>(function Sketcher(props, ref) {
+  const {
+    representation,
+    onChange,
+    onError,
+    height = '400',
+    width = '100%',
+    ...iframeProps
+  } = props;
+  const [sketcherInstance, setSketcherInstance] = useState<SketcherWASM | null>(null);
+
+  const initializeSketcherRef = useCallback(async (iframe: HTMLIFrameElement | null) => {
+    if (!iframe) {
+      return;
+    }
+
+    let instance: SketcherWASM;
+    while (!(instance = iframe.contentWindow?.Module)) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    setSketcherInstance(instance);
+  }, []);
+
+  const sketcherInstanceRef = useRef(sketcherInstance);
+  sketcherInstanceRef.current = sketcherInstance;
+  useImperativeHandle(
+    ref,
+    (): SketcherRef => ({
+      getInstance: async () => {
+        while (!sketcherInstanceRef.current) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        return sketcherInstanceRef.current;
+      },
+      sketcherExportStructure(format) {
+        if (!sketcherInstanceRef.current) {
+          return;
+        }
+
+        const { sketcher_export_text, Format } = sketcherInstanceRef.current;
+        return sketcher_export_text(Format[format]);
+      },
+      sketcherImportText(representation, clearStructure = true) {
+        if (!sketcherInstanceRef.current) {
+          return;
+        }
+        const { sketcher_clear, sketcher_import_text } = sketcherInstanceRef.current;
+        if (clearStructure) {
+          sketcher_clear();
+        }
+        sketcher_import_text(representation);
+      },
+    }),
+    [],
+  );
+
+  /**
+   * Sync onChange callback from props to the sketcher's change callback
+   */
+  useEffect(() => {
+    if (!sketcherInstance) {
+      return;
+    }
+
+    sketcherInstance.sketcher_changed_callback = () => onChange?.(sketcherInstance);
+    return () => {
+      delete sketcherInstance.sketcher_changed_callback;
+    };
+  }, [onChange, sketcherInstance]);
+
+  /**
+   * Sync the representation from props with the contents of the sketcher canvas
+   */
+  useEffect(
+    () => {
+      if (!sketcherInstance) {
+        return;
+      }
+      const { sketcher_clear, sketcher_import_text, getExceptionMessage } = sketcherInstance;
+
+      sketcher_clear();
+      if (!representation?.trim()) {
+        return;
+      }
+
+      try {
+        sketcher_import_text(representation);
+      } catch (e) {
+        if (typeof e === 'number') {
+          onError?.(`Error importing to sketcher [${getExceptionMessage(e).join(': ')}]`);
+        } else {
+          onError?.(`Error importing to sketcher [${e}]`);
+        }
+      }
+    },
+    // omitting onError here because the error handler changing shouldn't re-trigger a sketcher
+    // update, we just want to use the onError defined at the time of the representation change
+    // render
+    [representation, sketcherInstance],
+  );
+
+  return (
+    <iframe
+      ref={initializeSketcherRef}
+      title="Maestro Sketcher"
+      height={height}
+      width={width}
+      src={`static/wasm_shell.html?cache_bust=__WASM_HASH__`}
+      {...iframeProps}
+    />
+  );
+});
+
+export default Sketcher;

--- a/wasm/package/src/Sketcher.tsx
+++ b/wasm/package/src/Sketcher.tsx
@@ -1,12 +1,5 @@
 import type { ComponentProps } from 'react';
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import type { Merge, Tagged } from 'type-fest';
 

--- a/wasm/package/src/index.ts
+++ b/wasm/package/src/index.ts
@@ -1,0 +1,2 @@
+export * from './Sketcher';
+export { default as Sketcher } from './Sketcher';

--- a/wasm/package/tsconfig.json
+++ b/wasm/package/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es5",
     "lib": ["es6", "dom", "es2016", "es2017"],
     "sourceMap": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/wasm/package/tsconfig.json
+++ b/wasm/package/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist/react",
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "es2016", "es2017"],
+    "sourceMap": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["react"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
- Linked Case: SKETCH-2815

### Description

The React binding for the Maestro Sketcher lives in a separate repo, `rc-maestro-sketcher`, which wraps this project's WebAssembly build and re-publishes it. That split forces the component's `RepresentationFormat` enum to be a hand-maintained mirror of the C++ `Format` enum and relies on a nightly cron to chase WASM versions across the repo boundary.

This change makes `sketcher` the single source of truth by publishing the React component from `@schrodinger/sketcher` itself, as a `./react` subpath export alongside the existing WASM assets. A small Rollup/TypeScript build compiles the component into `dist/react` during the existing npm publish flow, with the iframe cache-bust hash derived from the assembled `wasm_shell.html` at build time.

Once published, the two consumers (LiveDesign and ACAS) will import `@schrodinger/sketcher/react` directly and `rc-maestro-sketcher` will be retired.

### Testing Done

Built the package locally and confirmed `dist/react` is produced with `__WASM_HASH__` replaced by the md5 of `wasm_shell.html`; verified `npm pack` includes both `dist/react` and the WASM assets, and that a scratch install resolves `@schrodinger/sketcher/react` with type declarations.
