### PR TITLE
SKETCH-2780: Adding monomeric H-bond tool

### DIFF
--- a/src/schrodinger/sketcher/icons/monomeric_hbond.svg
+++ b/src/schrodinger/sketcher/icons/monomeric_hbond.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 30 32"
+   style="enable-background:new 0 0 30 32;"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <style
+     type="text/css"
+     id="style1">
+	.st0{fill:#666666;}
+</style>
+  <path
+     style="fill:#666666;fill-opacity:1;stroke:#666666;stroke-width:3.21968;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:5.47345612,4.02460009;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     d="M 2.752991,15.991204 H 27.29127"
+     id="path1" />
+</svg>

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -49,6 +49,7 @@
 #include "schrodinger/sketcher/tool/draw_monomer_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h"
+#include "schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h"
 #include "schrodinger/sketcher/tool/draw_r_group_scene_tool.h"
 #include "schrodinger/sketcher/tool/edit_charge_scene_tool.h"
 #include "schrodinger/sketcher/tool/move_rotate_scene_tool.h"
@@ -649,6 +650,7 @@ void Scene::onModelValuesChanged(const std::unordered_set<ModelKey>& keys)
             case ModelKey::RNA_NUCLEOBASE:
             case ModelKey::DNA_NUCLEOBASE:
             case ModelKey::CUSTOM_NUCLEOTIDE:
+            case ModelKey::MONOMERIC_CONNECTION_TOOL:
                 updateSceneTool();
                 break;
             default:
@@ -779,6 +781,9 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
         if (connection_tool == MonomericConnectionTool::COVALENT_OR_DISULFIDE) {
             return std::make_shared<DrawMonomericConnectionSceneTool>(
                 m_fonts, this, m_mol_model);
+        } else {
+            return std::make_shared<DrawMonomericHBondSceneTool>(m_fonts, this,
+                                                                 m_mol_model);
         }
     }
     // tool not yet implemented

--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -991,5 +991,12 @@ void ensure_distinct_chain_names(RDKit::ROMol& mol_to_change,
     }
 }
 
+bool is_hydrogen_bond(const RDKit::Bond* const bond)
+{
+    std::string custom_linkage;
+    bond->getPropIfPresent(CUSTOM_BOND, custom_linkage);
+    return custom_linkage == (NA_BASE_AP_PAIR + "-" + NA_BASE_AP_PAIR);
+}
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -337,5 +337,10 @@ SKETCHER_API void
 ensure_distinct_chain_names(RDKit::ROMol& mol_to_change,
                             const RDKit::ROMol& reference_mol);
 
+/**
+ * @return whether the given bond represents a monomeric hydrogen bond
+ */
+SKETCHER_API bool is_hydrogen_bond(const RDKit::Bond* const bond);
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/sketcher.qrc
+++ b/src/schrodinger/sketcher/sketcher.qrc
@@ -47,6 +47,7 @@
     <file>icons/mode_erase_dis.svg</file>
     <file>icons/mode_monomer.svg</file>
     <file>icons/monomeric_connection.svg</file>
+    <file>icons/monomeric_hbond.svg</file>
     <file>icons/periodic_table.svg</file>
     <file>icons/periodic_table_dis.svg</file>
     <file>icons/reaction_arrow.svg</file>

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -550,17 +550,8 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragStart(
     if (m_drag_start_monomer_item == nullptr) {
         m_drag_start_ap_model_name = getDefaultDragStartAPModelName();
     } else {
-        auto ap_item =
-            getUnboundAttachmentPointAt(m_mouse_press_scene_pos, false);
-        if (ap_item == nullptr) {
-            // this monomer has no available attachment points. In this
-            // scenario, createDragHint will return false below and we'll ignore
-            // the drag.
-            m_drag_start_ap_model_name = "";
-        } else {
-            m_drag_start_ap_model_name =
-                ap_item->getAttachmentPoint().model_name;
-        }
+        m_drag_start_ap_model_name =
+            getAPModelNameAtPosOverMonomer(m_mouse_press_scene_pos);
     }
     // clear the attachment point labels. Note that this must happen *after* the
     // getUnboundAttachmentPointAt call, since that method requires the
@@ -582,6 +573,17 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragStart(
     m_drag_ignored = !handled;
 }
 
+std::string AbstractDrawMonomerOrMonomericConnectionSceneTool::
+    getAPModelNameAtPosOverMonomer(const QPointF& scene_pos) const
+{
+    auto ap_item = getUnboundAttachmentPointAt(scene_pos, false);
+    if (ap_item == nullptr) {
+        // this monomer has no available attachment points
+        return "";
+    } else {
+        return ap_item->getAttachmentPoint().model_name;
+    }
+}
 bool AbstractDrawMonomerOrMonomericConnectionSceneTool::
     createDragHintIfDragStartValid(const DragEndInfo& drag_end_info)
 {
@@ -620,31 +622,10 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::getDragEndInfo(
     // (i.e. not a standard backbone connection) between them, since our RDKit
     // monomer format currently doesn't support more than that
     if (m_drag_start_monomer_item != nullptr && drag_end_ap_item != nullptr) {
-        auto* monomer_start = m_drag_start_monomer_item->getAtom();
-        auto* monomer_end = hovered_monomer_item->getAtom();
-        auto* connection = m_mol_model->getMol()->getBondBetweenAtoms(
-            monomer_start->getIdx(), monomer_end->getIdx());
-        if (connection != nullptr) {
-            auto ap_name_end =
-                drag_end_ap_item->getAttachmentPoint().model_name;
-            auto [linkage, flipped] =
-                build_linkage_string(m_drag_start_ap_model_name, ap_name_end);
-            bool is_custom_bond =
-                get_is_custom_bond(monomer_start, monomer_end, linkage);
-            if (is_custom_bond && connection->hasProp(CUSTOM_BOND)) {
-                // this would be a custom connection (i.e. not a standard
-                // backbone connection) and this monomer pair already has one
-                drag_end_ap_item = nullptr;
-            } else if (!is_custom_bond &&
-                       (!connection->hasProp(CUSTOM_BOND) ||
-                        contains_two_monomer_linkages(connection))) {
-                // this would be a standard backbone connection and this monomer
-                // pair already has one (presumably in the opposite direction,
-                // since otherwise the attachment points would have already been
-                // bound)
-                drag_end_ap_item = nullptr;
-            }
-        }
+        auto ap_name_end = drag_end_ap_item->getAttachmentPoint().model_name;
+        if (!dragCanFormConnectionTo(hovered_monomer_item, ap_name_end)) {
+            drag_end_ap_item = nullptr;
+        };
     }
 
     DragEndInfo drag_end_info;
@@ -657,6 +638,44 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::getDragEndInfo(
         drag_end_info = std::make_pair(hovered_monomer_item, drag_end_ap_item);
     }
     return {drag_end_info, hovered_monomer_item};
+}
+
+bool AbstractDrawMonomerOrMonomericConnectionSceneTool::dragCanFormConnectionTo(
+    const AbstractMonomerItem* const hovered_monomer_item,
+    const std::string& ap_name_end) const
+{
+    auto* monomer_start = m_drag_start_monomer_item->getAtom();
+    auto* monomer_end = hovered_monomer_item->getAtom();
+    auto* connection = m_mol_model->getMol()->getBondBetweenAtoms(
+        monomer_start->getIdx(), monomer_end->getIdx());
+    if (connection != nullptr) {
+        if (ap_name_end == NA_BASE_AP_PAIR || is_hydrogen_bond(connection)) {
+            // If either the new bond or the existing bond is a hydrogen bond,
+            // then we're trying to mix a hydrogen bond and a covalent bond in
+            // the same connection, which isn't allowed. If both of them are
+            // hydrogen bonds, then we're trying to create a hydrogen bond that
+            // already exists, which isn't allowed.
+            return false;
+        }
+        auto [linkage, flipped] =
+            build_linkage_string(m_drag_start_ap_model_name, ap_name_end);
+        bool is_custom_bond =
+            get_is_custom_bond(monomer_start, monomer_end, linkage);
+        if (is_custom_bond && connection->hasProp(CUSTOM_BOND)) {
+            // this would be a custom connection (i.e. not a standard
+            // backbone connection) and this monomer pair already has one
+            return false;
+        } else if (!is_custom_bond &&
+                   (!connection->hasProp(CUSTOM_BOND) ||
+                    contains_two_monomer_linkages(connection))) {
+            // this would be a standard backbone connection and this monomer
+            // pair already has one (presumably in the opposite direction,
+            // since otherwise the attachment points would have already been
+            // bound)
+            return false;
+        }
+    }
+    return true;
 }
 
 void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragMove(

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
@@ -354,8 +354,16 @@ class SKETCHER_API AbstractDrawMonomerOrMonomericConnectionSceneTool
      *     drag
      *   - nullptr
      */
-    std::pair<DragEndInfo, AbstractMonomerItem*>
+    virtual std::pair<DragEndInfo, AbstractMonomerItem*>
     getDragEndInfo(const QPointF& scene_pos);
+
+    /**
+     * @return Whether the current drag can add a connection to the specified
+     * monomer and attachment point model name.
+     */
+    bool dragCanFormConnectionTo(
+        const AbstractMonomerItem* const hovered_monomer_item,
+        const std::string& ap_name_end) const;
 
     virtual void addDragStructureToMolModel(
         const HintFragmentMonomerInfo& hint_start_monomer_info,
@@ -405,6 +413,18 @@ class SKETCHER_API AbstractDrawMonomerOrMonomericConnectionSceneTool
      */
     virtual DragEndInfo
     getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const = 0;
+
+    /**
+     * @return the model name of the attachment point to use when the mouse
+     * cursor is at the specified coordinates. Returns empty string if there are
+     * no unbound attachment points at the coordinates.
+     * @param scene_pos The mouse position in scene coordinates, which are
+     * guaranteed to be over a monomer or an unbound monomeric attachment point.
+     * However, if the coordinates are over a monomer, there's no guarantee that
+     * the monomer has any unbound attachment points.
+     */
+    virtual std::string
+    getAPModelNameAtPosOverMonomer(const QPointF& scene_pos) const;
 };
 
 } // namespace sketcher

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.cpp
@@ -1,0 +1,108 @@
+#include "schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h"
+
+#include <QGraphicsLineItem>
+
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/scene.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+AbstractDrawMonomericConnectionSceneTool::
+    AbstractDrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
+                                             MolModel* mol_model) :
+    // the residue name and chain type are irrelevant since this class will
+    // never create a new residue, so just pass dummy values
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(
+        "", rdkit_extensions::ChainType::CHEM, fonts, scene, mol_model)
+{
+}
+
+void AbstractDrawMonomericConnectionSceneTool::
+    updateColorsAfterBackgroundColorChange(bool is_dark_mode)
+{
+    AbstractDrawMonomerOrMonomericConnectionSceneTool::
+        updateColorsAfterBackgroundColorChange(is_dark_mode);
+    m_invalid_drag_pen.setColor(is_dark_mode
+                                    ? CONNECTION_TOOL_INVALID_DRAG_COLOR_DARK_BG
+                                    : CONNECTION_TOOL_INVALID_DRAG_COLOR);
+    m_unbound_ap_label_hover_color =
+        is_dark_mode ? CONNECTION_TOOL_AP_LABEL_HOVER_COLOR_DARK_BG
+                     : CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
+}
+
+bool AbstractDrawMonomericConnectionSceneTool::clickShouldMutate(
+    const RDKit::Atom* /* monomer */,
+    const MonomerType /* monomer_type */) const
+{
+    return false;
+}
+
+std::optional<HintFragmentMonomerInfo>
+AbstractDrawMonomericConnectionSceneTool::
+    getHintFragmentMonomerInfoForDragStart()
+{
+    if (m_drag_start_monomer_item == nullptr) {
+        // the drag started over empty space, so we do nothing (unlike
+        // DrawMonomerSceneTool, which would add a new monomer here)
+        return std::nullopt;
+    } else if (!m_drag_start_ap_model_name.empty()) {
+        // the drag started over a monomer and it has an available attachment
+        // point
+        return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+            m_drag_start_monomer_item, m_drag_start_ap_model_name);
+    }
+    // the drag started over a monomer, but that monomer has no available
+    // unbound attachment points so we can't drag from it
+    return std::nullopt;
+}
+
+DragEndInfo
+AbstractDrawMonomericConnectionSceneTool::getDragEndInfoForNonMonomerPos(
+    const QPointF& scene_pos) const
+{
+    return scene_pos;
+}
+
+void AbstractDrawMonomericConnectionSceneTool::clearHintFragmentItem()
+{
+    AbstractDrawMonomerOrMonomericConnectionSceneTool::clearHintFragmentItem();
+    delete m_invalid_drag_item;
+    m_invalid_drag_item = nullptr;
+}
+
+void AbstractDrawMonomericConnectionSceneTool::createHintFragmentItem(
+    HintFragmentMonomerInfo& monomer_one_info,
+    HintFragmentMonomerInfo& monomer_two_info)
+{
+    if (monomer_one_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
+        monomer_two_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
+        AbstractDrawMonomerOrMonomericConnectionSceneTool::
+            createHintFragmentItem(monomer_one_info, monomer_two_info);
+        return;
+    }
+    auto start_qcoords = to_scene_xy(monomer_one_info.pos);
+    auto end_qcoords = to_scene_xy(monomer_two_info.pos);
+    auto* line_item = new QGraphicsLineItem({start_qcoords, end_qcoords});
+    m_invalid_drag_item = line_item;
+    line_item->setPen(m_invalid_drag_pen);
+    m_scene->addItem(line_item);
+    line_item->setVisible(true);
+}
+
+void AbstractDrawMonomericConnectionSceneTool::addDragStructureToMolModel(
+    const HintFragmentMonomerInfo& hint_start_monomer_info,
+    const HintFragmentMonomerInfo& hint_end_monomer_info)
+{
+    if (hint_start_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
+        hint_end_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
+        AbstractDrawMonomerOrMonomericConnectionSceneTool::
+            addDragStructureToMolModel(hint_start_monomer_info,
+                                       hint_end_monomer_info);
+    }
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <optional>
+
+#include <QColor>
+#include <QPen>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
+#include "schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h"
+
+class QGraphicsItem;
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * A base class for scene tools that draw connections between existing monomers
+ * without adding new monomers
+ */
+class SKETCHER_API AbstractDrawMonomericConnectionSceneTool
+    : public AbstractDrawMonomerOrMonomericConnectionSceneTool
+{
+  protected:
+    AbstractDrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
+                                             MolModel* mol_model);
+
+    QGraphicsItem* m_invalid_drag_item = nullptr;
+    QPen m_invalid_drag_pen = QPen(CONNECTION_TOOL_INVALID_DRAG_COLOR,
+                                   CONNECTION_TOOL_INVALID_DRAG_LINE_WIDTH);
+    QColor m_unbound_ap_label_hover_color =
+        CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
+
+    // Reimplemented AbstractSceneTool method
+    void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
+
+    // Reimplemented AbstractDrawMonomerOrMonomericConnectionSceneTool methods
+    bool clickShouldMutate(const RDKit::Atom* monomer,
+                           MonomerType monomer_type) const override;
+
+    std::optional<HintFragmentMonomerInfo>
+    getHintFragmentMonomerInfoForDragStart() override;
+
+    DragEndInfo
+    getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const override;
+
+    void clearHintFragmentItem() override;
+
+    void
+    createHintFragmentItem(HintFragmentMonomerInfo& monomer_one_info,
+                           HintFragmentMonomerInfo& monomer_two_info) override;
+
+    void addDragStructureToMolModel(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const HintFragmentMonomerInfo& hint_end_monomer_info) override;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.cpp
@@ -99,9 +99,12 @@ AbstractMonomerSceneTool::getTopMonomerItemAt(const QPointF& scene_pos) const
         }
     }
 
-    // if we're not over any of those, check to see if we're near a monomer. If
-    // we are, check to see whether we'd be over one of its attachment points
-    // once they're drawn
+    return getMonomerNear(scene_pos);
+}
+
+AbstractMonomerItem*
+AbstractMonomerSceneTool::getMonomerNear(const QPointF& scene_pos) const
+{
     QPainterPath near_scene_pos;
     // We want a circle radius that will definitely include the relevant monomer
     // if we're over an attachment point hover area, but we don't care if it's

--- a/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_monomer_scene_tool.h
@@ -82,6 +82,16 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
     AbstractMonomerItem* getTopMonomerItemAt(const QPointF& scene_pos) const;
 
     /**
+     * @param scene_pos scene coordinates that are not over a monomer or any
+     * unbound attachment point graphics items
+     * @return the graphics item representing the monomer that would have an
+     * unbound attachment point at the specified coordinates if the unbound
+     * attachment points for the monomer were drawn. Nullptr if no such monomer
+     * exists.
+     */
+    virtual AbstractMonomerItem* getMonomerNear(const QPointF& scene_pos) const;
+
+    /**
      * Return the top graphics item representing a monomeric connector at the
      * given coordinates. If there's no such graphics item, return nullptr.
      * @param scene_pos The position in Scene coordinates
@@ -113,7 +123,7 @@ class SKETCHER_API AbstractMonomerSceneTool : public StandardSceneToolBase
      * Label all unbound attachment points on the given monomer, placing all
      * newly created graphics items into the specified group and list.
      */
-    void labelUnboundAttachmentPointsOnMonomer(
+    virtual void labelUnboundAttachmentPointsOnMonomer(
         const RDKit::Atom* const monomer,
         AbstractMonomerItem* const monomer_item,
         QGraphicsItemGroup& attachment_point_labels_group,

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
@@ -1,13 +1,6 @@
 #include "schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h"
 
-#include <optional>
-#include <utility>
-#include <variant>
-
-#include <QGraphicsLineItem>
-
 #include "schrodinger/sketcher/molviewer/coord_utils.h"
-#include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
 
 namespace schrodinger
@@ -17,55 +10,13 @@ namespace sketcher
 
 DrawMonomericConnectionSceneTool::DrawMonomericConnectionSceneTool(
     const Fonts& fonts, Scene* scene, MolModel* mol_model) :
-    // the residue name and chain type are irrelevant since this tool will never
-    // create a new residue, so just pass dummy values
-    AbstractDrawMonomerOrMonomericConnectionSceneTool(
-        "", rdkit_extensions::ChainType::CHEM, fonts, scene, mol_model)
+    AbstractDrawMonomericConnectionSceneTool(fonts, scene, mol_model)
 {
 }
 
 QPixmap DrawMonomericConnectionSceneTool::createDefaultCursorPixmap() const
 {
     return cursor_hint_from_svg(":/icons/monomeric_connection.svg");
-}
-
-void DrawMonomericConnectionSceneTool::updateColorsAfterBackgroundColorChange(
-    bool is_dark_mode)
-{
-    AbstractDrawMonomerOrMonomericConnectionSceneTool::
-        updateColorsAfterBackgroundColorChange(is_dark_mode);
-    m_invalid_drag_pen.setColor(is_dark_mode
-                                    ? CONNECTION_TOOL_INVALID_DRAG_COLOR_DARK_BG
-                                    : CONNECTION_TOOL_INVALID_DRAG_COLOR);
-    m_unbound_ap_label_hover_color =
-        is_dark_mode ? CONNECTION_TOOL_AP_LABEL_HOVER_COLOR_DARK_BG
-                     : CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
-}
-
-bool DrawMonomericConnectionSceneTool::clickShouldMutate(
-    const RDKit::Atom* /* monomer */,
-    const MonomerType /* monomer_type */) const
-{
-    return false;
-}
-
-std::optional<HintFragmentMonomerInfo>
-DrawMonomericConnectionSceneTool::getHintFragmentMonomerInfoForDragStart()
-{
-    if (m_drag_start_monomer_item == nullptr) {
-        // the drag started over empty space, so we do nothing (unlike
-        // DrawMonomerSceneTool, which would add a new monomer here)
-        return std::nullopt;
-    } else if (!m_drag_start_ap_model_name.empty()) {
-        // the drag started over a monomer and it has an available attachment
-        // point
-        return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
-            m_drag_start_monomer_item, m_drag_start_ap_model_name);
-    } else {
-        // the drag started over a monomer, but that monomer has no available
-        // unbound attachment points so we can't drag from it
-        return std::nullopt;
-    }
 }
 
 std::optional<HintFragmentMonomerInfo>
@@ -98,50 +49,6 @@ void DrawMonomericConnectionSceneTool::updateHoveredUnboundAP(
         ap_item->setColor(ap_item == hovered_ap_item
                               ? m_unbound_ap_label_hover_color
                               : m_unbound_ap_label_color);
-    }
-}
-
-DragEndInfo DrawMonomericConnectionSceneTool::getDragEndInfoForNonMonomerPos(
-    const QPointF& cur_scene_pos) const
-{
-    return cur_scene_pos;
-}
-
-void DrawMonomericConnectionSceneTool::clearHintFragmentItem()
-{
-    AbstractDrawMonomerOrMonomericConnectionSceneTool::clearHintFragmentItem();
-    delete m_invalid_drag_item;
-    m_invalid_drag_item = nullptr;
-}
-
-void DrawMonomericConnectionSceneTool::createHintFragmentItem(
-    HintFragmentMonomerInfo& monomer_one_info,
-    HintFragmentMonomerInfo& monomer_two_info)
-{
-    if (monomer_one_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
-        monomer_two_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
-        AbstractDrawMonomerOrMonomericConnectionSceneTool::
-            createHintFragmentItem(monomer_one_info, monomer_two_info);
-        return;
-    }
-    auto start_qcoords = to_scene_xy(monomer_one_info.pos);
-    auto end_qcoords = to_scene_xy(monomer_two_info.pos);
-    auto* line_item = new QGraphicsLineItem({start_qcoords, end_qcoords});
-    m_invalid_drag_item = line_item;
-    line_item->setPen(m_invalid_drag_pen);
-    m_scene->addItem(line_item);
-    line_item->setVisible(true);
-}
-
-void DrawMonomericConnectionSceneTool::addDragStructureToMolModel(
-    const HintFragmentMonomerInfo& hint_start_monomer_info,
-    const HintFragmentMonomerInfo& hint_end_monomer_info)
-{
-    if (hint_start_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG &&
-        hint_end_monomer_info.atom_idx != NEW_MONOMER_FROM_INVALID_DRAG) {
-        AbstractDrawMonomerOrMonomericConnectionSceneTool::
-            addDragStructureToMolModel(hint_start_monomer_info,
-                                       hint_end_monomer_info);
     }
 }
 

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
@@ -5,22 +5,10 @@
 
 #include "schrodinger/sketcher/definitions.h"
 #include "schrodinger/sketcher/molviewer/monomer_constants.h"
-#include "schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h"
-
-class QGraphicsItem;
-
-namespace RDKit
-{
-class Atom;
-} // namespace RDKit
+#include "schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h"
 
 namespace schrodinger
 {
-
-namespace rdkit_extensions
-{
-enum class ChainType;
-} // namespace rdkit_extensions
 
 namespace sketcher
 {
@@ -35,35 +23,15 @@ namespace sketcher
  * the DrawMonomericHBondSceneTool.
  */
 class SKETCHER_API DrawMonomericConnectionSceneTool
-    : public AbstractDrawMonomerOrMonomericConnectionSceneTool
+    : public AbstractDrawMonomericConnectionSceneTool
 {
   public:
     DrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
                                      MolModel* mol_model);
 
-    // Reimplemented AbstractSceneTool method
-    void updateColorsAfterBackgroundColorChange(bool is_dark_mode) override;
-
   protected:
-    QGraphicsItem* m_invalid_drag_item = nullptr;
-    QPen m_invalid_drag_pen = QPen(CONNECTION_TOOL_INVALID_DRAG_COLOR,
-                                   CONNECTION_TOOL_INVALID_DRAG_LINE_WIDTH);
-    QColor m_unbound_ap_label_hover_color =
-        CONNECTION_TOOL_AP_LABEL_HOVER_COLOR;
-
     // Reimplemented AbstractSceneTool method
     QPixmap createDefaultCursorPixmap() const override;
-
-    // Reimplemented AbstractDrawMonomerOrMonomericConnectionSceneTool methods
-
-    /**
-     * Clicking never mutates a monomer for this tool.
-     */
-    bool clickShouldMutate(const RDKit::Atom* monomer,
-                           const MonomerType monomer_type) const override;
-
-    std::optional<HintFragmentMonomerInfo>
-    getHintFragmentMonomerInfoForDragStart() override;
 
     std::optional<HintFragmentMonomerInfo> getHintFragmentMonomerInfoForDragEnd(
         const HintFragmentMonomerInfo& hint_start_monomer_info,
@@ -71,19 +39,6 @@ class SKETCHER_API DrawMonomericConnectionSceneTool
 
     void updateHoveredUnboundAP(
         UnboundMonomericAttachmentPointItem* hovered_ap_item) override;
-
-    DragEndInfo
-    getDragEndInfoForNonMonomerPos(const QPointF& scene_pos) const override;
-
-    void clearHintFragmentItem() override;
-
-    void
-    createHintFragmentItem(HintFragmentMonomerInfo& monomer_one_info,
-                           HintFragmentMonomerInfo& monomer_two_info) override;
-
-    void addDragStructureToMolModel(
-        const HintFragmentMonomerInfo& hint_start_monomer_info,
-        const HintFragmentMonomerInfo& hint_end_monomer_info) override;
 
     UnboundMonomericAttachmentPointItem*
     getDefaultUnboundAttachmentPointForHoveredMonomer(

--- a/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.cpp
@@ -1,0 +1,89 @@
+#include "schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h"
+
+#include <utility>
+#include <variant>
+
+#include "schrodinger/sketcher/molviewer/coord_utils.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+DrawMonomericHBondSceneTool::DrawMonomericHBondSceneTool(const Fonts& fonts,
+                                                         Scene* scene,
+                                                         MolModel* mol_model) :
+    AbstractDrawMonomericConnectionSceneTool(fonts, scene, mol_model)
+{
+    m_highlight_types = InteractiveItemFlag::MONOMER;
+}
+
+QPixmap DrawMonomericHBondSceneTool::createDefaultCursorPixmap() const
+{
+    return cursor_hint_from_svg(":/icons/monomeric_hbond.svg");
+}
+
+void DrawMonomericHBondSceneTool::labelUnboundAttachmentPointsOnMonomer(
+    const RDKit::Atom* const monomer, AbstractMonomerItem* const monomer_item,
+    QGraphicsItemGroup& attachment_point_labels_group,
+    std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
+{
+}
+
+std::optional<HintFragmentMonomerInfo>
+DrawMonomericHBondSceneTool::getHintFragmentMonomerInfoForDragEnd(
+    const HintFragmentMonomerInfo& hint_start_monomer_info,
+    const DragEndInfo& drag_end_info)
+{
+    if (std::holds_alternative<QPointF>(drag_end_info)) {
+        auto end_pos = std::get<QPointF>(drag_end_info);
+        // the MonomerType doesn't matter here (since we're not going to draw an
+        // actual molecule) so we arbitrarily pick CHEM
+        return HintFragmentMonomerInfo{{nullptr},
+                                       MonomerType::CHEM,
+                                       to_mol_xy(end_pos),
+                                       "",
+                                       NEW_MONOMER_FROM_INVALID_DRAG};
+    } else {
+        auto [hovered_monomer_item, _drag_end_ap_item] =
+            std::get<MonomerAndAPItems>(drag_end_info);
+        return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
+            hovered_monomer_item, NA_BASE_AP_PAIR);
+    }
+}
+
+void DrawMonomericHBondSceneTool::updateHoveredUnboundAP(
+    UnboundMonomericAttachmentPointItem* hovered_ap_item)
+{
+}
+
+std::pair<DragEndInfo, AbstractMonomerItem*>
+DrawMonomericHBondSceneTool::getDragEndInfo(const QPointF& scene_pos)
+{
+    auto* hovered_monomer_item = getTopMonomerItemAt(scene_pos);
+    if (m_drag_start_monomer_item == nullptr ||
+        hovered_monomer_item == nullptr ||
+        hovered_monomer_item == m_drag_start_monomer_item ||
+        !dragCanFormConnectionTo(hovered_monomer_item, NA_BASE_AP_PAIR)) {
+        // we can't form a bond to this location
+        return {scene_pos, nullptr};
+    } else {
+        return {std::make_pair(hovered_monomer_item, nullptr),
+                hovered_monomer_item};
+    }
+}
+
+std::string DrawMonomericHBondSceneTool::getAPModelNameAtPosOverMonomer(
+    const QPointF& scene_pos) const
+{
+    return NA_BASE_AP_PAIR;
+}
+
+AbstractMonomerItem*
+DrawMonomericHBondSceneTool::getMonomerNear(const QPointF& scene_pos) const
+{
+    return nullptr;
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "schrodinger/sketcher/definitions.h"
+#include "schrodinger/sketcher/molviewer/monomer_constants.h"
+#include "schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h"
+
+namespace schrodinger
+{
+
+namespace sketcher
+{
+
+/**
+ * A scene tool that draws hydrogen bonds between monomers
+ */
+class SKETCHER_API DrawMonomericHBondSceneTool
+    : public AbstractDrawMonomericConnectionSceneTool
+{
+  public:
+    DrawMonomericHBondSceneTool(const Fonts& fonts, Scene* scene,
+                                MolModel* mol_model);
+
+  protected:
+    // Reimplemented AbstractSceneTool method
+    QPixmap createDefaultCursorPixmap() const override;
+
+    void labelUnboundAttachmentPointsOnMonomer(
+        const RDKit::Atom* const monomer,
+        AbstractMonomerItem* const monomer_item,
+        QGraphicsItemGroup& attachment_point_labels_group,
+        std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
+        override;
+
+    // Reimplemented AbstractDrawMonomerOrMonomericConnectionSceneTool methods
+
+    std::optional<HintFragmentMonomerInfo> getHintFragmentMonomerInfoForDragEnd(
+        const HintFragmentMonomerInfo& hint_start_monomer_info,
+        const DragEndInfo& drag_end_info) override;
+
+    void updateHoveredUnboundAP(
+        UnboundMonomericAttachmentPointItem* hovered_ap_item) override;
+
+    std::pair<DragEndInfo, AbstractMonomerItem*>
+    getDragEndInfo(const QPointF& scene_pos) override;
+
+    std::string
+    getAPModelNameAtPosOverMonomer(const QPointF& scene_pos) const override;
+
+    AbstractMonomerItem*
+    getMonomerNear(const QPointF& scene_pos) const override;
+};
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>100</width>
-    <height>274</height>
+    <height>276</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1260,6 +1260,35 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="hbond_btn">
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../sketcher.qrc">
+         <normaloff>:/icons/monomeric_hbond.svg</normaloff>:/icons/monomeric_hbond.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">monomeric_connection_group</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -1311,9 +1340,9 @@
  </resources>
  <connections/>
  <buttongroups>
+  <buttongroup name="monomeric_connection_group"/>
   <buttongroup name="nucleic_monomer_group"/>
   <buttongroup name="amino_monomer_group"/>
   <buttongroup name="amino_or_nucleic_group"/>
-  <buttongroup name="monomeric_connection_group"/>
  </buttongroups>
 </ui>

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -192,6 +192,8 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
     ui->monomeric_connection_group->setId(
         ui->covalent_or_disulfide_btn,
         static_cast<int>(MonomericConnectionTool::COVALENT_OR_DISULFIDE));
+    ui->monomeric_connection_group->setId(
+        ui->hbond_btn, static_cast<int>(MonomericConnectionTool::HBOND));
 }
 
 MonomerToolWidget::~MonomerToolWidget() = default;

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -411,6 +411,28 @@ BOOST_AUTO_TEST_CASE(test_drag_third_connection)
 }
 
 /**
+ * Make sure that dragging between two existing monomer won't create a
+ * connection between them if there's already a hydrogen bond (since monomer_mol
+ * won't mix covalent and hydrogen bonds)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_hydrogen_bond)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::PHE);
+
+    // drag from monomer to monomer
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    // the drag should have added a new monomer to the N terminus of the start
+    // monomer since we released over an invalid attachment point
+    fix.verifyHELM(
+        "PEPTIDE1{A.F}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+}
+
+/**
  * Place a monomer, hover next to it so the tool caches unbound attachment-
  * point items and a hint fragment, then undo the placement and move the
  * mouse. The monomer's child AP items get destroyed when the monomer is

--- a/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
@@ -23,7 +23,8 @@ namespace sketcher
 BOOST_AUTO_TEST_CASE(test_click_empty_space)
 {
     MonomerToolTestFixture fix;
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.mouseClick({0, 0});
     fix.confirmIsEmpty();
 }
@@ -36,7 +37,8 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer)
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A}$$$$V2.0");
     auto pos = fix.getMonomerPos(0);
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.mouseClick(pos);
     fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
 }
@@ -50,7 +52,8 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A}$$$$V2.0");
     auto monomer_pos = fix.getMonomerPos(0);
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     // hover over the monomer to trigger AP label creation
     fix.mouseMove(monomer_pos);
 
@@ -81,7 +84,8 @@ BOOST_AUTO_TEST_CASE(test_drag_monomer_to_empty)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A}$$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
 
     // Drag from the monomer to the right
     auto start_pos = fix.getMonomerPos(0);
@@ -98,7 +102,8 @@ BOOST_AUTO_TEST_CASE(test_drag_monomer_to_empty)
 BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty)
 {
     MonomerToolTestFixture fix;
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
 
     // Add initial monomer
     fix.importMolText("PEPTIDE1{A}$$$$V2.0");
@@ -147,7 +152,8 @@ BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty)
 BOOST_AUTO_TEST_CASE(test_drag_monomer_to_monomer_connects_default_aps)
 {
     MonomerToolTestFixture fix;
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
     auto pos1 = fix.getMonomerPos(0);
     auto pos2 = fix.getMonomerPos(1);
@@ -163,7 +169,8 @@ BOOST_AUTO_TEST_CASE(test_drag_monomer_to_monomer_connects_default_aps)
 BOOST_AUTO_TEST_CASE(test_drag_ap_to_ap_connects_via_both_aps)
 {
     MonomerToolTestFixture fix;
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
     auto ala_pos = fix.getMonomerPos(0);
     auto cys_pos = fix.getMonomerPos(1);
@@ -181,13 +188,13 @@ BOOST_AUTO_TEST_CASE(test_drag_ap_to_ap_connects_via_both_aps)
 }
 
 /**
- * Confirm that dragging from empty space to empty space with a peptide monomer
- * creates a dimer with a backbone connection
+ * Confirm that dragging from empty space to empty space has no effect
  */
 BOOST_AUTO_TEST_CASE(test_drag_empty_to_empty)
 {
     MonomerToolTestFixture fix;
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_pos = QPointF(100, 100);
     auto end_pos = start_pos + QPointF(100, 0);
     fix.mouseDrag(start_pos, end_pos);
@@ -201,7 +208,8 @@ BOOST_AUTO_TEST_CASE(test_drag_empty_to_monomer)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{C}$$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_pos = QPointF(100, 100);
     auto end_pos = fix.getMonomerPos(0);
     fix.mouseDrag(start_pos, end_pos);
@@ -217,7 +225,8 @@ BOOST_AUTO_TEST_CASE(test_drag_second_backbone_connection)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A.A}$$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
@@ -242,7 +251,8 @@ BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
     MonomerToolTestFixture fix;
     fix.importMolText(
         "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
@@ -266,7 +276,8 @@ BOOST_AUTO_TEST_CASE(test_drag_third_connection)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
@@ -278,6 +289,27 @@ BOOST_AUTO_TEST_CASE(test_drag_third_connection)
     fix.mouseMove(end_ap_pos);
     fix.mouseRelease(end_ap_pos);
     fix.verifyHELM("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two existing monomer won't create a
+ * connection between them if there's already a hydrogen bond (since monomer_mol
+ * won't mix covalent and hydrogen bonds)
+ */
+BOOST_AUTO_TEST_CASE(test_drag_hydrogen_bond)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
+
+    // drag from monomer to monomer
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
 }
 
 /**
@@ -298,7 +330,8 @@ BOOST_AUTO_TEST_CASE(test_undo_monomer_after_hint_fragment_no_crash)
     fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
 
     // hover over the monomer so the tool creates unbound AP items
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.mouseMove(monomer_pos);
 
     // hover over an attachment point so the tool also draws a hint fragment
@@ -341,7 +374,8 @@ BOOST_AUTO_TEST_CASE(test_undo_drag_end_monomer_no_crash)
     auto pos_b = fix.getMonomerPos(1);
 
     // start a drag from A's C attachment point
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     fix.mouseMove(pos_a);
     auto a_c_ap = fix.getAttachmentPointPos(0, "C");
     fix.mouseMove(a_c_ap);
@@ -374,7 +408,8 @@ BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
-    fix.setMonomericConnectionTool();
+    fix.setMonomericConnectionTool(
+        MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(1);
     auto end_monomer_pos = fix.getMonomerPos(0);
     fix.mouseMove(start_monomer_pos);

--- a/test/schrodinger/sketcher/tool/test_draw_monomeric_hbond_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomeric_hbond_scene_tool_integration_tests.cpp
@@ -1,0 +1,263 @@
+#define BOOST_TEST_MODULE test_draw_monomeric_hbond_scene_tool_integration_tests
+
+#include <QPointF>
+#include <boost/test/unit_test.hpp>
+
+#include "./test_monomer_integration_tests_common.h"
+#include "schrodinger/rdkit_extensions/convert.h"
+#include "schrodinger/sketcher/model/sketcher_model.h"
+#include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/scene_utils.h"
+#include "schrodinger/sketcher/public_constants.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Confirm that clicking in empty space has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_click_empty_space)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    fix.mouseClick({0, 0});
+    fix.confirmIsEmpty();
+}
+
+/**
+ * Confirm that clicking on an existing monomer has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_click_existing_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    auto pos = fix.getMonomerPos(0);
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer to empty space has no
+ * effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_empty)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+
+    // Drag from the monomer to the right
+    auto start_pos = fix.getMonomerPos(0);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+}
+
+/**
+ * Confirm that click-and-drag from an existing monomer to an existing monomer
+ * connects them via the default attachment points
+ */
+BOOST_AUTO_TEST_CASE(test_drag_monomer_to_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$$$$V2.0");
+    auto pos1 = fix.getMonomerPos(0);
+    auto pos2 = fix.getMonomerPos(1);
+    auto pos3 = fix.getMonomerPos(2);
+    fix.mouseDrag(pos1, pos2);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:"
+                   "pair-1:pair$$$V2.0");
+
+    // drag between the same two monomers and make sure that we don't try to add
+    // a second hydrogen bond
+    fix.mouseDrag(pos1, pos2);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:"
+                   "pair-1:pair$$$V2.0");
+
+    // create a hydrogen bond from chain 1 to chain 3
+    fix.mouseDrag(pos1, pos3);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:"
+                   "pair-1:pair|PEPTIDE1,PEPTIDE3,1:pair-1:pair$$$V2.0");
+
+    // create a hydrogen bond from chain 2 to chain 3
+    fix.mouseDrag(pos2, pos3);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:"
+                   "pair-1:pair|PEPTIDE1,PEPTIDE3,1:pair-1:pair|PEPTIDE2,"
+                   "PEPTIDE3,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Try dragging to and from a location where an attachment point would be with
+ * the DrawMonomericConnectionSceneTool.  Since the DrawMonomericHBondSceneTool
+ * doesn't display attachment points, these drags should have no effect.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_to_and_from_ap_location)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    fix.importMolText("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    auto pos1 = fix.getMonomerPos(0);
+    auto pos2 = fix.getMonomerPos(1);
+    fix.mouseDrag(fix.getPosJustOutsideOfMonomer(pos1, Direction::E), pos2);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    fix.mouseDrag(fix.getPosJustOutsideOfMonomer(pos1, Direction::W), pos2);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    fix.mouseDrag(fix.getPosJustOutsideOfMonomer(pos1, Direction::N), pos2);
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    fix.mouseDrag(pos1, fix.getPosJustOutsideOfMonomer(pos2, Direction::E));
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    fix.mouseDrag(pos1, fix.getPosJustOutsideOfMonomer(pos2, Direction::W));
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+    fix.mouseDrag(pos1, fix.getPosJustOutsideOfMonomer(pos2, Direction::N));
+    fix.verifyHELM("PEPTIDE1{A}|PEPTIDE2{C}$$$$V2.0");
+}
+
+/**
+ * Confirm that dragging from empty space to empty space has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_empty)
+{
+    MonomerToolTestFixture fix;
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = start_pos + QPointF(100, 0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.confirmIsEmpty();
+}
+
+/**
+ * Confirm that dragging from empty space to an existing monomer has no effect
+ */
+BOOST_AUTO_TEST_CASE(test_drag_empty_to_monomer)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_pos = QPointF(100, 100);
+    auto end_pos = fix.getMonomerPos(0);
+    fix.mouseDrag(start_pos, end_pos);
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two monomers connected by a standard backbone
+ * bond doesn't add a hydrogen bond between them, since monomer_mol won't mix
+ * covalent and hydrogen bonds in a single connection.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_already_backbone_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A.A}$$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A.A}$$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two monomers connected by a custom bond
+ * doesn't add a hydrogen bond between them, since monomer_mol won't mix
+ * covalent and hydrogen bonds in a single connection.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_already_custom_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+}
+
+/**
+ * Make sure that dragging between two monomers connected by both backbone and
+ * custom bonds doesn't add a hydrogen bond between them, since monomer_mol
+ * won't mix covalent and hydrogen bonds in a single connection.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_third_connection)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{C.C}$PEPTIDE1,PEPTIDE1,1:R3-2:R3$$$V2.0");
+}
+
+/**
+ * Start a drag from one monomer toward another, then undo (which destroys the
+ * second monomer) before releasing.
+ */
+BOOST_AUTO_TEST_CASE(test_undo_drag_end_monomer_no_crash)
+{
+    MonomerToolTestFixture fix;
+
+    // place two monomers far enough apart that they don't overlap
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.mouseClick(QPointF(100, 100));
+    auto pos_a = fix.getMonomerPos(0);
+    fix.mouseClick(pos_a + QPointF(200, 0));
+    BOOST_REQUIRE(fix.m_mol_model->getMol()->getNumAtoms() == 2);
+    auto pos_b = fix.getMonomerPos(1);
+
+    // start a drag from A to B
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    fix.mouseMove(pos_a);
+    fix.mousePress(pos_a);
+    fix.mouseMove(pos_b, Qt::LeftButton);
+
+    // undo the second click - destroys monomer B
+    auto* undo_stack = fix.m_mol_model->findChild<QUndoStack*>();
+    BOOST_REQUIRE(undo_stack != nullptr);
+    undo_stack->undo();
+    process_qt_events();
+    BOOST_TEST(fix.m_mol_model->getMol()->getNumAtoms() == 1);
+
+    // releasing the drag must not crash
+    fix.mouseRelease(pos_b);
+}
+
+/**
+ * Make sure that dragging from a nucleic acid base's "pair" attachment point to
+ * a peptide monomer doesn't cause a crash.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_monomer_pos = fix.getMonomerPos(1);
+    auto end_monomer_pos = fix.getMonomerPos(0);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Make sure that dragging to a nucleic acid base's "pair" attachment point from
+ * a peptide monomer doesn't cause a crash (i.e. dragging in the opposite
+ * direction relative to the last test).
+ */
+BOOST_AUTO_TEST_CASE(test_drag_to_na_base_from_peptide)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.setMonomericConnectionTool(MonomericConnectionTool::HBOND);
+    auto start_monomer_pos = fix.getMonomerPos(0);
+    auto end_monomer_pos = fix.getMonomerPos(1);
+    fix.mouseDrag(start_monomer_pos, end_monomer_pos);
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
+++ b/test/schrodinger/sketcher/tool/test_monomer_integration_tests_common.h
@@ -138,14 +138,14 @@ struct MonomerToolTestFixture {
         process_qt_events();
     }
 
-    void setMonomericConnectionTool()
+    void
+    setMonomericConnectionTool(const MonomericConnectionTool connection_tool)
     {
         m_sketcher_model->setValues({
             {ModelKey::DRAW_TOOL,
              QVariant::fromValue(DrawTool::MONOMERIC_CONNECTION)},
             {ModelKey::MONOMERIC_CONNECTION_TOOL,
-             QVariant::fromValue(
-                 MonomericConnectionTool::COVALENT_OR_DISULFIDE)},
+             QVariant::fromValue(connection_tool)},
         });
         process_qt_events();
     }
@@ -164,6 +164,15 @@ struct MonomerToolTestFixture {
         return to_scene_xy(mol->getConformer().getAtomPos(monomer_idx));
     }
 
+    QPointF getPosJustOutsideOfMonomer(const QPointF& monomer_pos,
+                                       const Direction dir)
+    {
+        auto offset_vec = direction_to_qt_vector(dir);
+        auto offset_dist =
+            UNBOUND_AP_LINE_LENGTH - 1 + STANDARD_AA_BORDER_WIDTH / 2;
+        return monomer_pos + offset_dist * offset_vec;
+    }
+
     QPointF getAttachmentPointPos(unsigned int monomer_idx,
                                   const std::string& ap_display_name)
     {
@@ -179,10 +188,8 @@ struct MonomerToolTestFixture {
             if (ap_item) {
                 auto ap = ap_item->getAttachmentPoint();
                 if (ap.display_name == ap_display_name) {
-                    auto offset_vec = direction_to_qt_vector(ap.direction);
-                    auto offset_dist = UNBOUND_AP_LINE_LENGTH - 1 +
-                                       STANDARD_AA_BORDER_WIDTH / 2;
-                    return monomer_pos + offset_dist * offset_vec;
+                    return getPosJustOutsideOfMonomer(monomer_pos,
+                                                      ap.direction);
                 }
             }
         }


### PR DESCRIPTION
- Linked Case: SKETCH-2780

### Description

This PR adds a monomer tool for creating hydrogen bonds between arbitrary monomers (i.e. the bond doesn't need to involve a nucleic acid base).  The new tool shares a fair bit of code with the DrawMonomericConnectionSceneTool, so I've refactored that class to create the AbstractDrawMonomericConnectionSceneTool, which contains the code shared by the standard connection tool (i.e. covalent and disulfide bonds) and the hydrogen bond tool.  Note that GitHub doesn't do a great job (or any job really) of showing copied files, so this diff looks far larger than it really is.  I also had to do a little bit of additional refactoring to AbstractMonomerSceneTool and AbstractDrawMonomerOrMonomericConnectionSceneTool so that the hydrogen bond tool wouldn't try to draw attachment points, since hydrogen bonds only use the "pair" attachment point.

While I was working on this, I also discovered that rdkit_extensions/monomer_mol doesn't allow a single connection to contain both a covalent/disulfide bond and a hydrogen bond; it can only represent one or the other.  I tweaked some of the existing code so that none of the monomeric tools would attempt to do this (which would trigger an exception).

### Testing Done

Added new integration tests for the new scene tool and for the can't-mix-covalent/disulfide-and-hydrogen-bond restriction.  Tested via the Windows desktop app.
