### PR TITLE
SKETCH-2779: Tweaking comments based on Claude suggestions in mmshare PR

### DIFF
--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -567,13 +567,7 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragStart(
     // attachment points to be in the Scene
     clearAttachmentPointsLabelsAndHintFragmentItem();
 
-    // since the drag just started, we can safely assume that we're not over a
-    // different monomer than m_drag_start_monomer_item, which means we want a
-    // drag to direction, not to another's monomer attachment point
-    // auto dir = getDragDirection(event->scenePos());
     auto [drag_end_info, _] = getDragEndInfo(event->scenePos());
-    // TODO: this is why drags aren't working for the connection tool, since the
-    // connection tool returns false for drags to a direction
     auto handled = createDragHintIfDragStartValid(drag_end_info);
     if (handled) {
         // hide the cursor hint while the hint structure is shown. Note that the

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
@@ -147,7 +147,7 @@ void DrawMonomericConnectionSceneTool::addDragStructureToMolModel(
 
 UnboundMonomericAttachmentPointItem* DrawMonomericConnectionSceneTool::
     getDefaultUnboundAttachmentPointForHoveredMonomer(
-        const bool no_default_if_click_should_mutate) const
+        const bool /* no_default_if_click_should_mutate */) const
 {
     auto [monomer, hovered_type] = getHoveredMonomerAndType();
     if (m_unbound_ap_items.empty()) {


### PR DESCRIPTION
- Linked Case: SKETCH-2779

### Description

Claude pointed out two minor comments issues in https://github.com/schrodinger/mmshare/pull/10740, so I'm backporting them to the `sketcher` repo.  I also removed a stale comment that described one of the commented out lines of code that was removed.

### Testing Done

Local build works correctly.
