### PR TITLE
Adding CMake dependencies for *.qrc files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,18 +143,26 @@ function(add_qrc_dependencies QRC_FILE)
   get_filename_component(QRC_DIR ${QRC_FILE} DIRECTORY)
   file(READ ${QRC_FILE} QRC_CONTENTS)
   string(REGEX MATCHALL "<file[^>]*>[^<]+</file>" QRC_FILE_ENTRIES
-         ${QRC_CONTENTS})
+               ${QRC_CONTENTS})
   set(QRC_DEPENDENCIES)
   foreach(QRC_FILE_ENTRY ${QRC_FILE_ENTRIES})
     string(REGEX REPLACE "^<file[^>]*>" "" QRC_RESOURCE ${QRC_FILE_ENTRY})
     string(REGEX REPLACE "</file>$" "" QRC_RESOURCE ${QRC_RESOURCE})
     string(STRIP ${QRC_RESOURCE} QRC_RESOURCE)
-    cmake_path(ABSOLUTE_PATH QRC_RESOURCE BASE_DIRECTORY ${QRC_DIR} NORMALIZE
-               OUTPUT_VARIABLE QRC_RESOURCE_PATH)
+    cmake_path(
+      ABSOLUTE_PATH
+      QRC_RESOURCE
+      BASE_DIRECTORY
+      ${QRC_DIR}
+      NORMALIZE
+      OUTPUT_VARIABLE
+      QRC_RESOURCE_PATH)
     list(APPEND QRC_DEPENDENCIES ${QRC_RESOURCE_PATH})
   endforeach()
-  set_property(SOURCE ${QRC_FILE} APPEND PROPERTY OBJECT_DEPENDS
-               "${QRC_DEPENDENCIES}")
+  set_property(
+    SOURCE ${QRC_FILE}
+    APPEND
+    PROPERTY OBJECT_DEPENDS "${QRC_DEPENDENCIES}")
 endfunction()
 
 # Configure the SKETCHER_LIB and RDKIT_EXTENSIONS_LIB libraries
@@ -163,13 +171,8 @@ function(build_schrodinger_library TARGET)
   set(SRC_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/${TARGET})
   # Collect all headers and source; note we collect public headers so that Qt
   # can build .moc files.
-  file(
-    GLOB_RECURSE
-    SOURCE_LIST
-    CONFIGURE_DEPENDS
-    ${INCLUDE_DIR}/*.h
-    ${SRC_DIR}/*.h
-    ${SRC_DIR}/*.cpp)
+  file(GLOB_RECURSE SOURCE_LIST CONFIGURE_DEPENDS ${INCLUDE_DIR}/*.h
+       ${SRC_DIR}/*.h ${SRC_DIR}/*.cpp)
   # Collect all resources
   file(GLOB_RECURSE SOURCE_LIST_QRC CONFIGURE_DEPENDS ${SRC_DIR}/*.qrc)
   list(APPEND SOURCE_LIST ${SOURCE_LIST_QRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,20 +136,47 @@ function(setup_target TARGET)
   endif()
 endfunction()
 
+# Add dependencies to Qt resource collection files (*.qrc). This ensures that
+# changes to an icon, font, etc. will trigger a rebuild of the relevant .qrc
+# file.
+function(add_qrc_dependencies QRC_FILE)
+  get_filename_component(QRC_DIR ${QRC_FILE} DIRECTORY)
+  file(READ ${QRC_FILE} QRC_CONTENTS)
+  string(REGEX MATCHALL "<file[^>]*>[^<]+</file>" QRC_FILE_ENTRIES
+         ${QRC_CONTENTS})
+  set(QRC_DEPENDENCIES)
+  foreach(QRC_FILE_ENTRY ${QRC_FILE_ENTRIES})
+    string(REGEX REPLACE "^<file[^>]*>" "" QRC_RESOURCE ${QRC_FILE_ENTRY})
+    string(REGEX REPLACE "</file>$" "" QRC_RESOURCE ${QRC_RESOURCE})
+    string(STRIP ${QRC_RESOURCE} QRC_RESOURCE)
+    cmake_path(ABSOLUTE_PATH QRC_RESOURCE BASE_DIRECTORY ${QRC_DIR} NORMALIZE
+               OUTPUT_VARIABLE QRC_RESOURCE_PATH)
+    list(APPEND QRC_DEPENDENCIES ${QRC_RESOURCE_PATH})
+  endforeach()
+  set_property(SOURCE ${QRC_FILE} APPEND PROPERTY OBJECT_DEPENDS
+               "${QRC_DEPENDENCIES}")
+endfunction()
+
 # Configure the SKETCHER_LIB and RDKIT_EXTENSIONS_LIB libraries
 function(build_schrodinger_library TARGET)
   set(INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/schrodinger/${TARGET})
   set(SRC_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/${TARGET})
-  # Collect all headers, source, and resources; note we collect public headers
-  # so that Qt can build .moc files
+  # Collect all headers and source; note we collect public headers so that Qt
+  # can build .moc files.
   file(
     GLOB_RECURSE
     SOURCE_LIST
     CONFIGURE_DEPENDS
     ${INCLUDE_DIR}/*.h
     ${SRC_DIR}/*.h
-    ${SRC_DIR}/*.cpp
-    ${SRC_DIR}/*.qrc)
+    ${SRC_DIR}/*.cpp)
+  # Collect all resources
+  file(GLOB_RECURSE SOURCE_LIST_QRC CONFIGURE_DEPENDS ${SRC_DIR}/*.qrc)
+  list(APPEND SOURCE_LIST ${SOURCE_LIST_QRC})
+  foreach(QRC_FILE ${SOURCE_LIST_QRC})
+    add_qrc_dependencies(${QRC_FILE})
+  endforeach()
+
   add_library(${TARGET} ${SOURCE_LIST})
   add_library(schrodinger::${TARGET} ALIAS ${TARGET})
   set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME schrodinger_${TARGET})


### PR DESCRIPTION
- Linked Case: <issue>

### Description

CMake doesn't understand *.qrc files well enough to rebuild them when a referenced icon, font, etc. changes.  This led to some mild annoyance when I was tweaking the monomeric hydrogen bond icon in SKETCH-2780, so I had Codex add a function to our `CMakeLists.txt`.  The new function parses filenames out of the `<file>...</file>` blocks and adds them as explicit dependencies, so CMake will take those files into account when deciding whether to rebuild the *.qrc file.  This definitely wouldn't be sufficient for _any_ *.qrc file (e.g., it doesn't understand `<qresource prefix="all/files/relative/to/this">`), but it's good enough for our *.qrc files.

### Testing Done

Built Sketcher locally.
