### PR TITLE
ensure consistent CW spelling of rings

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -511,6 +511,29 @@ generate_coordinates_for_cycles(RDKit::ROMol& polymer,
     params.forceRDKit = true;
     params.useRingTemplates = false;
     RDDepict::compute2DCoords(polymer, params);
+
+    // Ensure consistent ring direction (CW) for single-ring polymers by
+    // checking if the ring atoms are laid out in ascending backbone order.
+    // RDKit's normalizeRing can produce different orderings for different ring
+    // sizes. If ascending (CCW), mirror the y-coordinates to flip to CW.
+    // Only apply this fix for single rings where ALL atoms are in the ring,
+    // to avoid disrupting layouts with external attachments.
+    auto& conformer = polymer.getConformer();
+    const auto& rings = polymer.getRingInfo()->atomRings();
+    if (rings.size() == 1 && rings[0].size() == polymer.getNumAtoms()) {
+        const auto& ring = rings[0];
+        if (ring.size() > 2 && ring[1] < ring.back()) {
+            // Ring is in ascending order (CCW) - mirror y-coordinates around
+            // centroid to make it CW
+            auto centroid = compute_centroid(polymer, ring);
+            for (auto atom_idx : ring) {
+                auto pos = conformer.getAtomPos(atom_idx);
+                pos.y = 2 * centroid.y - pos.y;
+                conformer.setAtomPos(atom_idx, pos);
+            }
+        }
+    }
+
     orient_ring_system(polymer);
 
     // finalize coordinates of rings and of their immediate neighbors.

--- a/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
+++ b/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
@@ -743,4 +743,52 @@ BOOST_AUTO_TEST_CASE(TestPositionInCoilsScore)
     }
 }
 
+BOOST_AUTO_TEST_CASE(CyclicRingsHaveConsistentDirection)
+{
+    // Test that cyclic rings are always drawn in the same direction (CCW)
+    // regardless of odd/even ring size. RDKit's normalizeRing can produce
+    // different atom orderings for different ring sizes, but our fix ensures
+    // consistent visual direction.
+
+    // 9-atom ring (odd)
+    std::string helm_odd =
+        "PEPTIDE1{C.P.M.H.V.I.K.C}|CHEM1{[mDBX]}$PEPTIDE1,CHEM1,1:R3-1:R1|"
+        "PEPTIDE1,CHEM1,8:R3-1:R2$$$V2.0";
+    // 10-atom ring (even)
+    std::string helm_even =
+        "PEPTIDE1{C.P.M.M.H.V.I.K.C}|CHEM1{[mDBX]}$PEPTIDE1,CHEM1,1:R3-1:R1|"
+        "PEPTIDE1,CHEM1,9:R3-1:R2$$$V2.0";
+
+    auto mol_odd = helm::helm_to_rdkit(helm_odd);
+    auto mol_even = helm::helm_to_rdkit(helm_even);
+
+    schrodinger::rdkit_extensions::compute_monomer_mol_coords(*mol_odd);
+    schrodinger::rdkit_extensions::compute_monomer_mol_coords(*mol_even);
+
+    auto& conf_odd = mol_odd->getConformer();
+    auto& conf_even = mol_even->getConformer();
+
+    // Check direction by looking at the cross product of consecutive edges.
+    // For CCW, the cross product (v1 x v2).z should be positive.
+    auto check_ccw = [](const RDKit::Conformer& conf, int a, int b, int c) {
+        auto p0 = conf.getAtomPos(a);
+        auto p1 = conf.getAtomPos(b);
+        auto p2 = conf.getAtomPos(c);
+        double v1x = p1.x - p0.x;
+        double v1y = p1.y - p0.y;
+        double v2x = p2.x - p1.x;
+        double v2y = p2.y - p1.y;
+        double cross_z = v1x * v2y - v1y * v2x;
+        return cross_z > 0;
+    };
+
+    // Check first 3 backbone atoms (0, 1, 2) for both rings
+    bool odd_ccw = check_ccw(conf_odd, 0, 1, 2);
+    bool even_ccw = check_ccw(conf_even, 0, 1, 2);
+
+    BOOST_CHECK_MESSAGE(odd_ccw == even_ccw,
+                        "Odd and even sized rings should have the same "
+                        "winding direction");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Linked Case: CRDGEN-418

### Description

looks like rdkit normalizeRing returns ring spelt out in opposite directions for add and even... not sure why. This flips coordinates in half of the cases so they are all spelt out CW. Note that this is only done when there's a single ring of monomers without any other decoration

PEPTIDE1{C.P.M.H.V.I.K.C}|CHEM1{[mDBX]}$PEPTIDE1,CHEM1,1:R3-1:R1|PEPTIDE1,CHEM1,8:R3-1:R2$$$V2.0

PEPTIDE1{C.P.M.M.H.V.I.K.C}|CHEM1{[mDBX]}$PEPTIDE1,CHEM1,1:R3-1:R1|PEPTIDE1,CHEM1,9:R3-1:R2$$$V2.0

<img width="520" height="261" alt="Screenshot 2026-08-10 at 12 32 52" src="https://github.com/user-attachments/assets/ef275d8b-10c8-491b-9c2f-1d23c15e1382" />


### Testing Done

added a test