### PR TITLE
SKETCH-2700: Tests now run with --platform offscreen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,11 @@ if(ENABLE_TESTING)
     target_include_directories(${TEST_TARGET}
                                PRIVATE ${PROJECT_SOURCE_DIR}/test)
     target_link_libraries(${TEST_TARGET} PRIVATE ${TEST_DEPENDENCIES})
+    if(NOT QT6_IS_SHARED_LIBS_BUILD)
+      # we use the offscreen platform to make sure that the tests don't pop up
+      # windows on the screen while they're running
+      qt_import_plugins(${TEST_TARGET} INCLUDE Qt6::QOffscreenIntegrationPlugin)
+    endif()
     if(MSVC)
       # ignore discarded [[nodiscard]] values for the tests
       target_compile_options(${TEST_TARGET} PRIVATE -wd4834)

--- a/src/schrodinger/sketcher/font_loader.h
+++ b/src/schrodinger/sketcher/font_loader.h
@@ -7,7 +7,7 @@ namespace schrodinger
 namespace sketcher
 {
 
-void load_font_resources();
+SKETCHER_API void load_font_resources();
 
 } // namespace sketcher
 } // namespace schrodinger

--- a/test/schrodinger/sketcher/qapplication_required_fixture.h
+++ b/test/schrodinger/sketcher/qapplication_required_fixture.h
@@ -3,11 +3,15 @@
 #pragma once
 
 #include <csignal>
+#include <vector>
 
 #include <QApplication>
+#include <QByteArray>
 #include <fmt/format.h>
 #include <boost/test/unit_test.hpp>
 #include <cstdlib>
+
+#include "schrodinger/sketcher/font_loader.h"
 
 /// @return true if there is a display
 static bool has_display()
@@ -50,17 +54,35 @@ class QApplicationRequiredFixture
         });
 
         // Qt requires argc and argv to stay valid for the entire lifetime of
-        // the QApplication object, so pass boost master test suite variables.
-        d_app.reset(new QApplication(
-            boost::unit_test::framework::master_test_suite().argc,
-            boost::unit_test::framework::master_test_suite().argv));
+        // the QApplication object.
+        const auto& test_suite =
+            boost::unit_test::framework::master_test_suite();
+        d_arguments.reserve(test_suite.argc + 2);
+        for (int i = 0; i < test_suite.argc; ++i) {
+            d_arguments.emplace_back(test_suite.argv[i]);
+        }
+        d_arguments.emplace_back("--platform");
+        d_arguments.emplace_back("offscreen");
+
+        d_argv.reserve(d_arguments.size());
+        for (auto& argument : d_arguments) {
+            d_argv.push_back(argument.data());
+        }
+        d_argc = static_cast<int>(d_argv.size());
+        d_app.reset(new QApplication(d_argc, d_argv.data()));
 
         // Initialize Qt resources (fonts, icons, etc.)
 #ifdef SKETCHER_STATIC_DEFINE
         Q_INIT_RESOURCE(sketcher);
 #endif
+        // load the Arimo font so that font width calculations result in
+        // expected values
+        schrodinger::sketcher::load_font_resources();
     }
 
   private:
+    int d_argc = 0;
+    std::vector<QByteArray> d_arguments;
+    std::vector<char*> d_argv;
     std::unique_ptr<QApplication> d_app;
 };


### PR DESCRIPTION
- Linked Case: SKETCH-2700

### Description

The unit tests now run with --platform offscreen, so they shouldn't cause windows to pop up on the screen while they're running.  There are two related changes here that were required to get this working:
- the tests load the Arimo font.  Apparently, the tests had been running with a fallback font.  Previously, this didn't matter too much, but the offscreen platform doesn't bother to read in fonts from the operating system.  (Presumably since there's no chance of anyone actually seeing the font.)  As a result, the tests were being run with a weird enough font that AtomItem's text eliding was returning unexpected results.
- In static builds (i.e. the OSS builds used by the GitHub runner, but not the $SCHRODINGER builds), the tests executables are now statically linked against Qt's offscreen platform.  Otherwise, all of the GitHub runners would crash when they tried to run the tests.

### Testing Done

The tests pass with a local $SCHRODINGER build, and all GitHub runners passed when I ran them on my fork.
