### PR TITLE
SKETCH-2779, SKETCH-2780: Adding tooltips to monomeric connector buttons

### DIFF
--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -1244,6 +1244,9 @@
          <height>32</height>
         </size>
        </property>
+       <property name="toolTip">
+        <string>Covalent or disulfide bond</string>
+       </property>
        <property name="text">
         <string>...</string>
        </property>
@@ -1272,6 +1275,9 @@
          <width>32</width>
          <height>32</height>
         </size>
+       </property>
+       <property name="toolTip">
+        <string>Hydrogen bond</string>
        </property>
        <property name="text">
         <string>...</string>


### PR DESCRIPTION
- Linked Case: SKETCH-2779, SKETCH-2780

### Description

This add tooltips to the new side bar buttons for the monomer connection tools.

### Testing Done

Confirmed that the tooltips appear on the Windows desktop build.
