### PR TITLE
Fixing CMake error for /f/build/Windows-x64 builds on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,9 @@ find_package(zstd ${ZSTD_VERSION} REQUIRED)
 
 # The EXPAT::EXPAT target used in RDKit doesn't actually exist... it's actually
 # lowercase expat::expat, so we create an alias to satisfy rdkit's dependencies
-add_library(EXPAT::EXPAT ALIAS expat::expat)
+if(NOT TARGET EXPAT::EXPAT)
+  add_library(EXPAT::EXPAT ALIAS expat::expat)
+endif()
 
 # Common library/executable configuration
 function(setup_target TARGET)


### PR DESCRIPTION
### Description

After pulling the latest version of `main`, I get the following error when running a $SCHRODINGER-based Sketcher build:
```
CMake Error at CMakeLists.txt:86 (add_library):
  add_library cannot create ALIAS target "EXPAT::EXPAT" because another
  target with the same name already exists.
```
I'm on Windows, so I initially assumed the issue related to case-sensitivity somehow, but according to Codex, the issue is that $SCHRODINGER builds don't set `CMAKE_FIND_PACKAGE_PREFER_CONFIG`.  As a result, the `find_package(EXPAT ${EXPAT_VERSION} REQUIRED)` call uses CMake's built-in `FindEXPAT.cmake`, which already creates an `EXPAT::EXPAT` target.  To avoid the build error, I've wrapped the EXPAT aliasing inside an `if(NOT TARGET EXPAT::EXPAT)` block so that we skip trying to create the alias unless it's needed.

### Testing Done

Ran a clean and an incremental $SCHRODINGER-based build successfully.
