### PR TITLE
SKETCH-2752, SKETCH-2739: Fixing keyboard shortcuts

### DIFF
--- a/src/schrodinger/sketcher/model/sketcher_model.cpp
+++ b/src/schrodinger/sketcher/model/sketcher_model.cpp
@@ -476,6 +476,12 @@ bool SketcherModel::hasNAPhosphateSelection() const
     return contains_item<NucleicAcidPhosphateItem>(*this);
 }
 
+bool SketcherModel::hasNucleicAcidSelection() const
+{
+    return hasNABaseSelection() || hasNASugarSelection() ||
+           hasNAPhosphateSelection();
+}
+
 bool SketcherModel::hasMonomerSelection() const
 {
     return contains_item<AbstractMonomerItem>(*this);

--- a/src/schrodinger/sketcher/model/sketcher_model.h
+++ b/src/schrodinger/sketcher/model/sketcher_model.h
@@ -623,6 +623,7 @@ class SKETCHER_API SketcherModel : public QObject
     virtual bool hasNABaseSelection() const;
     virtual bool hasNASugarSelection() const;
     virtual bool hasNAPhosphateSelection() const;
+    virtual bool hasNucleicAcidSelection() const;
     virtual bool hasMonomerSelection() const;
 
     /**

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -1582,11 +1582,9 @@ void SketcherWidget::handleNucleicAcidKeyboardShortcuts(
          QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
     };
 
-    // if there's a selection (i.e. has_targets is true), then the keypress is
-    // going to mutate monomers so we don't care what current_tool is (since the
-    // real current tool is the selection tool, not a nucleic acid tool)
     if (!has_targets && (current_tool == NucleicAcidTool::RNA_NUCLEOTIDE ||
                          current_tool == NucleicAcidTool::DNA_NUCLEOTIDE)) {
+        // a full nucleotide tool is active
         if (BASE_KEYS.contains(key)) {
             // switch the base of the current full nucleotide tool
             auto base = std::get<StdNucleobase>(BASE_KEYS.at(key));
@@ -1602,6 +1600,7 @@ void SketcherWidget::handleNucleicAcidKeyboardShortcuts(
         // the P key has no effect in this scenario
     } else if (!has_targets &&
                current_tool == NucleicAcidTool::CUSTOM_NUCLEOTIDE) {
+        // the custom nucleotide tool is active
         auto nt = m_sketcher_model->getCustomNucleotide();
         bool handled = true;
         if (BASE_KEYS.contains(key)) {
@@ -1625,8 +1624,8 @@ void SketcherWidget::handleNucleicAcidKeyboardShortcuts(
     } else {
         // either a monomer tool is active, in which case we'll switch to the
         // requested monomer tool (i.e. not a full nucleotide tool), or there's
-        // a selection, in which case we'll mutate all of the
-        // bases or sugars or phosphates
+        // a selection, in which case we'll mutate all of the bases or sugars or
+        // phosphates
         NucleicAcidTool tool;
         bool handled = true;
         if (BASE_KEYS.contains(key)) {

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -1292,6 +1292,33 @@ void SketcherWidget::setToolbarsVisible(const bool visible)
     m_ui->line->setVisible(visible);
 }
 
+/**
+ * Determine whether we should interpret a keyboard shortcut as an amino acid or
+ * a nucleic acid. If there a selection of only amino acids or only nucleic
+ * acids (ignoring CHEM and BLOB monomers), then we follow the selection.
+ * Otherwise, we go with whatever the side bar is currently set to.
+ */
+static MonomerToolType
+determine_monomeric_keyboard_shortcut_type(const SketcherModel* const model,
+                                           const ModelObjsByType& targets)
+{
+    if (targets.atoms.empty()) {
+        // if there's no selection, base the keyboard shortcuts on the current
+        // side bar
+        return model->getMonomerToolType();
+    }
+    bool has_peptide_selection = model->hasPeptideSelection();
+    bool has_nucleic_acid_selection = model->hasNucleicAcidSelection();
+
+    if (has_peptide_selection && !has_nucleic_acid_selection) {
+        return MonomerToolType::AMINO_ACID;
+    } else if (has_nucleic_acid_selection && !has_peptide_selection) {
+        return MonomerToolType::NUCLEIC_ACID;
+    } else {
+        return model->getMonomerToolType();
+    }
+}
+
 void SketcherWidget::keyPressEvent(QKeyEvent* event)
 {
     QWidget::keyPressEvent(event);
@@ -1313,7 +1340,8 @@ void SketcherWidget::keyPressEvent(QKeyEvent* event)
     if (!handled) {
         if (m_sketcher_model->getToolSet() == ToolSet::ATOMISTIC) {
             handleAtomisticKeyboardShortcuts(event, cursor_pos, targets);
-        } else if (m_sketcher_model->getMonomerToolType() ==
+        } else if (determine_monomeric_keyboard_shortcut_type(m_sketcher_model,
+                                                              targets) ==
                    MonomerToolType::AMINO_ACID) {
             handleAminoAcidKeyboardShortcuts(event, cursor_pos, targets);
         } else {
@@ -1489,13 +1517,14 @@ void SketcherWidget::handleAminoAcidKeyboardShortcuts(
     if (KEY_TO_AMINO_ACID.contains(key)) {
         auto amino_acid_tool = KEY_TO_AMINO_ACID.at(key);
         bool has_targets = !targets.atoms.empty();
+        auto res_name = AMINO_ACID_TOOL_TO_RES_NAME.at(amino_acid_tool);
         std::pair<ModelKey, QVariant> kv_pair = {
-            ModelKey::AMINO_ACID_TOOL, QVariant::fromValue(amino_acid_tool)};
+            ModelKey::AMINO_ACID_SYMBOL, QString::fromStdString(res_name)};
         std::unordered_map<ModelKey, QVariant> kv_pairs = {
             {ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
             {ModelKey::MONOMER_TOOL_TYPE,
              QVariant::fromValue(MonomerToolType::AMINO_ACID)},
-        };
+            {ModelKey::AMINO_ACID_TOOL, QVariant::fromValue(amino_acid_tool)}};
         updateModelForKeyboardShortcut(has_targets, kv_pair, kv_pairs, targets);
     }
 }
@@ -1546,68 +1575,82 @@ void SketcherWidget::handleNucleicAcidKeyboardShortcuts(
     auto key = Qt::Key(event->key());
     std::optional<std::pair<ModelKey, QVariant>> kv_pair;
     auto current_tool = m_sketcher_model->getNucleicAcidTool();
-    switch (current_tool) {
-        case NucleicAcidTool::RNA_NUCLEOTIDE:
-        case NucleicAcidTool::DNA_NUCLEOTIDE:
-            if (BASE_KEYS.contains(key)) {
-                // switch the base of the current full nucleotide tool
-                auto base = std::get<StdNucleobase>(BASE_KEYS.at(key));
-                auto model_key = current_tool == NucleicAcidTool::RNA_NUCLEOTIDE
-                                     ? ModelKey::RNA_NUCLEOBASE
-                                     : ModelKey::DNA_NUCLEOBASE;
-                kv_pair = {model_key, QVariant::fromValue(base)};
-            } else if (SUGAR_KEYS.contains(key)) {
-                // switch the specified full nucleotide tool
-                auto tool = std::get<1>(SUGAR_KEYS.at(key));
-                kv_pair = {ModelKey::NUCLEIC_ACID_TOOL,
-                           QVariant::fromValue(tool)};
-            }
-            // the P key has no effect in this scenario
-            break;
-        case NucleicAcidTool::CUSTOM_NUCLEOTIDE: {
-            auto nt = m_sketcher_model->getCustomNucleotide();
-            if (BASE_KEYS.contains(key)) {
-                // switch the base of the current tool
-                auto base = std::get<QString>(BASE_KEYS.at(key));
-                std::get<1>(nt) = base;
-            } else if (SUGAR_KEYS.contains(key)) {
-                // switch the sugar of the current tool
-                auto sugar = std::get<QString>(SUGAR_KEYS.at(key));
-                std::get<0>(nt) = sugar;
-            } else if (key == Qt::Key_P) {
-                // remove any phosphate modifications from the current tool
-                auto phosphate = std::get<QString>(P_KEY);
-                std::get<2>(nt) = phosphate;
-            } else {
-                break;
-            }
-            kv_pair = {ModelKey::CUSTOM_NUCLEOTIDE, QVariant::fromValue(nt)};
-            break;
-        }
-        default: {
-            // a monomer tool is active, so switch to the requested monomer tool
-            // (i.e. not a full nucleotide tool)
-            NucleicAcidTool tool;
-            if (BASE_KEYS.contains(key)) {
-                tool = std::get<NucleicAcidTool>(BASE_KEYS.at(key));
-            } else if (SUGAR_KEYS.contains(key)) {
-                tool = std::get<2>(SUGAR_KEYS.at(key));
-            } else if (key == Qt::Key_P) {
-                tool = std::get<NucleicAcidTool>(P_KEY);
-            } else {
-                break;
-            }
+    bool has_targets = !targets.atoms.empty();
+    std::unordered_map<ModelKey, QVariant> kv_pairs = {
+        {ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
+        {ModelKey::MONOMER_TOOL_TYPE,
+         QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
+    };
+
+    // if there's a selection (i.e. has_targets is true), then the keypress is
+    // going to mutate monomers so we don't care what current_tool is (since the
+    // real current tool is the selection tool, not a nucleic acid tool)
+    if (!has_targets && (current_tool == NucleicAcidTool::RNA_NUCLEOTIDE ||
+                         current_tool == NucleicAcidTool::DNA_NUCLEOTIDE)) {
+        if (BASE_KEYS.contains(key)) {
+            // switch the base of the current full nucleotide tool
+            auto base = std::get<StdNucleobase>(BASE_KEYS.at(key));
+            auto model_key = current_tool == NucleicAcidTool::RNA_NUCLEOTIDE
+                                 ? ModelKey::RNA_NUCLEOBASE
+                                 : ModelKey::DNA_NUCLEOBASE;
+            kv_pair = {model_key, QVariant::fromValue(base)};
+        } else if (SUGAR_KEYS.contains(key)) {
+            // switch the specified full nucleotide tool
+            auto tool = std::get<1>(SUGAR_KEYS.at(key));
             kv_pair = {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)};
+        }
+        // the P key has no effect in this scenario
+    } else if (!has_targets &&
+               current_tool == NucleicAcidTool::CUSTOM_NUCLEOTIDE) {
+        auto nt = m_sketcher_model->getCustomNucleotide();
+        bool handled = true;
+        if (BASE_KEYS.contains(key)) {
+            // switch the base of the current tool
+            auto base = std::get<QString>(BASE_KEYS.at(key));
+            std::get<1>(nt) = base;
+        } else if (SUGAR_KEYS.contains(key)) {
+            // switch the sugar of the current tool
+            auto sugar = std::get<QString>(SUGAR_KEYS.at(key));
+            std::get<0>(nt) = sugar;
+        } else if (key == Qt::Key_P) {
+            // remove any phosphate modifications from the current tool
+            auto phosphate = std::get<QString>(P_KEY);
+            std::get<2>(nt) = phosphate;
+        } else {
+            handled = false;
+        }
+        if (handled) {
+            kv_pair = {ModelKey::CUSTOM_NUCLEOTIDE, QVariant::fromValue(nt)};
+        }
+    } else {
+        // either a monomer tool is active, in which case we'll switch to the
+        // requested monomer tool (i.e. not a full nucleotide tool), or there's
+        // a selection, in which case we'll mutate all of the
+        // bases or sugars or phosphates
+        NucleicAcidTool tool;
+        bool handled = true;
+        if (BASE_KEYS.contains(key)) {
+            tool = std::get<NucleicAcidTool>(BASE_KEYS.at(key));
+        } else if (SUGAR_KEYS.contains(key)) {
+            tool = std::get<2>(SUGAR_KEYS.at(key));
+        } else if (key == Qt::Key_P) {
+            tool = std::get<NucleicAcidTool>(P_KEY);
+        } else {
+            handled = false;
+        }
+        if (handled) {
+            // we need to set both NUCLEIC_ACID_TOOL and NUCLEIC_ACID_SYMBOL
+            kv_pairs.insert(
+                {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)});
+            auto symbol = NUCLEIC_ACID_TOOL_TO_RES_NAME.at(tool);
+            auto mutation =
+                NucleicAcidMutation(tool, QString::fromStdString(symbol));
+            kv_pair = {ModelKey::NUCLEIC_ACID_SYMBOL,
+                       QVariant::fromValue(mutation)};
         }
     }
 
     if (kv_pair.has_value()) {
-        std::unordered_map<ModelKey, QVariant> kv_pairs = {
-            {ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
-            {ModelKey::MONOMER_TOOL_TYPE,
-             QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
-        };
-        bool has_targets = !targets.atoms.empty();
         updateModelForKeyboardShortcut(has_targets, *kv_pair, kv_pairs,
                                        targets);
     }

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -1,8 +1,11 @@
 #define BOOST_TEST_MODULE sketcher_widget_test
 
 #include <string>
+#include <tuple>
 
 #include <QGraphicsSvgItem>
+#include <QKeyEvent>
+#include <QMouseEvent>
 #include <QString>
 
 #include <rdkit/GraphMol/ChemReactions/Reaction.h>
@@ -63,6 +66,43 @@ struct TestWidgetFixture {
 };
 
 BOOST_GLOBAL_FIXTURE(TestWidgetFixture);
+
+static void send_key_press(TestSketcherWidget& sk, Qt::Key key,
+                           const QString& text)
+{
+    QKeyEvent event(QEvent::KeyPress, key, Qt::NoModifier, text);
+    QCoreApplication::sendEvent(&sk, &event);
+    QCoreApplication::processEvents();
+}
+
+static void click_scene_center(TestSketcherWidget& sk)
+{
+    auto* viewport = sk.m_ui->view->viewport();
+    const auto click_pos = viewport->rect().center();
+    const auto global_click_pos = viewport->mapToGlobal(click_pos);
+    QMouseEvent mouse_press(QEvent::MouseButtonPress, click_pos,
+                            global_click_pos, Qt::LeftButton, Qt::LeftButton,
+                            Qt::NoModifier);
+    QCoreApplication::sendEvent(viewport, &mouse_press);
+    QMouseEvent mouse_release(QEvent::MouseButtonRelease, click_pos,
+                              global_click_pos, Qt::LeftButton, Qt::NoButton,
+                              Qt::NoModifier);
+    QCoreApplication::sendEvent(viewport, &mouse_release);
+    QCoreApplication::processEvents();
+}
+
+static void set_nucleic_acid_tool(TestSketcherWidget& sk, NucleicAcidTool tool)
+{
+    sk.m_sketcher_model->setValues(
+        {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
+         {ModelKey::TOOL_SET, QVariant::fromValue(ToolSet::MONOMERIC)},
+         {ModelKey::MONOMER_TOOL_TYPE,
+          QVariant::fromValue(MonomerToolType::NUCLEIC_ACID)},
+         {ModelKey::NUCLEIC_ACID_TOOL, QVariant::fromValue(tool)},
+         {ModelKey::NUCLEIC_ACID_SYMBOL,
+          QVariant::fromValue(NucleicAcidMutation{tool, ""})}});
+    QCoreApplication::processEvents();
+}
 
 BOOST_AUTO_TEST_CASE(test_addRDKitMolecule_getRDKitMolecule)
 {
@@ -605,6 +645,153 @@ BOOST_AUTO_TEST_CASE(test_toolAtomChainTool)
 }
 
 /**
+ * Verify that an amino acid keyboard shortcut rebuilds the scene tool with the
+ * newly selected amino acid.
+ */
+BOOST_AUTO_TEST_CASE(test_amino_acid_shortcut_updates_scene_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    sk.m_sketcher_model->setValues(
+        {{ModelKey::DRAW_TOOL, QVariant::fromValue(DrawTool::MONOMER)},
+         {ModelKey::TOOL_SET, QVariant::fromValue(ToolSet::MONOMERIC)},
+         {ModelKey::MONOMER_TOOL_TYPE,
+          QVariant::fromValue(MonomerToolType::AMINO_ACID)},
+         {ModelKey::AMINO_ACID_TOOL, QVariant::fromValue(AminoAcidTool::ALA)},
+         {ModelKey::AMINO_ACID_SYMBOL, QString("A")}});
+
+    sk.show();
+    QCoreApplication::processEvents();
+
+    send_key_press(sk, Qt::Key_C, "c");
+    click_scene_center(sk);
+
+    BOOST_TEST(sk.getString(Format::HELM) == "PEPTIDE1{C}$$$$V2.0");
+}
+
+/**
+ * Verify shortcuts update full nucleotide tools, including that P has no
+ * effect on an RNA or DNA nucleotide tool.
+ */
+BOOST_AUTO_TEST_CASE(test_full_nucleotide_shortcuts_update_scene_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    set_nucleic_acid_tool(sk, NucleicAcidTool::RNA_NUCLEOTIDE);
+    sk.show();
+    QCoreApplication::processEvents();
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_C, "c");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{R(C)P}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_D, "d");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{[dR](A)P}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_T, "t");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{[dR](T)P}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_P, "p");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{[dR](T)P}$$$$V2.0");
+}
+
+/**
+ * Verify base and sugar shortcuts update a custom nucleotide scene tool.
+ */
+BOOST_AUTO_TEST_CASE(test_custom_nucleotide_shortcuts_update_scene_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    set_nucleic_acid_tool(sk, NucleicAcidTool::CUSTOM_NUCLEOTIDE);
+    sk.m_sketcher_model->setValue(
+        ModelKey::CUSTOM_NUCLEOTIDE,
+        QVariant::fromValue(
+            std::tuple<QString, QString, QString>{"dR", "T", "P"}));
+    sk.show();
+    QCoreApplication::processEvents();
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_C, "c");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{[dR](C)P}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_R, "r");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{R(C)P}$$$$V2.0");
+}
+
+/**
+ * Verify shortcuts switch between individual nucleic acid monomer tools.
+ */
+BOOST_AUTO_TEST_CASE(test_nucleic_acid_monomer_shortcuts_update_scene_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    set_nucleic_acid_tool(sk, NucleicAcidTool::N);
+    sk.show();
+    QCoreApplication::processEvents();
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_A, "a");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{A}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_R, "r");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{R}$$$$V2.0");
+
+    sk.clear();
+    send_key_press(sk, Qt::Key_P, "p");
+    click_scene_center(sk);
+    BOOST_TEST(sk.getString(Format::HELM) == "RNA1{P}$$$$V2.0");
+}
+
+static void check_all_monomers_have_res_name(const RDKit::ROMol& mol,
+                                             std::string_view res_name)
+{
+    for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+        BOOST_TEST(get_monomer_res_name(mol.getAtomWithIdx(i)) == res_name);
+    }
+}
+
+static void check_nucleic_acid_base_mutation(const RDKit::ROMol& mol,
+                                             std::string_view base_res_name)
+{
+    int base_count = 0;
+    int sugar_count = 0;
+    int phosphate_count = 0;
+    for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+        auto* atom = mol.getAtomWithIdx(i);
+        auto type = get_monomer_type(atom);
+        if (type == MonomerType::NA_BASE) {
+            BOOST_TEST(get_monomer_res_name(atom) == base_res_name);
+            ++base_count;
+        } else if (type == MonomerType::NA_SUGAR) {
+            BOOST_TEST(get_monomer_res_name(atom) == "R");
+            ++sugar_count;
+        } else if (type == MonomerType::NA_PHOSPHATE) {
+            BOOST_TEST(get_monomer_res_name(atom) == "P");
+            ++phosphate_count;
+        } else {
+            BOOST_FAIL("Monomer had its type unexpectedly changed");
+        }
+    }
+    // R(X)P.R(X)P = 2 bases, 2 sugars, 2 phosphates
+    BOOST_TEST(base_count == 2);
+    BOOST_TEST(sugar_count == 2);
+    BOOST_TEST(phosphate_count == 2);
+}
+
+/**
  * Verify that pinging AMINO_ACID_SYMBOL with a selection mutates the selected
  * peptide monomers.
  */
@@ -625,10 +812,32 @@ BOOST_AUTO_TEST_CASE(test_pingMutateMonomersPeptide)
 
     // verify all monomers are now "C" (cysteine)
     const auto* mol = model->getMol();
-    for (unsigned int i = 0; i < mol->getNumAtoms(); ++i) {
-        auto* atom = mol->getAtomWithIdx(i);
-        BOOST_TEST(get_monomer_res_name(atom) == "C");
+    check_all_monomers_have_res_name(*mol, "C");
+}
+
+/**
+ * Verify that an amino acid keyboard shortcut with a selection mutates the
+ * selected peptide monomers. Tested with both the amino acid tools active on
+ * the side bar and the nucleic acid tools active, since the keyboard shortcuts
+ * should follow the selection.
+ */
+BOOST_DATA_TEST_CASE(test_shortcutMutateMonomersPeptide,
+                     boost::unit_test::data::make({false, true}), set_na_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    if (set_na_tool) {
+        set_nucleic_acid_tool(sk, NucleicAcidTool::N);
     }
+    sk.addFromString("PEPTIDE1{A.G.L}$$$$V2.0");
+    auto model = sk.m_mol_model;
+
+    model->selectAll();
+    BOOST_TEST(sk.m_sketcher_model->hasActiveSelection());
+
+    send_key_press(sk, Qt::Key_C, "c");
+
+    check_all_monomers_have_res_name(*model->getMol(), "C");
 }
 
 /**
@@ -651,30 +860,32 @@ BOOST_AUTO_TEST_CASE(test_pingMutateMonomersNucleicAcidBase)
         ModelKey::NUCLEIC_ACID_SYMBOL,
         NucleicAcidMutation{NucleicAcidTool::U, "U"});
 
-    const auto* mol = model->getMol();
-    int base_count = 0;
-    int sugar_count = 0;
-    int phosphate_count = 0;
-    for (unsigned int i = 0; i < mol->getNumAtoms(); ++i) {
-        auto* atom = mol->getAtomWithIdx(i);
-        auto type = get_monomer_type(atom);
-        if (type == MonomerType::NA_BASE) {
-            BOOST_TEST(get_monomer_res_name(atom) == "U");
-            ++base_count;
-        } else if (type == MonomerType::NA_SUGAR) {
-            BOOST_TEST(get_monomer_res_name(atom) == "R");
-            ++sugar_count;
-        } else if (type == MonomerType::NA_PHOSPHATE) {
-            BOOST_TEST(get_monomer_res_name(atom) == "P");
-            ++phosphate_count;
-        } else {
-            BOOST_FAIL("Monomer had its type unexpectedly changed");
-        }
+    check_nucleic_acid_base_mutation(*model->getMol(), "U");
+}
+
+/**
+ * Verify that a nucleic acid keyboard shortcut with a selection only mutates
+ * bases, leaving sugars and phosphates unchanged. Tested with both the nucleic
+ * acid tools active on the side bar and the amino acid tools active, since the
+ * keyboard shortcuts should follow the selection.
+ */
+BOOST_DATA_TEST_CASE(test_shortcutMutateMonomersNucleicAcidBase,
+                     boost::unit_test::data::make({true, false}), set_na_tool)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.setInterfaceType(InterfaceType::ATOMISTIC_OR_MONOMERIC);
+    if (set_na_tool) {
+        set_nucleic_acid_tool(sk, NucleicAcidTool::N);
     }
-    // R(A)P.R(G)P = 2 bases, 2 sugars, 2 phosphates
-    BOOST_TEST(base_count == 2);
-    BOOST_TEST(sugar_count == 2);
-    BOOST_TEST(phosphate_count == 2);
+    sk.addFromString("RNA1{R(A)P.R(G)P}$$$$V2.0");
+    auto model = sk.m_mol_model;
+
+    model->selectAll();
+    BOOST_TEST(sk.m_sketcher_model->hasActiveSelection());
+
+    send_key_press(sk, Qt::Key_U, "u");
+
+    check_nucleic_acid_base_mutation(*model->getMol(), "U");
 }
 
 /**


### PR DESCRIPTION
- Linked Case: SKETCH-2752, SKETCH-2739

### Description

Both of these cases had the same underlying issue: the SketcherWidget wasn't fully updated to handle the SketcherModel changes required for non-native monomers.  That change added two new model keys: `ModelKey::AMINO_ACID_SYMBOL` and `ModelKey::NUCLEIC_ACID_SYMBOL` (which are strings) to go along with the existing `ModelKey::AMINO_ACID_TOOL` and `ModelKey::NUCLEIC_ACID_TOOL`  keys (which are enums).  `SketcherWidget::keyPressEvent` only updated the `_TOOL` keys, though, not the `_SYMBOL` keys.

While I was fixing this, I also made one additional change to how monomeric keyboard shortcuts are handled: if there's a selection containing only amino acids or only nucleic acids, then we use the selection to determine whether the keyboard shortcut should be interpreted as an amino acid shortcut or a nucleic acid shortcut instead of using the current side bar contents.  That's almost certainly what the user intended, especially since the alternative is guaranteed to be a no-op.

### Testing Done

Tested on the Windows desktop app, and added a bunch of new unit tests
