### PR TITLE
SKETCH-2594: Changes to a ui file no longer require two incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,14 @@ function(build_schrodinger_library TARGET)
   set(SRC_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/${TARGET})
   # Collect all headers and source; note we collect public headers so that Qt
   # can build .moc files.
-  file(GLOB_RECURSE SOURCE_LIST CONFIGURE_DEPENDS ${INCLUDE_DIR}/*.h
-       ${SRC_DIR}/*.h ${SRC_DIR}/*.cpp)
+  file(
+    GLOB_RECURSE
+    SOURCE_LIST
+    CONFIGURE_DEPENDS
+    ${INCLUDE_DIR}/*.h
+    ${SRC_DIR}/*.h
+    ${SRC_DIR}/*.cpp
+    ${SRC_DIR}/*.ui)
   # Collect all resources
   file(GLOB_RECURSE SOURCE_LIST_QRC CONFIGURE_DEPENDS ${SRC_DIR}/*.qrc)
   list(APPEND SOURCE_LIST ${SOURCE_LIST_QRC})
@@ -189,9 +195,35 @@ function(build_schrodinger_library TARGET)
   target_compile_definitions(${TARGET} PRIVATE IN_${TARGET_UPPER}_DLL)
 endfunction()
 
+# Add direct dependencies from C++ sources to the .ui files whose generated
+# headers they include. Without these edges, Ninja may decide that a source is
+# up-to-date before AUTOUIC regenerates its header, requiring a second build
+# before a ui change is incorporated.
+function(add_ui_dependencies TARGET UI_DIR)
+  get_target_property(TARGET_SOURCES ${TARGET} SOURCES)
+  foreach(SOURCE_FILE ${TARGET_SOURCES})
+    if(SOURCE_FILE MATCHES "\\.(cc|cpp|cxx)$")
+      file(STRINGS ${SOURCE_FILE} UI_INCLUDES
+           REGEX "#[ \t]*include[ \t]*[<\"][^>\"]*ui_[A-Za-z0-9_]+\\.h[>\"]")
+      foreach(UI_INCLUDE ${UI_INCLUDES})
+        string(REGEX REPLACE ".*ui_([A-Za-z0-9_]+)\\.h.*" "\\1" UI_BASENAME
+                             ${UI_INCLUDE})
+        set(UI_FILE ${UI_DIR}/${UI_BASENAME}.ui)
+        if(EXISTS ${UI_FILE})
+          set_property(
+            SOURCE ${SOURCE_FILE}
+            APPEND
+            PROPERTY OBJECT_DEPENDS ${UI_FILE})
+        endif()
+      endforeach()
+    endif()
+  endforeach()
+endfunction()
+
 # Enable Qt's MOC and UIC features
 function(enable_qt_moc TARGET)
   set(UI_DIR ${PROJECT_SOURCE_DIR}/src/schrodinger/sketcher/ui)
+  add_ui_dependencies(${TARGET} ${UI_DIR})
   set_target_properties(
     ${TARGET}
     PROPERTIES AUTOMOC ON


### PR DESCRIPTION
- Linked Case: SKETCH-2594

### Description

Similar to https://github.com/schrodinger/sketcher/pull/389, CMake doesn't understand .ui files well enough to know that it needs to rebuild anything that includes `ui_whatever.h` when `whatever.ui` changes.  As a result, changes to a `*.ui` file require two incremental builds before they take effect: one build to compile `whatever.ui` into `ui_whatever.h`, and a second build to notice that  `ui_whatever.h` has changed and update anything that includes it.  This PR adds explicit dependencies between `*.cpp` files and any relevant `*.ui` files, meaning that the `*.ui` changes will correctly trigger a rebuild of the `*.cpp` files on the next CMake run..

### Testing Done

Tested ui changes with a local build
