### PR TITLE
CRDGEN-419: SEGV in RNA coordgen

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -1571,6 +1571,12 @@ find_hairpin_turn(const RDKit::ROMol& polymer)
         }
     }
 
+    if (turn_ends.first == -1) {
+        // A single intrapolymer pair forms an isolated ring, so there is no
+        // hairpin turn that needs to be laid out.
+        return {};
+    }
+
     // turn_ends are the indices, in turn_monomers, of the monomers at the top
     // and bottom end of the hairpin turn respectively - so they're either
     // adjacent or at the ends of the vector. We want to orient the vector so
@@ -1597,6 +1603,9 @@ layout_hairpin_polymer(RDKit::ROMol& polymer,
                        std::unordered_set<int>& placed_monomers_idcs)
 {
     auto hairpin_turn = find_hairpin_turn(polymer);
+    if (hairpin_turn.empty()) {
+        return;
+    }
     auto& conformer = polymer.getConformer();
 
     // layout the hairpin turn

--- a/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
+++ b/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
@@ -508,6 +508,14 @@ BOOST_DATA_TEST_CASE(
                                      << "\nComputed coords: " << actual_str);
 }
 
+BOOST_AUTO_TEST_CASE(TestSingleIntrapolymerPairDoesNotCrash)
+{
+    const auto mol = helm_to_rdkit(
+        "RNA1{R(A)P.R(C)P.R(G)P.R(A)P}$RNA1,RNA1,2:pair-8:pair$$$V2.0");
+
+    BOOST_CHECK_NO_THROW(compute_monomer_mol_coords(*mol));
+}
+
 BOOST_AUTO_TEST_SUITE(TestMonomerCoordgenCheckCoords)
 
 static RDKit::RWMol


### PR DESCRIPTION
### Description

When an RNA sequence has a single internal h-bond, the hairpin layout bit crashes because it assumes there will be at least 2 rings.

Reviewed in private repo.

### Testing Done

added a test, all existing coordinate generation tests pass
