### PR TITLE
Pass --fresh to CMake on Windows when compiler location changes

### DIFF
--- a/premake
+++ b/premake
@@ -45,6 +45,22 @@ if [[ "$OSTYPE" == darwin* ]]; then
     POST_BUILD_COMMANDS="@find $BUILD_DIR \\( -name '*.dylib' -o -type f -perm +111 \\) ! -type l | while read target; do install_name_tool -change /Users/localbuildbot/builds/software/lib/Darwin-x86_64/sqlite-3.42.0/lib/libsqlite3.0.dylib /usr/lib/libsqlite3.0.dylib \"\$\$target\"; install_name_tool -change /software/lib/Darwin-x86_64/zlib-1.2.11/lib/libz.1.dylib /usr/lib/libz.1.dylib \"\$\$target\"; done"
 fi
 
+# Start with a fresh CMake cache if the compiler has moved. CMake considers the
+# compiler immutable after the build tree has been configured.
+ADDITIONAL_CMAKE_CONFIGURE_ARGS=""
+if [ -n "$CXX_COMPILER" ]; then
+    CACHED_CXX_COMPILER=$(sed -n 's/^CMAKE_CXX_COMPILER:[^=]*=//p' \
+        "$BUILD_DIR/CMakeCache.txt" 2>/dev/null || true)
+    NORMALIZED_CXX_COMPILER=$(cygpath -m "$CXX_COMPILER")
+    NORMALIZED_CACHED_CXX_COMPILER=""
+    if [ -n "$CACHED_CXX_COMPILER" ]; then
+        NORMALIZED_CACHED_CXX_COMPILER=$(cygpath -m "$CACHED_CXX_COMPILER")
+    fi
+    if [ "$NORMALIZED_CACHED_CXX_COMPILER" != "$NORMALIZED_CXX_COMPILER" ]; then
+        ADDITIONAL_CMAKE_CONFIGURE_ARGS="--fresh"
+    fi
+fi
+
 # Generate Makefile wrapper
 cat > "$BUILD_DIR/Makefile" << EOF
 .PHONY: all test memtest
@@ -57,7 +73,8 @@ all:
 	      -DENFORCE_DEPENDENCY_VERSIONS=OFF \\
 	      -DBUILD_SHARED_LIBS=ON \\
 	      -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \\
-	      ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER="$CXX_COMPILER"}
+	      ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER="$CXX_COMPILER"} \\
+          $ADDITIONAL_CMAKE_CONFIGURE_ARGS
 	cmake --build $BUILD_DIR --config $BUILD_TYPE
 	cmake --install $BUILD_DIR --config $BUILD_TYPE --prefix $BUILD_DIR
 	$POST_BUILD_COMMANDS

--- a/premake
+++ b/premake
@@ -45,8 +45,11 @@ if [[ "$OSTYPE" == darwin* ]]; then
     POST_BUILD_COMMANDS="@find $BUILD_DIR \\( -name '*.dylib' -o -type f -perm +111 \\) ! -type l | while read target; do install_name_tool -change /Users/localbuildbot/builds/software/lib/Darwin-x86_64/sqlite-3.42.0/lib/libsqlite3.0.dylib /usr/lib/libsqlite3.0.dylib \"\$\$target\"; install_name_tool -change /software/lib/Darwin-x86_64/zlib-1.2.11/lib/libz.1.dylib /usr/lib/libz.1.dylib \"\$\$target\"; done"
 fi
 
-# Start with a fresh CMake cache if the compiler has moved. CMake considers the
-# compiler immutable after the build tree has been configured.
+# Start with a fresh CMake cache if the compiler has moved, since CMake
+# considers the compiler immutable after the build tree has been configured.
+# Without this, incremental Windows builds will fail whenever mmshare's
+# dependencies change, as that causes buildinger to create a new buildvenv
+# with a slightly different path, meaning that the path to MSVC will change.
 ADDITIONAL_CMAKE_CONFIGURE_ARGS=""
 if [ -n "$CXX_COMPILER" ]; then
     CACHED_CXX_COMPILER=$(sed -n 's/^CMAKE_CXX_COMPILER:[^=]*=//p' \


### PR DESCRIPTION
- Linked Case: None

### Description

Every time an mmshare change causes the buildenv to be rebuilt, I have to do an `rm -rf $SCHRODINGER/sketcher` before I can build Sketcher again.  Otherwise, I get an error along the lines of
```
make: Entering directory '/f/build/Windows-x64/sketcher'
cmake -B "F:/build/Windows-x64/sketcher" \
      -S "F:/repos/src/sketcher" \
      -G Ninja \
      -DCMAKE_BUILD_TYPE="Release" \
      -DENFORCE_DEPENDENCY_VERSIONS=OFF \
      -DBUILD_SHARED_LIBS=ON \
      -DCMAKE_PREFIX_PATH="F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger;F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger/zlib-1.2.11;F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger/share/eigen3;F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger/coordgenlibs-3.0.2/lib/cmake;F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger/maeparser-1.3.2/lib/cmake;F:/build/Windows-x64/schrodinger_buildenv_packages/.pixi/envs/schrodinger/sqlite-3.42.0" \
      -DCMAKE_CXX_COMPILER=/F/build/Windows-x64/buildvenv/8ee1771/Scripts/cl.exe
CMake Error at CMakeLists.txt:6 (project):
  The CMAKE_CXX_COMPILER:

    F:/build/Windows-x64/buildvenv/cb6d33c/Scripts/cl.exe

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
make: *** [Makefile:4: all] Error 1
make: Leaving directory '/f/build/Windows-x64/sketcher'
WARNING: sketcher:all returned 2 in 0h0m1s
CRITICAL: Repo sketcher all build failed
```
Basically, CMake complains that it can't find the compiler because it's looking in the old buildenv location instead of the new one, even though the new location is passed on the command line.  Sometimes, running the build a second time will fix the issue, but not always.  Apparently, this is because the CMAKE_CXX_COMPILER setting is essentially considered immutable, and changing it without clearing the CMake cache and all CMake temp files from the build tree is unsupported.  Sometimes this results in an error, but it can theoretically lead to an infinite loop in the CMake internals according to Google.

This can be fixed this by passing `--fresh` to the CMake configure step since that wipes out the CMake cache and temp files, but it (not surprisingly) increases build time by a fair bit.  This PR tweaks the premake file so that it passes `--fresh` to CMake, but only when the CMAKE_CXX_COMPILER location has actually changed so that I don't get slow builds every time.  Since CMAKE_CXX_COMPILER only gets set on Windows, this change shouldn't affect building on other platforms.

### Testing Done

Confirmed that `--fresh` gets passed when the buildvenv directory changes, but doesn't get passed otherwise.
