### PR TITLE
SKETCH-2832: SMILES monomers now show atomistic image in tool tip

### DIFF
--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
@@ -2,13 +2,19 @@
 
 #include <cmath>
 
+#include <QBuffer>
+#include <QGraphicsScene>
 #include <QPainter>
+#include <QSvgGenerator>
 
 #include <rdkit/GraphMol/Atom.h>
 #include <rdkit/GraphMol/MonomerInfo.h>
 
 #include "schrodinger/sketcher/image_constants.h"
 #include "schrodinger/sketcher/molviewer/coord_utils.h"
+#include "schrodinger/sketcher/molviewer/scene_utils.h"
+#include "schrodinger/sketcher/rdkit/mol_update.h"
+#include "schrodinger/rdkit_extensions/convert.h"
 #include "schrodinger/rdkit_extensions/helm.h"
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
@@ -18,14 +24,106 @@ namespace schrodinger
 namespace sketcher
 {
 
-AbstractMonomerItem::AbstractMonomerItem(const RDKit::Atom* monomer,
-                                         const Fonts& fonts,
-                                         const bool is_dark_mode,
-                                         QGraphicsItem* parent) :
+AbstractMonomerItem::AbstractMonomerItem(
+    const RDKit::Atom* monomer, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, const bool is_dark_mode,
+    QGraphicsItem* parent) :
     AbstractAtomOrMonomerItem(monomer, parent),
     m_fonts(fonts),
+    m_atom_display_settings(&atom_display_settings),
+    m_bond_display_settings(&bond_display_settings),
     m_is_dark_mode(is_dark_mode)
 {
+}
+
+/**
+ * @return the tool tip for a SMILES monomer containing the given SMILES string.
+ * The tool tip will contain an image of the molecule as a base64-encoded SVG
+ * that can be rendered by QToolTip.
+ */
+static QString get_tool_tip_containing_smiles_image(
+    const std::string smiles, const Fonts& fonts,
+    const AtomDisplaySettings* const atom_display_settings,
+    const BondDisplaySettings* const bond_display_settings)
+{
+    // convert the SMILES string to an RDKit molecule
+    boost::shared_ptr<RDKit::RWMol> smiles_mol;
+    try {
+        smiles_mol = rdkit_extensions::to_rdkit(
+            smiles, rdkit_extensions::Format::EXTENDED_SMILES);
+        prepare_mol(*smiles_mol);
+    } catch (...) {
+        // if we can't parse the SMILES, then leave the tool tip empty
+        return QString();
+    }
+
+    // create graphics items for the molecule and load them into a scene
+    auto [all_items, atom_to_atom_item, bond_to_bond_item,
+          bond_to_secondary_connection_item, s_group_to_s_group_item] =
+        create_graphics_items_for_mol(smiles_mol.get(), fonts,
+                                      *atom_display_settings,
+                                      *bond_display_settings);
+    QGraphicsScene scene;
+    for (auto* item : all_items) {
+        // the scene takes ownership of the graphics items here, so we
+        // don't have to worry about destroying them manually
+        scene.addItem(item);
+    }
+
+    // the tool tip should be no larger than SMILES_MONOMER_TOOLTIP_SIZE by
+    // SMILES_MONOMER_TOOLTIP_SIZE pixels, and should be trimmed to the shape of
+    // the scene
+    auto scene_rect = scene.sceneRect();
+    if (scene_rect.isEmpty()) {
+        // the scene is empty, so give up
+        return QString();
+    }
+    qreal svg_width, svg_height;
+    svg_width = svg_height = SMILES_MONOMER_TOOLTIP_SIZE;
+    auto scene_width = scene_rect.width();
+    auto scene_height = scene_rect.height();
+    if (scene_width > scene_height) {
+        svg_height *= (scene_height / scene_width);
+    } else {
+        svg_width *= (scene_width / scene_height);
+    }
+    auto size = QSizeF(svg_width, svg_height).toSize();
+
+    // render the scene to an SVG
+    auto buffer = QBuffer();
+    buffer.open(QIODevice::WriteOnly);
+    auto svg_gen = QSvgGenerator();
+    svg_gen.setOutputDevice(&buffer);
+    svg_gen.setSize(size);
+    svg_gen.setViewBox(QRect(QPoint(0, 0), size));
+    {
+        QPainter painter(&svg_gen);
+        scene.render(&painter);
+    }
+    buffer.close();
+
+    // create the tool tip string containing the base64-encoded SVG
+    auto image_bytes = buffer.data();
+    return QString("<img src='data:image/svg+xml;base64,%1'>")
+        .arg(image_bytes.toBase64());
+}
+
+void AbstractMonomerItem::updateCachedData()
+{
+    prepareGeometryChange();
+    bool is_smiles_monomer = false;
+    m_atom->getPropIfPresent(SMILES_MONOMER, is_smiles_monomer);
+    QString tool_tip;
+    if (is_smiles_monomer) {
+        auto smiles = m_atom->getMonomerInfo()->getResidueName();
+        if (!smiles.empty()) {
+            tool_tip = get_tool_tip_containing_smiles_image(
+                smiles, m_fonts, m_atom_display_settings,
+                m_bond_display_settings);
+        }
+    }
+    setToolTip(tool_tip);
 }
 
 void AbstractMonomerItem::paint(QPainter* painter,

--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
@@ -29,7 +29,7 @@ namespace
  * displaying it.) This constant controls the ratio of SVG "pixels" to tool tip
  * pixels.
  */
-const int TOOL_TIP_OVERSAMPLING_RATIO = 1;
+const int TOOL_TIP_OVERSAMPLING_RATIO = 2;
 } // namespace
 
 namespace schrodinger
@@ -56,7 +56,7 @@ AbstractMonomerItem::AbstractMonomerItem(
  * that can be rendered by QToolTip.
  */
 static QString get_tool_tip_containing_smiles_image(
-    const std::string smiles, const Fonts& fonts,
+    const std::string& smiles, const Fonts& fonts,
     const AtomDisplaySettings* const atom_display_settings,
     const BondDisplaySettings* const bond_display_settings,
     const bool is_dark_mode)

--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.cpp
@@ -19,6 +19,19 @@
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
 
+namespace
+{
+/**
+ * For SMILES monomers, we generate tool tips containing atomistic images. Even
+ * though these images are vector-based SVGs, they are become aliased when
+ * rendered unless we increase the "resolution" of the image. (Presumably, the
+ * Qt internals use the SVG's resolution to rasterize the image before
+ * displaying it.) This constant controls the ratio of SVG "pixels" to tool tip
+ * pixels.
+ */
+const int TOOL_TIP_OVERSAMPLING_RATIO = 1;
+} // namespace
+
 namespace schrodinger
 {
 namespace sketcher
@@ -45,7 +58,8 @@ AbstractMonomerItem::AbstractMonomerItem(
 static QString get_tool_tip_containing_smiles_image(
     const std::string smiles, const Fonts& fonts,
     const AtomDisplaySettings* const atom_display_settings,
-    const BondDisplaySettings* const bond_display_settings)
+    const BondDisplaySettings* const bond_display_settings,
+    const bool is_dark_mode)
 {
     // convert the SMILES string to an RDKit molecule
     boost::shared_ptr<RDKit::RWMol> smiles_mol;
@@ -65,6 +79,9 @@ static QString get_tool_tip_containing_smiles_image(
                                       *atom_display_settings,
                                       *bond_display_settings);
     QGraphicsScene scene;
+    auto bg_color =
+        is_dark_mode ? DARK_BACKGROUND_COLOR : LIGHT_BACKGROUND_COLOR;
+    scene.setBackgroundBrush(bg_color);
     for (auto* item : all_items) {
         // the scene takes ownership of the graphics items here, so we
         // don't have to worry about destroying them manually
@@ -95,18 +112,22 @@ static QString get_tool_tip_containing_smiles_image(
     buffer.open(QIODevice::WriteOnly);
     auto svg_gen = QSvgGenerator();
     svg_gen.setOutputDevice(&buffer);
-    svg_gen.setSize(size);
-    svg_gen.setViewBox(QRect(QPoint(0, 0), size));
+    svg_gen.setSize(TOOL_TIP_OVERSAMPLING_RATIO * size);
+    svg_gen.setViewBox(QRect(QPoint(0, 0), TOOL_TIP_OVERSAMPLING_RATIO * size));
     {
         QPainter painter(&svg_gen);
         scene.render(&painter);
     }
     buffer.close();
 
-    // create the tool tip string containing the base64-encoded SVG
+    // create the tool tip string containing the base64-encoded SVG. We
+    // explicitly specify the size of the image to force oversampling when
+    // rasterizing the SVG, which prevents aliasing.
     auto image_bytes = buffer.data();
-    return QString("<img src='data:image/svg+xml;base64,%1'>")
-        .arg(image_bytes.toBase64());
+    return QString("<img width='%1' height='%2' "
+                   "src='data:image/svg+xml;base64,%3'>")
+        .arg(QString::number(size.width()), QString::number(size.height()),
+             image_bytes.toBase64());
 }
 
 void AbstractMonomerItem::updateCachedData()
@@ -120,7 +141,7 @@ void AbstractMonomerItem::updateCachedData()
         if (!smiles.empty()) {
             tool_tip = get_tool_tip_containing_smiles_image(
                 smiles, m_fonts, m_atom_display_settings,
-                m_bond_display_settings);
+                m_bond_display_settings, m_is_dark_mode);
         }
     }
     setToolTip(tool_tip);

--- a/src/schrodinger/sketcher/molviewer/abstract_monomer_item.h
+++ b/src/schrodinger/sketcher/molviewer/abstract_monomer_item.h
@@ -30,6 +30,9 @@ enum class ChainType;
 namespace sketcher
 {
 
+class AtomDisplaySettings;
+class BondDisplaySettings;
+
 /**
  * An abstract parent class for graphics items that represent monomers.
  */
@@ -37,8 +40,12 @@ class SKETCHER_API AbstractMonomerItem : public AbstractAtomOrMonomerItem
 {
   public:
     AbstractMonomerItem(const RDKit::Atom* monomer, const Fonts& fonts,
+                        const AtomDisplaySettings& atom_display_settings,
+                        const BondDisplaySettings& bond_display_settings,
                         const bool is_dark_mode = false,
                         QGraphicsItem* parent = nullptr);
+
+    void updateCachedData() override;
 
     /**
      * Replace the monomer-specific colors with the given colors.
@@ -69,6 +76,8 @@ class SKETCHER_API AbstractMonomerItem : public AbstractAtomOrMonomerItem
 
   protected:
     const Fonts& m_fonts;
+    const AtomDisplaySettings* m_atom_display_settings;
+    const BondDisplaySettings* m_bond_display_settings;
     QPen m_border_pen;
     QBrush m_border_brush = QBrush(Qt::BrushStyle::SolidPattern);
     QString m_main_label_text;

--- a/src/schrodinger/sketcher/molviewer/amino_acid_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/amino_acid_item.cpp
@@ -20,8 +20,11 @@ namespace sketcher
 enum class AminoAcidType { STANDARD, D, OTHER };
 
 AminoAcidItem::AminoAcidItem(const RDKit::Atom* monomer, const Fonts& fonts,
+                             const AtomDisplaySettings& atom_display_settings,
+                             const BondDisplaySettings& bond_display_settings,
                              const bool is_dark_mode, QGraphicsItem* parent) :
-    AbstractMonomerItem(monomer, fonts, is_dark_mode, parent)
+    AbstractMonomerItem(monomer, fonts, atom_display_settings,
+                        bond_display_settings, is_dark_mode, parent)
 {
     setZValue(static_cast<qreal>(ZOrder::MONOMER));
     updateCachedData();
@@ -68,7 +71,7 @@ static void set_path_to_rounded_rect(QPainterPath& highlighting_path,
 
 void AminoAcidItem::updateCachedData()
 {
-    prepareGeometryChange();
+    AbstractMonomerItem::updateCachedData();
 
     auto res_name = get_monomer_res_name(m_atom);
     m_main_label_text = elide_text(res_name);

--- a/src/schrodinger/sketcher/molviewer/amino_acid_item.h
+++ b/src/schrodinger/sketcher/molviewer/amino_acid_item.h
@@ -19,6 +19,8 @@ class SKETCHER_API AminoAcidItem : public AbstractMonomerItem
 {
   public:
     AminoAcidItem(const RDKit::Atom* atom, const Fonts& fonts,
+                  const AtomDisplaySettings& atom_display_settings,
+                  const BondDisplaySettings& bond_display_settings,
                   const bool is_dark_mode = false,
                   QGraphicsItem* parent = nullptr);
 

--- a/src/schrodinger/sketcher/molviewer/chem_monomer_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/chem_monomer_item.cpp
@@ -7,10 +7,13 @@ namespace schrodinger
 namespace sketcher
 {
 
-ChemMonomerItem::ChemMonomerItem(const RDKit::Atom* monomer, const Fonts& fonts,
-                                 const bool is_dark_mode,
-                                 QGraphicsItem* parent) :
-    AbstractMonomerItem(monomer, fonts, is_dark_mode, parent)
+ChemMonomerItem::ChemMonomerItem(
+    const RDKit::Atom* monomer, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, const bool is_dark_mode,
+    QGraphicsItem* parent) :
+    AbstractMonomerItem(monomer, fonts, atom_display_settings,
+                        bond_display_settings, is_dark_mode, parent)
 {
     setZValue(static_cast<qreal>(ZOrder::MONOMER));
     m_border_brush.setColor(CHEM_MONOMER_RECT_COLOR);
@@ -29,7 +32,7 @@ int ChemMonomerItem::type() const
 
 void ChemMonomerItem::updateCachedData()
 {
-    prepareGeometryChange();
+    AbstractMonomerItem::updateCachedData();
     auto res_name = get_monomer_res_name(m_atom);
     m_main_label_text = elide_text(res_name);
     auto [border_width, border_height] = get_rect_size_to_fit_label(

--- a/src/schrodinger/sketcher/molviewer/chem_monomer_item.h
+++ b/src/schrodinger/sketcher/molviewer/chem_monomer_item.h
@@ -21,6 +21,8 @@ class SKETCHER_API ChemMonomerItem : public AbstractMonomerItem
 {
   public:
     ChemMonomerItem(const RDKit::Atom* monomer, const Fonts& fonts,
+                    const AtomDisplaySettings& atom_display_settings,
+                    const BondDisplaySettings& bond_display_settings,
                     const bool is_dark_mode = false,
                     QGraphicsItem* parent = nullptr);
 

--- a/src/schrodinger/sketcher/molviewer/monomer_constants.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_constants.h
@@ -296,5 +296,11 @@ const QColor CONNECTION_TOOL_AP_LABEL_HOVER_COLOR_DARK_BG = QColor("#EEEEEE");
  */
 const qreal MONOMER_CURSOR_HINT_MIN_SCENE_SIZE_SCALE = 1.4;
 
+/**
+ * The maximum width and height of the tooltip for SMILES monomers, which
+ * contain an atomistic image of the monomer.
+ */
+const int SMILES_MONOMER_TOOLTIP_SIZE = 250;
+
 } // namespace sketcher
 } // namespace schrodinger

--- a/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.cpp
@@ -15,12 +15,16 @@ namespace schrodinger::sketcher
 
 MonomerHintFragmentItem::MonomerHintFragmentItem(
     std::shared_ptr<RDKit::RWMol> fragment, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings,
     const std::vector<size_t>& atom_indices_to_hide,
     const int bond_index_to_label, const QColor monomer_background_color,
     QGraphicsItem* parent) :
     QGraphicsItemGroup(parent),
     m_frag(fragment),
     m_fonts(&fonts),
+    m_atom_display_settings(&atom_display_settings),
+    m_bond_display_settings(&bond_display_settings),
     m_atom_indices_to_hide(atom_indices_to_hide),
     m_bond_index_to_label(bond_index_to_label),
     m_monomer_background_color(monomer_background_color),
@@ -34,7 +38,9 @@ void MonomerHintFragmentItem::createGraphicsItems()
 {
     auto [all_items, atom_to_atom_item, bond_to_bond_item,
           bond_to_secondary_connection_item, s_group_to_s_group_item] =
-        create_graphics_items_for_mol(m_frag.get(), *m_fonts);
+        create_graphics_items_for_mol(m_frag.get(), *m_fonts,
+                                      *m_atom_display_settings,
+                                      *m_bond_display_settings);
     for (auto* item : all_items) {
         addToGroup(item);
     }

--- a/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h
+++ b/src/schrodinger/sketcher/molviewer/monomer_hint_fragment_item.h
@@ -21,6 +21,8 @@ namespace schrodinger::sketcher
 
 class Fonts;
 class Scene;
+class AtomDisplaySettings;
+class BondDisplaySettings;
 
 /**
  * A graphics item showing a blue hint structure for monomeric models.
@@ -33,6 +35,10 @@ class MonomerHintFragmentItem : public QGraphicsItemGroup
      * molecule may be modified.
      * @param fonts The fonts to use for displaying the fragment. This object
      * must not be destroyed while this graphics item is in use.
+     * @param atom_display_settings The atom display settings to use. This
+     * object must not be destroyed while this graphics item is in use.
+     * @param bond_display_settings The bond display settings to use. This
+     * object must not be destroyed while this graphics item is in use.
      * @param atom_indices_to_hide The graphics item for these atom will be
      * hidden. Normally used to hide atoms that overlap the existing Sketcher
      * structure.
@@ -46,6 +52,8 @@ class MonomerHintFragmentItem : public QGraphicsItemGroup
      */
     MonomerHintFragmentItem(std::shared_ptr<RDKit::RWMol> fragment,
                             const Fonts& fonts,
+                            const AtomDisplaySettings& atom_display_settings,
+                            const BondDisplaySettings& bond_display_settings,
                             const std::vector<size_t>& atom_indices_to_hide,
                             const int bond_index_to_label,
                             const QColor monomer_background_color,
@@ -65,6 +73,8 @@ class MonomerHintFragmentItem : public QGraphicsItemGroup
   protected:
     std::shared_ptr<RDKit::RWMol> m_frag;
     const Fonts* m_fonts = nullptr;
+    const AtomDisplaySettings* m_atom_display_settings = nullptr;
+    const BondDisplaySettings* m_bond_display_settings = nullptr;
     std::vector<size_t> m_atom_indices_to_hide;
     int m_bond_index_to_label = -1;
     QColor m_monomer_background_color;

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.cpp
@@ -19,11 +19,13 @@ namespace schrodinger
 namespace sketcher
 {
 
-NucleicAcidBaseItem::NucleicAcidBaseItem(const RDKit::Atom* monomer,
-                                         const Fonts& fonts,
-                                         const bool is_dark_mode,
-                                         QGraphicsItem* parent) :
-    AbstractMonomerItem(monomer, fonts, is_dark_mode, parent)
+NucleicAcidBaseItem::NucleicAcidBaseItem(
+    const RDKit::Atom* monomer, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, const bool is_dark_mode,
+    QGraphicsItem* parent) :
+    AbstractMonomerItem(monomer, fonts, atom_display_settings,
+                        bond_display_settings, is_dark_mode, parent)
 {
     setZValue(static_cast<qreal>(ZOrder::MONOMER));
 
@@ -70,7 +72,7 @@ static void set_path_to_diamond(QPainterPath& path, const qreal width,
 
 void NucleicAcidBaseItem::updateCachedData()
 {
-    prepareGeometryChange();
+    AbstractMonomerItem::updateCachedData();
 
     auto res_name = get_monomer_res_name(m_atom);
     m_main_label_text = elide_text(res_name);

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.h
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_base_item.h
@@ -20,6 +20,8 @@ class SKETCHER_API NucleicAcidBaseItem : public AbstractMonomerItem
 {
   public:
     NucleicAcidBaseItem(const RDKit::Atom* atom, const Fonts& fonts,
+                        const AtomDisplaySettings& atom_display_settings,
+                        const BondDisplaySettings& bond_display_settings,
                         const bool is_dark_mode = false,
                         QGraphicsItem* parent = nullptr);
 

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.cpp
@@ -12,11 +12,13 @@ namespace schrodinger
 namespace sketcher
 {
 
-NucleicAcidPhosphateItem::NucleicAcidPhosphateItem(const RDKit::Atom* monomer,
-                                                   const Fonts& fonts,
-                                                   const bool is_dark_mode,
-                                                   QGraphicsItem* parent) :
-    AbstractMonomerItem(monomer, fonts, is_dark_mode, parent)
+NucleicAcidPhosphateItem::NucleicAcidPhosphateItem(
+    const RDKit::Atom* monomer, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, const bool is_dark_mode,
+    QGraphicsItem* parent) :
+    AbstractMonomerItem(monomer, fonts, atom_display_settings,
+                        bond_display_settings, is_dark_mode, parent)
 {
     setZValue(static_cast<qreal>(ZOrder::MONOMER));
     m_border_brush.setColor(NA_BACKBONE_COLOR);
@@ -48,7 +50,7 @@ static void set_path_to_ellipse(QPainterPath& path, const QRectF& rect,
 
 void NucleicAcidPhosphateItem::updateCachedData()
 {
-    prepareGeometryChange();
+    AbstractMonomerItem::updateCachedData();
 
     auto res_name = get_monomer_res_name(m_atom);
     m_main_label_text = elide_text(res_name);

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.h
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_phosphate_item.h
@@ -17,6 +17,8 @@ class SKETCHER_API NucleicAcidPhosphateItem : public AbstractMonomerItem
 {
   public:
     NucleicAcidPhosphateItem(const RDKit::Atom* atom, const Fonts& fonts,
+                             const AtomDisplaySettings& atom_display_settings,
+                             const BondDisplaySettings& bond_display_settings,
                              const bool is_dark_mode = false,
                              QGraphicsItem* parent = nullptr);
 

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_sugar_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_sugar_item.cpp
@@ -7,11 +7,13 @@ namespace schrodinger
 namespace sketcher
 {
 
-NucleicAcidSugarItem::NucleicAcidSugarItem(const RDKit::Atom* monomer,
-                                           const Fonts& fonts,
-                                           const bool is_dark_mode,
-                                           QGraphicsItem* parent) :
-    AbstractMonomerItem(monomer, fonts, is_dark_mode, parent)
+NucleicAcidSugarItem::NucleicAcidSugarItem(
+    const RDKit::Atom* monomer, const Fonts& fonts,
+    const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, const bool is_dark_mode,
+    QGraphicsItem* parent) :
+    AbstractMonomerItem(monomer, fonts, atom_display_settings,
+                        bond_display_settings, is_dark_mode, parent)
 {
     setZValue(static_cast<qreal>(ZOrder::MONOMER));
     m_border_brush.setColor(NA_BACKBONE_COLOR);
@@ -25,7 +27,7 @@ int NucleicAcidSugarItem::type() const
 
 void NucleicAcidSugarItem::updateCachedData()
 {
-    prepareGeometryChange();
+    AbstractMonomerItem::updateCachedData();
 
     auto res_name = get_monomer_res_name(m_atom);
     m_main_label_text = elide_text(res_name);

--- a/src/schrodinger/sketcher/molviewer/nucleic_acid_sugar_item.h
+++ b/src/schrodinger/sketcher/molviewer/nucleic_acid_sugar_item.h
@@ -21,6 +21,8 @@ class SKETCHER_API NucleicAcidSugarItem : public AbstractMonomerItem
 {
   public:
     NucleicAcidSugarItem(const RDKit::Atom* atom, const Fonts& fonts,
+                         const AtomDisplaySettings& atom_display_settings,
+                         const BondDisplaySettings& bond_display_settings,
                          const bool is_dark_mode = false,
                          QGraphicsItem* parent = nullptr);
 

--- a/src/schrodinger/sketcher/molviewer/scene.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene.cpp
@@ -751,7 +751,9 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
                 res_name = AMINO_ACID_TOOL_TO_RES_NAME.at(tool);
             }
             return std::make_shared<DrawMonomerSceneTool>(
-                res_name, rdkit_extensions::ChainType::PEPTIDE, m_fonts, this,
+                res_name, rdkit_extensions::ChainType::PEPTIDE, m_fonts,
+                *m_sketcher_model->getAtomDisplaySettingsPtr(),
+                *m_sketcher_model->getBondDisplaySettingsPtr(), this,
                 m_mol_model);
         } else {
             auto tool = m_sketcher_model->getNucleicAcidTool();
@@ -766,24 +768,32 @@ std::shared_ptr<AbstractSceneTool> Scene::getNewSceneTool()
                 // HELM considers DNA to be a type of RNA, so we want an RNA
                 // chain type regardless of which nucleic acid we're drawing
                 return std::make_shared<DrawMonomerSceneTool>(
-                    res_name, rdkit_extensions::ChainType::RNA, m_fonts, this,
+                    res_name, rdkit_extensions::ChainType::RNA, m_fonts,
+                    *m_sketcher_model->getAtomDisplaySettingsPtr(),
+                    *m_sketcher_model->getBondDisplaySettingsPtr(), this,
                     m_mol_model);
             } else {
                 // the tool is for a full nucleotide
                 auto [sugar, base, phos] = *m_sketcher_model->getNucleotide();
                 return get_nucleotide_fragment_scene_tool(
                     sugar.toStdString(), base.toStdString(), phos.toStdString(),
-                    m_fonts, this, m_mol_model);
+                    m_fonts, *m_sketcher_model->getAtomDisplaySettingsPtr(),
+                    *m_sketcher_model->getBondDisplaySettingsPtr(), this,
+                    m_mol_model);
             }
         }
     } else if (draw_tool == DrawTool::MONOMERIC_CONNECTION) {
         auto connection_tool = m_sketcher_model->getMonomericConnectionTool();
         if (connection_tool == MonomericConnectionTool::COVALENT_OR_DISULFIDE) {
             return std::make_shared<DrawMonomericConnectionSceneTool>(
-                m_fonts, this, m_mol_model);
+                m_fonts, *m_sketcher_model->getAtomDisplaySettingsPtr(),
+                *m_sketcher_model->getBondDisplaySettingsPtr(), this,
+                m_mol_model);
         } else {
-            return std::make_shared<DrawMonomericHBondSceneTool>(m_fonts, this,
-                                                                 m_mol_model);
+            return std::make_shared<DrawMonomericHBondSceneTool>(
+                m_fonts, *m_sketcher_model->getAtomDisplaySettingsPtr(),
+                *m_sketcher_model->getBondDisplaySettingsPtr(), this,
+                m_mol_model);
         }
     }
     // tool not yet implemented
@@ -919,7 +929,9 @@ void Scene::updateMonomerLabelSizeOnModel()
             continue;
         }
         // create a temporary graphics item to figure out the label size
-        auto* item = get_monomer_graphics_item(atom, m_fonts);
+        auto* item = get_monomer_graphics_item(
+            atom, m_fonts, *m_sketcher_model->getAtomDisplaySettingsPtr(),
+            *m_sketcher_model->getBondDisplaySettingsPtr());
         const auto bounding_rect = item->boundingRect();
         RDGeom::Point3D size(bounding_rect.width() / VIEW_SCALE,
                              bounding_rect.height() / VIEW_SCALE, 0);

--- a/src/schrodinger/sketcher/molviewer/scene_utils.cpp
+++ b/src/schrodinger/sketcher/molviewer/scene_utils.cpp
@@ -56,21 +56,30 @@ get_predictive_highlighting_path_for_bond(const RDKit::Bond* bond,
 /**
  * Construct and return a monomer graphics item for representing the given atom.
  */
-AbstractMonomerItem* get_monomer_graphics_item(const RDKit::Atom* atom,
-                                               const Fonts& fonts,
-                                               const bool is_dark_mode)
+AbstractMonomerItem*
+get_monomer_graphics_item(const RDKit::Atom* atom, const Fonts& fonts,
+                          const AtomDisplaySettings& atom_display_settings,
+                          const BondDisplaySettings& bond_display_settings,
+                          const bool is_dark_mode)
 {
     switch (get_monomer_type(atom)) {
         case MonomerType::PEPTIDE:
-            return new AminoAcidItem(atom, fonts, is_dark_mode);
+            return new AminoAcidItem(atom, fonts, atom_display_settings,
+                                     bond_display_settings, is_dark_mode);
         case MonomerType::CHEM:
-            return new ChemMonomerItem(atom, fonts, is_dark_mode);
+            return new ChemMonomerItem(atom, fonts, atom_display_settings,
+                                       bond_display_settings, is_dark_mode);
         case MonomerType::NA_BASE:
-            return new NucleicAcidBaseItem(atom, fonts, is_dark_mode);
+            return new NucleicAcidBaseItem(atom, fonts, atom_display_settings,
+                                           bond_display_settings, is_dark_mode);
         case MonomerType::NA_PHOSPHATE:
-            return new NucleicAcidPhosphateItem(atom, fonts, is_dark_mode);
+            return new NucleicAcidPhosphateItem(
+                atom, fonts, atom_display_settings, bond_display_settings,
+                is_dark_mode);
         case MonomerType::NA_SUGAR:
-            return new NucleicAcidSugarItem(atom, fonts, is_dark_mode);
+            return new NucleicAcidSugarItem(atom, fonts, atom_display_settings,
+                                            bond_display_settings,
+                                            is_dark_mode);
         default:
             throw std::runtime_error("Unrecognized monomer type");
     }
@@ -113,8 +122,9 @@ create_graphics_items_for_mol(const RDKit::ROMol* mol, const Fonts& fonts,
         const auto pos = conformer.getAtomPos(i);
         QGraphicsItem* atom_item =
             is_atom_monomeric(atom)
-                ? static_cast<QGraphicsItem*>(
-                      get_monomer_graphics_item(atom, fonts, is_dark_mode))
+                ? static_cast<QGraphicsItem*>(get_monomer_graphics_item(
+                      atom, fonts, atom_display_settings, bond_display_settings,
+                      is_dark_mode))
                 : new AtomItem(atom, fonts, atom_display_settings);
         atom_item->setPos(to_scene_xy(pos));
         atom_to_atom_item[atom] = atom_item;

--- a/src/schrodinger/sketcher/molviewer/scene_utils.h
+++ b/src/schrodinger/sketcher/molviewer/scene_utils.h
@@ -48,11 +48,17 @@ class NonMolecularObject;
  * Create and return a graphics item for the given monomer
  * @param atom An atom that represents a monomer
  * @param fonts The fonts for the graphics item to use
+ * @param atom_display_settings The settings for displaying atoms (only used for
+ * SMILES monomers)
+ * @param bond_display_settings The settings for displaying bonds (only used for
+ * SMILES monomers)
  * @return The newly created graphics item. Destruction of this graphics item is
  * the responsibility of the calling scope.
  */
 SKETCHER_API AbstractMonomerItem*
 get_monomer_graphics_item(const RDKit::Atom* atom, const Fonts& fonts,
+                          const AtomDisplaySettings& atom_display_settings,
+                          const BondDisplaySettings& bond_display_settings,
                           const bool is_dark_mode = false);
 
 /**
@@ -78,11 +84,11 @@ std::tuple<std::vector<QGraphicsItem*>,
            std::unordered_map<const RDKit::Bond*, QGraphicsItem*>,
            std::unordered_map<const RDKit::Bond*, QGraphicsItem*>,
            std::unordered_map<const RDKit::SubstanceGroup*, SGroupItem*>>
-create_graphics_items_for_mol(
-    const RDKit::ROMol* mol, const Fonts& fonts,
-    const AtomDisplaySettings& atom_display_settings = AtomDisplaySettings(),
-    const BondDisplaySettings& bond_display_settings = BondDisplaySettings(),
-    const bool is_dark_mode = false, const bool draw_attachment_points = true);
+create_graphics_items_for_mol(const RDKit::ROMol* mol, const Fonts& fonts,
+                              const AtomDisplaySettings& atom_display_settings,
+                              const BondDisplaySettings& bond_display_settings,
+                              const bool is_dark_mode = false,
+                              const bool draw_attachment_points = true);
 
 /**
  * Update all graphics items to represent an updated conformer

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -42,11 +42,15 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::
     AbstractDrawMonomerOrMonomericConnectionSceneTool(
         const std::string& res_name,
         const rdkit_extensions::ChainType chain_type, const Fonts& fonts,
-        Scene* scene, MolModel* mol_model) :
+        const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model) :
     AbstractMonomerSceneTool(fonts, scene, mol_model),
     m_res_name(res_name),
     m_chain_type(chain_type),
-    m_bolded_fonts(fonts)
+    m_bolded_fonts(fonts),
+    m_atom_display_settings(&atom_display_settings),
+    m_bond_display_settings(&bond_display_settings)
 {
     // we handle predictive highlighting manually in onMouseMove, so we disable
     // StandardSceneToolsBase's predictive highlighting
@@ -468,7 +472,8 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::createHintFragmentItem(
     }
 
     m_hint_fragment_item = new MonomerHintFragmentItem(
-        frag, m_bolded_fonts, atom_indices_to_hide, bond_index_to_label,
+        frag, m_bolded_fonts, *m_atom_display_settings,
+        *m_bond_display_settings, atom_indices_to_hide, bond_index_to_label,
         m_monomer_background_color);
     m_scene->addItem(m_hint_fragment_item);
 }

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
@@ -39,6 +39,8 @@ namespace sketcher
 class MonomerHintFragmentItem;
 class UnboundMonomericAttachmentPointItem;
 class MonomerConnectorItem;
+class AtomDisplaySettings;
+class BondDisplaySettings;
 
 using MonomerAndAPItems =
     std::pair<AbstractMonomerItem*, UnboundMonomericAttachmentPointItem*>;
@@ -149,7 +151,9 @@ class SKETCHER_API AbstractDrawMonomerOrMonomericConnectionSceneTool
     AbstractDrawMonomerOrMonomericConnectionSceneTool(
         const std::string& res_name,
         const rdkit_extensions::ChainType chain_type, const Fonts& fonts,
-        Scene* scene, MolModel* mol_model);
+        const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model);
     virtual ~AbstractDrawMonomerOrMonomericConnectionSceneTool();
 
     // Reimplemented AbstractSceneTool methods
@@ -168,6 +172,8 @@ class SKETCHER_API AbstractDrawMonomerOrMonomericConnectionSceneTool
         rdkit_extensions::ChainType::CHEM;
     MonomerType m_monomer_type;
     Fonts m_bolded_fonts;
+    const AtomDisplaySettings* m_atom_display_settings = nullptr;
+    const BondDisplaySettings* m_bond_display_settings = nullptr;
 
     bool m_drag_ignored;
     AbstractMonomerItem* m_drag_start_monomer_item = nullptr;

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.cpp
@@ -11,12 +11,15 @@ namespace sketcher
 {
 
 AbstractDrawMonomericConnectionSceneTool::
-    AbstractDrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
-                                             MolModel* mol_model) :
+    AbstractDrawMonomericConnectionSceneTool(
+        const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model) :
     // the residue name and chain type are irrelevant since this class will
     // never create a new residue, so just pass dummy values
     AbstractDrawMonomerOrMonomericConnectionSceneTool(
-        "", rdkit_extensions::ChainType::CHEM, fonts, scene, mol_model)
+        "", rdkit_extensions::ChainType::CHEM, fonts, atom_display_settings,
+        bond_display_settings, scene, mol_model)
 {
 }
 

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomeric_connection_scene_tool.h
@@ -24,8 +24,10 @@ class SKETCHER_API AbstractDrawMonomericConnectionSceneTool
     : public AbstractDrawMonomerOrMonomericConnectionSceneTool
 {
   protected:
-    AbstractDrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
-                                             MolModel* mol_model);
+    AbstractDrawMonomericConnectionSceneTool(
+        const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model);
 
     QGraphicsItem* m_invalid_drag_item = nullptr;
     QPen m_invalid_drag_pen = QPen(CONNECTION_TOOL_INVALID_DRAG_COLOR,

--- a/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.cpp
@@ -55,10 +55,11 @@ const std::vector<MonomerFragmentAttachmentInfo> NUCLEOTIDE_ATTACHMENT_INFO = {
 constexpr double NUCLEOTIDE_DRAG_ANGLE_ADJUSTMENT = M_PI / 2.0;
 
 std::shared_ptr<DrawMonomerFragmentSceneTool>
-get_nucleotide_fragment_scene_tool(const std::string& sugar,
-                                   const std::string& base,
-                                   const std::string& phos, const Fonts& fonts,
-                                   Scene* scene, MolModel* mol_model)
+get_nucleotide_fragment_scene_tool(
+    const std::string& sugar, const std::string& base, const std::string& phos,
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model)
 {
     auto to_helm_monomer = [](const std::string& monomer) {
         if (monomer.size() > 1) {
@@ -75,7 +76,8 @@ get_nucleotide_fragment_scene_tool(const std::string& sugar,
     prepare_mol(*mol);
     return std::make_shared<DrawMonomerFragmentSceneTool>(
         *mol, NUCLEOTIDE_ATTACHMENT_INFO, SUGAR_IDX,
-        NUCLEOTIDE_DRAG_ANGLE_ADJUSTMENT, fonts, scene, mol_model);
+        NUCLEOTIDE_DRAG_ANGLE_ADJUSTMENT, fonts, atom_display_settings,
+        bond_display_settings, scene, mol_model);
 }
 
 /**
@@ -102,12 +104,16 @@ DrawMonomerFragmentSceneTool::DrawMonomerFragmentSceneTool(
     const RDKit::ROMol& mol,
     const std::vector<MonomerFragmentAttachmentInfo> attachment_info,
     const int index_to_center_on_click, const double drag_angle_adjustment,
-    const Fonts& fonts, Scene* scene, MolModel* mol_model) :
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model) :
     AbstractMonomerSceneTool(fonts, scene, mol_model),
     m_frag(mol),
     m_attachment_info(attachment_info),
     m_index_to_center_on_click(index_to_center_on_click),
-    m_drag_angle_adjustment(drag_angle_adjustment)
+    m_drag_angle_adjustment(drag_angle_adjustment),
+    m_atom_display_settings(&atom_display_settings),
+    m_bond_display_settings(&bond_display_settings)
 {
     set_all_atoms_monomeric(m_frag);
     m_frag.getConformer().set3D(false);
@@ -145,8 +151,9 @@ QPixmap DrawMonomerFragmentSceneTool::createDefaultCursorPixmap() const
     fonts_copy.setSize(FONT_SIZE);
     fonts_copy.m_main_label_font.setBold(true);
     fonts_copy.updateFontMetrics();
-    MonomerHintFragmentItem graphics_item(frag_copy, fonts_copy, {}, -1,
-                                          m_monomer_background_color);
+    MonomerHintFragmentItem graphics_item(
+        frag_copy, fonts_copy, *m_atom_display_settings,
+        *m_bond_display_settings, {}, -1, m_monomer_background_color);
     auto cursor_hint =
         cursor_hint_from_graphics_item(&graphics_item, -1, CURSOR_HINT_SCALE);
 
@@ -235,7 +242,8 @@ void DrawMonomerFragmentSceneTool::onLeftButtonPress(
         move_mol_to_coords_and_rotate(*frag_copy, m_index_to_center_on_click,
                                       to_mol_xy(scene_pos), 0.0);
         m_hint_fragment_item = new MonomerHintFragmentItem(
-            frag_copy, *m_fonts, {}, -1, m_monomer_background_color);
+            frag_copy, *m_fonts, *m_atom_display_settings,
+            *m_bond_display_settings, {}, -1, m_monomer_background_color);
         m_scene->addItem(m_hint_fragment_item);
     }
 }
@@ -384,7 +392,8 @@ void DrawMonomerFragmentSceneTool::drawFragmentHintFor(
         attachment_info.frag_monomer_ap_model_name);
 
     m_hint_fragment_item = new MonomerHintFragmentItem(
-        hint_mol, *m_fonts, {hovered_monomer_copy_idx}, new_connection_idx,
+        hint_mol, *m_fonts, *m_atom_display_settings, *m_bond_display_settings,
+        {hovered_monomer_copy_idx}, new_connection_idx,
         m_monomer_background_color);
     m_scene->addItem(m_hint_fragment_item);
 }

--- a/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_fragment_scene_tool.h
@@ -21,6 +21,8 @@ namespace sketcher
 {
 
 class AbstractMonomerItem;
+class AtomDisplaySettings;
+class BondDisplaySettings;
 class DrawMonomerFragmentSceneTool;
 class UnboundMonomericAttachmentPointItem;
 
@@ -43,10 +45,11 @@ struct MonomerFragmentAttachmentInfo {
  * the given residue names.
  */
 std::shared_ptr<DrawMonomerFragmentSceneTool>
-get_nucleotide_fragment_scene_tool(const std::string& sugar,
-                                   const std::string& base,
-                                   const std::string& phos, const Fonts& fonts,
-                                   Scene* scene, MolModel* mol_model);
+get_nucleotide_fragment_scene_tool(
+    const std::string& sugar, const std::string& base, const std::string& phos,
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model);
 
 /**
  * A scene tool for drawing monomeric fragments
@@ -87,7 +90,9 @@ class SKETCHER_API DrawMonomerFragmentSceneTool
         const RDKit::ROMol& mol,
         const std::vector<MonomerFragmentAttachmentInfo> attachment_info,
         const int index_to_center_on_click, const double drag_angle_adjustment,
-        const Fonts& fonts, Scene* scene, MolModel* mol_model);
+        const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model);
 
     // Reimplemented AbstractSceneTool methods
     QPixmap createDefaultCursorPixmap() const override;
@@ -105,6 +110,8 @@ class SKETCHER_API DrawMonomerFragmentSceneTool
     int m_index_to_center_on_click;
     bool m_press_was_over_monomer = false;
     double m_drag_angle_adjustment;
+    const AtomDisplaySettings* m_atom_display_settings = nullptr;
+    const BondDisplaySettings* m_bond_display_settings = nullptr;
 
     /**
      * @return the attachment point graphics item that we should attach the

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -23,9 +23,12 @@ using rdkit_extensions::Direction;
 
 DrawMonomerSceneTool::DrawMonomerSceneTool(
     const std::string& res_name, const rdkit_extensions::ChainType chain_type,
-    const Fonts& fonts, Scene* scene, MolModel* mol_model) :
-    AbstractDrawMonomerOrMonomericConnectionSceneTool(res_name, chain_type,
-                                                      fonts, scene, mol_model)
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model) :
+    AbstractDrawMonomerOrMonomericConnectionSceneTool(
+        res_name, chain_type, fonts, atom_display_settings,
+        bond_display_settings, scene, mol_model)
 {
 }
 
@@ -187,7 +190,9 @@ QPixmap DrawMonomerSceneTool::createDefaultCursorPixmap() const
         rdkit_extensions::makeMonomer(m_res_name, chain_id, 1, false);
 
     std::shared_ptr<AbstractMonomerItem> monomer_item;
-    monomer_item.reset(get_monomer_graphics_item(monomer.get(), *m_fonts));
+    monomer_item.reset(get_monomer_graphics_item(monomer.get(), *m_fonts,
+                                                 *m_atom_display_settings,
+                                                 *m_bond_display_settings));
     monomer_item->setMonomerColors(Qt::GlobalColor::transparent,
                                    CURSOR_HINT_COLOR, CURSOR_HINT_COLOR);
     // make sure that the cursor hint is at least a little smaller than an

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.h
@@ -23,6 +23,8 @@ enum class ChainType;
 namespace sketcher
 {
 
+class AtomDisplaySettings;
+class BondDisplaySettings;
 struct HintFragmentMonomerInfo;
 
 /**
@@ -34,7 +36,10 @@ class SKETCHER_API DrawMonomerSceneTool
   public:
     DrawMonomerSceneTool(const std::string& res_name,
                          const rdkit_extensions::ChainType chain_type,
-                         const Fonts& fonts, Scene* scene, MolModel* mol_model);
+                         const Fonts& fonts,
+                         const AtomDisplaySettings& atom_display_settings,
+                         const BondDisplaySettings& bond_display_settings,
+                         Scene* scene, MolModel* mol_model);
 
     // Reimplemented AbstractSceneTool method
     void onLeftButtonClick(QGraphicsSceneMouseEvent* const event) override;

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
@@ -9,8 +9,11 @@ namespace sketcher
 {
 
 DrawMonomericConnectionSceneTool::DrawMonomericConnectionSceneTool(
-    const Fonts& fonts, Scene* scene, MolModel* mol_model) :
-    AbstractDrawMonomericConnectionSceneTool(fonts, scene, mol_model)
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model) :
+    AbstractDrawMonomericConnectionSceneTool(
+        fonts, atom_display_settings, bond_display_settings, scene, mol_model)
 {
 }
 

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.h
@@ -26,8 +26,10 @@ class SKETCHER_API DrawMonomericConnectionSceneTool
     : public AbstractDrawMonomericConnectionSceneTool
 {
   public:
-    DrawMonomericConnectionSceneTool(const Fonts& fonts, Scene* scene,
-                                     MolModel* mol_model);
+    DrawMonomericConnectionSceneTool(
+        const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model);
 
   protected:
     // Reimplemented AbstractSceneTool method

--- a/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.cpp
@@ -10,10 +10,12 @@ namespace schrodinger
 namespace sketcher
 {
 
-DrawMonomericHBondSceneTool::DrawMonomericHBondSceneTool(const Fonts& fonts,
-                                                         Scene* scene,
-                                                         MolModel* mol_model) :
-    AbstractDrawMonomericConnectionSceneTool(fonts, scene, mol_model)
+DrawMonomericHBondSceneTool::DrawMonomericHBondSceneTool(
+    const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+    const BondDisplaySettings& bond_display_settings, Scene* scene,
+    MolModel* mol_model) :
+    AbstractDrawMonomericConnectionSceneTool(
+        fonts, atom_display_settings, bond_display_settings, scene, mol_model)
 {
     m_highlight_types = InteractiveItemFlag::MONOMER;
 }

--- a/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_hbond_scene_tool.h
@@ -21,8 +21,10 @@ class SKETCHER_API DrawMonomericHBondSceneTool
     : public AbstractDrawMonomericConnectionSceneTool
 {
   public:
-    DrawMonomericHBondSceneTool(const Fonts& fonts, Scene* scene,
-                                MolModel* mol_model);
+    DrawMonomericHBondSceneTool(
+        const Fonts& fonts, const AtomDisplaySettings& atom_display_settings,
+        const BondDisplaySettings& bond_display_settings, Scene* scene,
+        MolModel* mol_model);
 
   protected:
     // Reimplemented AbstractSceneTool method

--- a/test/schrodinger/sketcher/molviewer/test_amino_acid_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_amino_acid_item.cpp
@@ -1,0 +1,44 @@
+#define BOOST_TEST_MODULE test_amino_acid_item
+
+#include <boost/test/unit_test.hpp>
+
+#include "schrodinger/rdkit_extensions/monomer_mol.h"
+#include "schrodinger/sketcher/molviewer/amino_acid_item.h"
+#include "schrodinger/sketcher/molviewer/atom_display_settings.h"
+#include "schrodinger/sketcher/molviewer/bond_display_settings.h"
+#include "schrodinger/sketcher/molviewer/fonts.h"
+
+#include "../qapplication_required_fixture.h"
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Make sure that the tool tip for a standard amino acid is empty, while the
+ * tool tip for a SMILES monomer contains an image
+ */
+BOOST_AUTO_TEST_CASE(test_tool_tips)
+{
+    Fonts fonts;
+    AtomDisplaySettings atom_display_settings;
+    BondDisplaySettings bond_display_settings;
+
+    auto alanine = rdkit_extensions::makeMonomer("A", "PEPTIDE1", 1, false);
+    AminoAcidItem alanine_item(alanine.get(), fonts, atom_display_settings,
+                               bond_display_settings);
+    BOOST_TEST(alanine_item.toolTip().isEmpty());
+
+    auto smiles_monomer =
+        rdkit_extensions::makeMonomer("CC", "PEPTIDE1", 2, true);
+    AminoAcidItem smiles_monomer_item(smiles_monomer.get(), fonts,
+                                      atom_display_settings,
+                                      bond_display_settings);
+    BOOST_TEST(smiles_monomer_item.toolTip().startsWith("<img src="));
+}
+
+} // namespace sketcher
+} // namespace schrodinger

--- a/test/schrodinger/sketcher/molviewer/test_amino_acid_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_amino_acid_item.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(test_tool_tips)
     AminoAcidItem smiles_monomer_item(smiles_monomer.get(), fonts,
                                       atom_display_settings,
                                       bond_display_settings);
-    BOOST_TEST(smiles_monomer_item.toolTip().startsWith("<img src="));
+    BOOST_TEST(smiles_monomer_item.toolTip().startsWith("<img"));
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
@@ -10,6 +10,8 @@
 #include "../test_common.h"
 #include "schrodinger/rdkit_extensions/monomer_mol.h"
 #include "schrodinger/sketcher/molviewer/abstract_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/atom_display_settings.h"
+#include "schrodinger/sketcher/molviewer/bond_display_settings.h"
 #include "schrodinger/sketcher/molviewer/fonts.h"
 #include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
@@ -37,13 +39,16 @@ struct TestMonomer {
     std::unique_ptr<RDKit::Atom> atom;
     std::unique_ptr<AbstractMonomerItem> item;
     Fonts fonts;
+    AtomDisplaySettings atom_display_settings;
+    BondDisplaySettings bond_display_settings;
 
     TestMonomer(const std::string& res_name,
                 const rdkit_extensions::ChainType chain_type)
     {
         auto chain_id = rdkit_extensions::toString(chain_type) + "1";
         atom = rdkit_extensions::makeMonomer(res_name, chain_id, 1, false);
-        item.reset(get_monomer_graphics_item(atom.get(), fonts));
+        item.reset(get_monomer_graphics_item(
+            atom.get(), fonts, atom_display_settings, bond_display_settings));
     }
 
     /// Create an attachment point item with a numbered name (e.g. R1, R2)


### PR DESCRIPTION
- Linked Case: SKETCH-2832

### Description

SMILES monomers now have a tool tip that shows an atomistic image of the SMILES molecule:
<img width="1279" height="826" alt="image" src="https://github.com/user-attachments/assets/a370fec5-4518-4671-8822-678660b49461" />
This is implemented using the standard Qt tooltips, which can handle images if they're passed as HTML containing a base64-encoded image.  Unfortunately, this means that the image rendering is a bit aliased, as you can see in the screen shot above.  The only way to fix this would be to manually implement our own tool-tip-like behavior using mouse events.  I've done this for Python panels before I learned about the base64-encoding trick, but it takes a bit of work.  It doesn't seem worth worrying about until Laura complains about it.

Also, as a result of this change, monomer graphics items now take `AtomDisplaySettings` and `BondDisplaySettings` objects so that the SMILES molecule can be rendered using the current atomistic settings.  This change required updating a bunch of signatures of constructors and other functions so that we could pass settings from the `Scene` to the graphics items and scene tools (which instantiate graphics items for hints when hovering over monomers).  That's the main reason why this diff touches so many files.  The only new logic is in abstract_monomer_item.cpp; everything else is just small tweaks to pass these settings around.

While I was working on this case, I filed SKETCH-2842 to change the label for SMILES monomers from `***` to a small thumbnail of the tool tip image.  What do people think of that idea?  The image won't be large enough to make out all of the details, but it should at least give an idea of what the atomistic structure is, and it seems a lot more informative than just `***`.  It shouldn't be difficult to implement now that the monomeric graphics items receive the atom and bond settings.  We'd probably want to make the bond lines a little thicker so they're visible at the small size, similar to what we do for cursor hints.

### Testing Done

Tested on the Windows desktop add and added a new unit test that sanity checks tool tips.
