### PR TITLE
SKETCH-2833: Amino acids other than cysteine now have H-bond attachment point instead of R3

### DIFF
--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -43,17 +43,10 @@ const std::string H_BOND_LINKAGE =
 // issues with C++′s handling of Unicode.
 const std::unordered_map<MonomerType, std::vector<std::string>>
     NUMBERED_AP_NAMES_BY_MONOMER_TYPE = {
-        {MonomerType::PEPTIDE, {"N", "C", "X"}},
+        {MonomerType::PEPTIDE, {"N", "C", "S"}},
         {MonomerType::NA_BASE, {"N1/9"}},
         {MonomerType::NA_SUGAR, {"5'", "3'", "1'"}},
 };
-
-// standard attachment point names that don't follow the "R#" naming scheme.
-// Given as a pair of model name, display name
-const std::unordered_map<MonomerType,
-                         std::vector<std::pair<std::string, std::string>>>
-    EXPECTED_AP_CUSTOM_NAMES = {
-        {MonomerType::NA_BASE, {{H_BOND_AP_MODEL_NAME, H_BOND_DISPLAY_NAME}}}};
 
 const int INVALID_ATTACHMENT_POINT_SPEC = -2;
 
@@ -561,10 +554,18 @@ get_unbound_attachment_points(const RDKit::Atom* monomer,
 
     // figure out how many numbered attachment points we expect
     auto monomer_type = get_monomer_type(monomer);
+    bool is_amino_acid_other_than_cysteine =
+        monomer_type == MonomerType::PEPTIDE &&
+        get_monomer_res_name(monomer) != CYS_RES_NAME;
     int num_numbered_aps = -1;
     if (NUMBERED_AP_NAMES_BY_MONOMER_TYPE.contains(monomer_type)) {
         num_numbered_aps =
             NUMBERED_AP_NAMES_BY_MONOMER_TYPE.at(monomer_type).size();
+        if (is_amino_acid_other_than_cysteine) {
+            // only cysteine can form disulfides, other amino acids will have a
+            // H-bond attachment point added below
+            num_numbered_aps -= 1;
+        }
     } else if (monomer_type == MonomerType::NA_PHOSPHATE) {
         num_numbered_aps = 2;
     } else {
@@ -595,23 +596,20 @@ get_unbound_attachment_points(const RDKit::Atom* monomer,
             }
         }
 
-        // figure out which attachment points with custom names are unbound
-        if (EXPECTED_AP_CUSTOM_NAMES.contains(monomer_type)) {
-            for (const auto& [ap_model_name, ap_display_name] :
-                 EXPECTED_AP_CUSTOM_NAMES.at(monomer_type)) {
-                if (!bound_aps_with_custom_names.contains(ap_model_name)) {
-                    auto dir = calculate_direction_for_unbound_attachment_point(
-                        ATTACHMENT_POINT_WITH_CUSTOM_NAME, ap_model_name,
-                        monomer_type, bound_aps, available_aps,
-                        occupied_directions);
-                    occupied_directions.insert(dir);
-                    // XCode 14 requires push_back instead of emplace_back and
-                    // curly brackets instead of parenthesis here
-                    available_aps.push_back(UnboundAttachmentPoint{
-                        ap_model_name, ap_display_name,
-                        ATTACHMENT_POINT_WITH_CUSTOM_NAME, dir});
-                }
-            }
+        // figure out if we should add an unbound H-bond attachment point
+        bool expect_h_bond_ap = monomer_type == MonomerType::NA_BASE ||
+                                is_amino_acid_other_than_cysteine;
+        if (expect_h_bond_ap &&
+            !bound_aps_with_custom_names.contains(H_BOND_AP_MODEL_NAME)) {
+            auto dir = calculate_direction_for_unbound_attachment_point(
+                ATTACHMENT_POINT_WITH_CUSTOM_NAME, H_BOND_AP_MODEL_NAME,
+                monomer_type, bound_aps, available_aps, occupied_directions);
+            occupied_directions.insert(dir);
+            // XCode 14 requires push_back instead of emplace_back and
+            // curly brackets instead of parenthesis here
+            available_aps.push_back(UnboundAttachmentPoint{
+                H_BOND_AP_MODEL_NAME, H_BOND_DISPLAY_NAME,
+                ATTACHMENT_POINT_WITH_CUSTOM_NAME, dir});
         }
     } catch (const NoAvailableDirectionsException&) {
         // there are so many attachment points that we can't generate directions

--- a/src/schrodinger/sketcher/rdkit/monomeric.h
+++ b/src/schrodinger/sketcher/rdkit/monomeric.h
@@ -45,7 +45,7 @@ enum class ConnectorType {
 
 namespace PeptideAP
 {
-enum { N = 1, C = 2, SIDECHAIN = 3 };
+enum { N = 1, C = 2, S = 3 };
 }
 
 namespace NASugarAP
@@ -61,6 +61,8 @@ enum { TO_PREV_SUGAR = 1, TO_NEXT_SUGAR = 2 };
 constexpr int NA_BASE_AP_N1_9 = 1;
 const std::string H_BOND_AP_MODEL_NAME = "pair";
 const std::string H_BOND_DISPLAY_NAME = "H-bond";
+
+const std::string CYS_RES_NAME = "C";
 
 /**
  * Convert any of the above attachment point enums (or NA_BASE_AP_N1_9) to the

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -238,10 +238,11 @@ UnboundMonomericAttachmentPointItem* get_default_attachment_point(
     return nullptr;
 }
 
-std::string
-get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
-                                     const std::string_view existing_monomer_ap,
-                                     const MonomerType new_monomer_type)
+std::string get_attachment_point_for_new_monomer(
+    const MonomerType existing_monomer_type,
+    const std::string_view existing_monomer_ap,
+    const MonomerType new_monomer_type,
+    const std::string_view new_monomer_res_name)
 {
     switch (new_monomer_type) {
         case MonomerType::CHEM:
@@ -253,9 +254,13 @@ get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
                 } else if (existing_monomer_ap ==
                            ap_model_name_for(PeptideAP::C)) {
                     return ap_model_name_for(PeptideAP::N);
+                } else if (existing_monomer_ap ==
+                               ap_model_name_for(PeptideAP::S) &&
+                           new_monomer_res_name == CYS_RES_NAME) {
+                    return ap_model_name_for(PeptideAP::S);
                 }
             }
-            return ap_model_name_for(PeptideAP::S);
+            return H_BOND_AP_MODEL_NAME;
         case MonomerType::NA_BASE:
             if (existing_monomer_type == MonomerType::NA_SUGAR &&
                 existing_monomer_ap ==
@@ -344,7 +349,7 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::
     // dragged from a C terminus), use that one
     auto ideal_ap_model_name = get_attachment_point_for_new_monomer(
         drag_start_monomer_type, m_drag_start_ap_model_name,
-        drag_end_monomer_type);
+        drag_end_monomer_type, drag_end_res_name);
     for (auto* ap_item : m_drag_end_unbound_ap_items) {
         if (ap_item->getAttachmentPoint().model_name == ideal_ap_model_name) {
             return ap_item;
@@ -565,7 +570,7 @@ HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
         rdkit_extensions::makeMonomer(m_res_name, chain_id, res_num, false);
     auto ap_model_name = get_attachment_point_for_new_monomer(
         start_monomer_info.monomer_type, start_monomer_info.ap_model_name,
-        m_monomer_type);
+        m_monomer_type, m_res_name);
     return HintFragmentMonomerInfo{std::move(monomer), m_monomer_type, pos,
                                    ap_model_name, NEW_MONOMER_FROM_DRAG};
 }

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -30,6 +30,7 @@
 #include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/molviewer/scene_utils.h"
 #include "schrodinger/sketcher/molviewer/unbound_monomeric_attachment_point_item.h"
+#include "schrodinger/sketcher/rdkit/monomeric.h"
 
 namespace schrodinger
 {
@@ -183,7 +184,8 @@ find_attachment_point_with_num(
 }
 
 UnboundMonomericAttachmentPointItem* get_default_attachment_point(
-    const MonomerType hovered_type, const MonomerType tool_type,
+    const MonomerType hovered_type, const std::string& hovered_res_name,
+    const MonomerType tool_type, const std::string& tool_res_name,
     const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items)
 {
     if (unbound_ap_items.empty()) {
@@ -191,14 +193,23 @@ UnboundMonomericAttachmentPointItem* get_default_attachment_point(
     } else if (hovered_type == MonomerType::CHEM) {
         return find_min_attachment_point_by_num(unbound_ap_items);
     } else if (hovered_type == MonomerType::PEPTIDE) {
+        UnboundMonomericAttachmentPointItem* default_ap = nullptr;
         if (tool_type == MonomerType::PEPTIDE) {
-            return find_preferred_attachment_point_by_num(
-                unbound_ap_items,
-                {PeptideAP::C, PeptideAP::N, PeptideAP::SIDECHAIN});
-        } else if (tool_type == MonomerType::CHEM) {
-            return find_attachment_point_with_num(unbound_ap_items,
-                                                  PeptideAP::SIDECHAIN);
+            std::vector<int> aps_to_look_for = {PeptideAP::C, PeptideAP::N};
+            if (hovered_res_name == CYS_RES_NAME &&
+                tool_res_name == CYS_RES_NAME) {
+                // only offer to form a disulfide if we're forming a connection
+                // between two cysteines
+                aps_to_look_for.push_back(PeptideAP::S);
+            }
+            default_ap = find_preferred_attachment_point_by_num(
+                unbound_ap_items, aps_to_look_for);
         }
+        if (default_ap == nullptr) {
+            default_ap = find_attachment_point_with_name(unbound_ap_items,
+                                                         H_BOND_AP_MODEL_NAME);
+        }
+        return default_ap;
     } else if (hovered_type == MonomerType::NA_BASE) {
         if (tool_type == MonomerType::NA_BASE ||
             tool_type == MonomerType::CHEM) {
@@ -244,7 +255,7 @@ get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
                     return ap_model_name_for(PeptideAP::N);
                 }
             }
-            return ap_model_name_for(PeptideAP::SIDECHAIN);
+            return ap_model_name_for(PeptideAP::S);
         case MonomerType::NA_BASE:
             if (existing_monomer_type == MonomerType::NA_SUGAR &&
                 existing_monomer_ap ==
@@ -313,18 +324,20 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::
         }
     }
 
-    // get the monomer type for the start and end monomers
-    auto get_drag_monomer_type =
+    // get the monomer type and residue name for the start and end monomers
+    auto get_drag_monomer_type_and_res_name =
         [this](const AbstractMonomerItem* const monomer_item) {
             if (monomer_item == nullptr) {
-                return m_monomer_type;
+                return std::make_pair(m_monomer_type, m_res_name);
             }
             auto [monomer, monomer_type] = get_monomer_and_type(monomer_item);
-            return monomer_type;
+            auto res_name = get_monomer_res_name(monomer);
+            return std::make_pair(monomer_type, res_name);
         };
-    auto drag_start_monomer_type =
-        get_drag_monomer_type(m_drag_start_monomer_item);
-    auto drag_end_monomer_type = get_drag_monomer_type(m_drag_end_monomer_item);
+    auto [drag_start_monomer_type, drag_start_res_name] =
+        get_drag_monomer_type_and_res_name(m_drag_start_monomer_item);
+    auto [drag_end_monomer_type, drag_end_res_name] =
+        get_drag_monomer_type_and_res_name(m_drag_end_monomer_item);
 
     // if the user is hovered over the monomer itself (not an attachment point)
     // and the "correct" attachment point is available (e.g. N terminus when we
@@ -341,9 +354,9 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::
     // if the correct attachment point isn't available then there's probably no
     // good option, so use whatever we would've defaulted if we'd started the
     // drag at this monomer.
-    return get_default_attachment_point(drag_end_monomer_type,
-                                        drag_start_monomer_type,
-                                        m_drag_end_unbound_ap_items);
+    return get_default_attachment_point(
+        drag_end_monomer_type, drag_end_res_name, drag_start_monomer_type,
+        drag_start_res_name, m_drag_end_unbound_ap_items);
 }
 
 std::tuple<const RDKit::Atom*, MonomerType>
@@ -369,8 +382,9 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::
         clickShouldMutate(monomer, monomer_type)) {
         return nullptr;
     }
-    return get_default_attachment_point(monomer_type, m_monomer_type,
-                                        m_unbound_ap_items);
+    return get_default_attachment_point(
+        monomer_type, get_monomer_res_name(monomer), m_monomer_type, m_res_name,
+        m_unbound_ap_items);
 }
 
 bool AbstractDrawMonomerOrMonomericConnectionSceneTool::
@@ -386,8 +400,9 @@ bool AbstractDrawMonomerOrMonomericConnectionSceneTool::
     if (clickShouldMutate(monomer, monomer_type)) {
         return true;
     }
-    return get_default_attachment_point(monomer_type, m_monomer_type,
-                                        m_unbound_ap_items) != nullptr;
+    return get_default_attachment_point(
+               monomer_type, get_monomer_res_name(monomer), m_monomer_type,
+               m_res_name, m_unbound_ap_items) != nullptr;
 }
 
 void AbstractDrawMonomerOrMonomericConnectionSceneTool::onMouseMove(
@@ -520,7 +535,15 @@ HintFragmentMonomerInfo AbstractDrawMonomerOrMonomericConnectionSceneTool::
         const AbstractMonomerItem* const monomer_item,
         const UnboundMonomericAttachmentPointItem* const ap_item) const
 {
-    auto ap_model_name = ap_item->getAttachmentPoint().model_name;
+    std::string ap_model_name;
+    if (ap_item == nullptr) {
+        // if there's no attachment point item, then the drag must have started
+        // from a "pair" AP (meaning that we didn't draw any attachment points
+        // since the drag can only create H-bonds)
+        ap_model_name = H_BOND_AP_MODEL_NAME;
+    } else {
+        ap_model_name = ap_item->getAttachmentPoint().model_name;
+    }
     return createHintFragmentMonomerInfoForHintToOrFromExistingMonomer(
         monomer_item, ap_model_name);
 }
@@ -634,7 +657,15 @@ AbstractDrawMonomerOrMonomericConnectionSceneTool::getDragEndInfo(
     }
 
     DragEndInfo drag_end_info;
-    if (drag_end_ap_item == nullptr) {
+    if (m_drag_start_monomer_item != nullptr &&
+        m_drag_start_ap_model_name == H_BOND_AP_MODEL_NAME &&
+        hovered_monomer_item != nullptr &&
+        dragCanFormConnectionTo(hovered_monomer_item, H_BOND_AP_MODEL_NAME)) {
+        // We can form a hydrogen bond here. There's no drag_end_ap_item in this
+        // scenario because we didn't draw any AP items, since a drag starting
+        // from a "pair" AP can only form H-bonds
+        drag_end_info = std::make_pair(hovered_monomer_item, nullptr);
+    } else if (drag_end_ap_item == nullptr) {
         // there's no available attachment point at the cursor (or there is one
         // but we can't use it because this pair of monomers already has that
         // type of connection), so we display the drag hint in a direction
@@ -699,7 +730,11 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragMove(
             clearDragEndAttachmentPointsLabels();
         }
         m_drag_end_monomer_item = hovered_monomer_item;
-        if (hovered_monomer_item != nullptr) {
+        // draw attachment points unless we're dragging from "pair" AP (in which
+        // case we can only form H-bonds, so we don't need numbered attachment
+        // points)
+        if (hovered_monomer_item != nullptr &&
+            m_drag_start_ap_model_name != H_BOND_AP_MODEL_NAME) {
             labelAttachmentPointsOnDragEndMonomer(
                 hovered_monomer_item->getAtom(), hovered_monomer_item);
         }

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
@@ -89,10 +89,11 @@ SKETCHER_API UnboundMonomericAttachmentPointItem* get_default_attachment_point(
  * When adding a new monomer bound to an existing monomer, determine the
  * appropriate attach point to use for the new-monomer-end of the connection.
  */
-SKETCHER_API std::string
-get_attachment_point_for_new_monomer(const MonomerType existing_monomer_type,
-                                     const std::string_view existing_monomer_ap,
-                                     const MonomerType new_monomer_type);
+SKETCHER_API std::string get_attachment_point_for_new_monomer(
+    const MonomerType existing_monomer_type,
+    const std::string_view existing_monomer_ap,
+    const MonomerType new_monomer_type,
+    const std::string_view new_monomer_res_name);
 
 /**
  * @return the monomer represented by the given graphics item, along with its

--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.h
@@ -71,13 +71,18 @@ constexpr int NEW_MONOMER_FROM_INVALID_DRAG = -2;
  * Return the default unbound attachment point; that is, the attachment point
  * that should be selected when the user hovers over a monomer.
  * @param hovered_type The type of monomer being hovered over
+ * @param hovered_res_name The residue name of monomer being hovered over. Used
+ * to determine whether we can form a disulfide bond.
  * @param tool_type  The type of monomer that would be drawn by the active scene
  * tool
+ * @param tool_res_name The residue name of monomer from the active scene tool.
+ * Used to determine whether we can form a disulfide bond.
  * @param unbound_ap_items A list of all graphics items representing unbound
  * attachment points of the hovered monomer
  */
 SKETCHER_API UnboundMonomericAttachmentPointItem* get_default_attachment_point(
-    const MonomerType hovered_type, const MonomerType tool_type,
+    const MonomerType hovered_type, const std::string& hovered_res_name,
+    const MonomerType tool_type, const std::string& tool_res_name,
     const std::vector<UnboundMonomericAttachmentPointItem*>& unbound_ap_items);
 
 /**

--- a/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomer_scene_tool.cpp
@@ -92,7 +92,8 @@ void DrawMonomerSceneTool::onLeftButtonClick(
             // default attachment point for this tool, so add a new monomer
             // bound to that attachment point
             auto new_monomer_ap_name = get_attachment_point_for_new_monomer(
-                monomer_type, clicked_ap->model_name, m_monomer_type);
+                monomer_type, clicked_ap->model_name, m_monomer_type,
+                m_res_name);
             auto new_pos = get_default_coords_for_bound_monomer(
                 monomer, clicked_ap->direction);
             // the attachment point labels won't be valid once the new monomer

--- a/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_monomeric_connection_scene_tool.cpp
@@ -65,9 +65,13 @@ UnboundMonomericAttachmentPointItem* DrawMonomericConnectionSceneTool::
     } else if (hovered_type == MonomerType::CHEM) {
         return find_min_attachment_point_by_num(m_unbound_ap_items);
     } else if (hovered_type == MonomerType::PEPTIDE) {
-        return find_preferred_attachment_point_by_num(
-            m_unbound_ap_items,
-            {PeptideAP::C, PeptideAP::N, PeptideAP::SIDECHAIN});
+        auto default_ap = find_preferred_attachment_point_by_num(
+            m_unbound_ap_items, {PeptideAP::C, PeptideAP::N, PeptideAP::S});
+        if (default_ap == nullptr) {
+            default_ap = find_attachment_point_with_name(m_unbound_ap_items,
+                                                         H_BOND_AP_MODEL_NAME);
+        }
+        return default_ap;
     } else if (hovered_type == MonomerType::NA_BASE) {
         return find_attachment_point_with_name(m_unbound_ap_items,
                                                H_BOND_AP_MODEL_NAME);

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom0);
         exp_available = {{"R1", "N", 1, Direction::W},
                          {"R2", "C", 2, Direction::E},
-                         {"R3", "X", 3, Direction::N}};
+                         {"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps.empty());
         BOOST_TEST(unbound_aps == exp_available);
     }
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E}};
         exp_available = {{"R1", "N", 1, Direction::W},
-                         {"R3", "X", 3, Direction::N}};
+                         {"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W}};
         exp_available = {{"R2", "C", 2, Direction::E},
-                         {"R3", "X", 3, Direction::N}};
+                         {"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E},
-                     {"R3", "X", 3, atom2, false, Direction::N}};
+                     {"R3", "S", 3, atom2, false, Direction::N}};
         exp_available = {{"R1", "N", 1, Direction::W}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
@@ -122,14 +122,14 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W},
                      {"R2", "C", 2, atom2, false, Direction::E}};
-        exp_available = {{"R3", "X", 3, Direction::N}};
+        exp_available = {{"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom2);
         exp_bound = {{"R1", "N", 1, atom1, false, Direction::W},
-                     {"R3", "X", 3, atom0, false, Direction::N}};
+                     {"R3", "S", 3, atom0, false, Direction::N}};
         exp_available = {{"R2", "C", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E},
-                     {"R3", "X", 3, atom1, true, Direction::N}};
+                     {"R3", "S", 3, atom1, true, Direction::N}};
         exp_available = {{"R1", "N", 1, Direction::W}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W},
-                     {"R3", "X", 3, atom0, true, Direction::N}};
+                     {"R3", "S", 3, atom0, true, Direction::N}};
         exp_available = {{"R2", "C", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
@@ -291,9 +291,9 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         BOOST_TEST(unbound_aps == exp_available);
     }
 
-    // an amino acid with an unrecognized attachment point (R4)
+    // an amino acid with unrecognized attachment points
     mol = rdkit_extensions::to_rdkit(
-        "PEPTIDE1{A.A}$PEPTIDE1,PEPTIDE1,1:R3-2:R4$$$V2.0");
+        "PEPTIDE1{A.A}$PEPTIDE1,PEPTIDE1,1:R4-2:R4$$$V2.0");
     prepare_mol(*mol);
     {
         atom0 = mol->getAtomWithIdx(0);
@@ -302,8 +302,9 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E},
-                     {"R3", "X", 3, atom1, true, Direction::E}};
-        exp_available = {{"R1", "N", 1, Direction::W}};
+                     {"R4", "R4", 4, atom1, true, Direction::E}};
+        exp_available = {{"R1", "N", 1, Direction::W},
+                         {"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
@@ -312,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W},
                      {"R4", "R4", 4, atom0, true, Direction::W}};
         exp_available = {{"R2", "C", 2, Direction::E},
-                         {"R3", "X", 3, Direction::N}};
+                         {"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
@@ -76,8 +76,8 @@ struct TestMonomer {
 BOOST_AUTO_TEST_CASE(test_empty_list_returns_nullptr)
 {
     std::vector<UnboundMonomericAttachmentPointItem*> empty;
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::PEPTIDE, empty);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::PEPTIDE, "A", empty);
     BOOST_TEST(result == nullptr);
 }
 
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE(test_chem_hovered_returns_min_num)
     auto* ap2 = monomer.makeAP(2);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap3, ap1, ap2};
 
-    auto* result = get_default_attachment_point(MonomerType::CHEM,
-                                                MonomerType::CHEM, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::CHEM, "LIG", MonomerType::CHEM, "LIG", items);
     BOOST_TEST(result == ap1);
 }
 
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(test_chem_hovered_prefers_numbered_over_custom_name)
     auto* ap2 = monomer.makeAP(2);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap_custom, ap2};
 
-    auto* result = get_default_attachment_point(MonomerType::CHEM,
-                                                MonomerType::CHEM, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::CHEM, "LIG", MonomerType::CHEM, "LIG", items);
     BOOST_TEST(result == ap2);
 
     // reverse the order of the attachment point list and make sure that we get
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_chem_hovered_prefers_numbered_over_custom_name)
                                                                      ap_custom};
 
     auto* result_reversed = get_default_attachment_point(
-        MonomerType::CHEM, MonomerType::CHEM, items_reversed);
+        MonomerType::CHEM, "LIG", MonomerType::CHEM, "LIG", items_reversed);
     BOOST_TEST(result_reversed == ap2);
 }
 
@@ -124,8 +124,8 @@ BOOST_AUTO_TEST_CASE(test_chem_hovered_returns_custom_name_when_only_option)
     auto* ap_custom = monomer.makeNamedAP("pair");
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap_custom};
 
-    auto* result = get_default_attachment_point(MonomerType::CHEM,
-                                                MonomerType::CHEM, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::CHEM, "LIG", MonomerType::CHEM, "LIG", items);
     BOOST_TEST(result == ap_custom);
 }
 
@@ -135,36 +135,76 @@ BOOST_AUTO_TEST_CASE(test_peptide_peptide_prefers_ap2)
     TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
     auto* ap1 = monomer.makeAP(1);
     auto* ap2 = monomer.makeAP(2);
-    auto* ap3 = monomer.makeAP(3);
-    std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2, ap3};
+    auto* ap_hbond = monomer.makeNamedAP("pair");
+    std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2, ap_hbond};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::PEPTIDE, "A", items);
     BOOST_TEST(result == ap2);
 }
 
 /// PEPTIDE hovered + PEPTIDE tool: falls back to R1 when R2 is absent
 BOOST_AUTO_TEST_CASE(test_peptide_peptide_falls_back_to_ap1)
 {
-    TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
+    TestMonomer monomer("CYS", rdkit_extensions::ChainType::PEPTIDE);
     auto* ap1 = monomer.makeAP(1);
     auto* ap3 = monomer.makeAP(3);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap3};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "C", MonomerType::PEPTIDE, "C", items);
     BOOST_TEST(result == ap1);
 }
 
-/// PEPTIDE hovered + PEPTIDE tool: falls back to R3 when R1 and R2 are absent
-BOOST_AUTO_TEST_CASE(test_peptide_peptide_falls_back_to_ap3)
+/// non-cysteine PEPTIDE hovered + non-cysteine PEPTIDE tool: default to H-bond
+/// when R1 and R2 are absent
+BOOST_AUTO_TEST_CASE(test_peptide_peptide_falls_back_to_hbond)
 {
     TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
+    auto* ap_hbond = monomer.makeNamedAP("pair");
+    std::vector<UnboundMonomericAttachmentPointItem*> items{ap_hbond};
+
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::PEPTIDE, "A", items);
+    BOOST_TEST(result == ap_hbond);
+}
+
+/// cysteine hovered + non-cysteine PEPTIDE tool: no default when R1 and R2 are
+/// absent
+BOOST_AUTO_TEST_CASE(cysteine_peptide_falls_back_to_hbond)
+{
+    TestMonomer monomer("CYS", rdkit_extensions::ChainType::PEPTIDE);
     auto* ap3 = monomer.makeAP(3);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap3};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "C", MonomerType::PEPTIDE, "A", items);
+    BOOST_TEST(result == nullptr);
+}
+
+/// non-cysteine PEPTIDE hovered + cysteine PEPTIDE tool: default to H-bond when
+/// R1 and R2 are absent
+BOOST_AUTO_TEST_CASE(peptide_cysteine_falls_back_to_hbond)
+{
+    TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
+    auto* ap_hbond = monomer.makeNamedAP("pair");
+    std::vector<UnboundMonomericAttachmentPointItem*> items{ap_hbond};
+
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::PEPTIDE, "C", items);
+    BOOST_TEST(result == ap_hbond);
+}
+
+/// cysteine hovered + cysteine tool: default to disulfide bond when R1 and R2
+/// are absent
+BOOST_AUTO_TEST_CASE(test_cysteine_cysteine)
+{
+    TestMonomer monomer("CYS", rdkit_extensions::ChainType::PEPTIDE);
+    auto* ap3 = monomer.makeAP(3);
+    std::vector<UnboundMonomericAttachmentPointItem*> items{ap3};
+
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "C", MonomerType::PEPTIDE, "C", items);
     BOOST_TEST(result == ap3);
 }
 
@@ -175,23 +215,23 @@ BOOST_AUTO_TEST_CASE(test_peptide_peptide_returns_nullptr_when_no_preferred)
     auto* ap4 = monomer.makeAP(4);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap4};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::PEPTIDE, "A", items);
     BOOST_TEST(result == nullptr);
 }
 
-/// PEPTIDE hovered + CHEM tool: returns R3
+/// cysteine hovered + CHEM tool: no default
 BOOST_AUTO_TEST_CASE(test_peptide_chem_returns_ap3)
 {
-    TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
+    TestMonomer monomer("CYS", rdkit_extensions::ChainType::PEPTIDE);
     auto* ap1 = monomer.makeAP(1);
     auto* ap2 = monomer.makeAP(2);
     auto* ap3 = monomer.makeAP(3);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2, ap3};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::CHEM, items);
-    BOOST_TEST(result == ap3);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "CYS", MonomerType::CHEM, "LIG", items);
+    BOOST_TEST(result == nullptr);
 }
 
 /// PEPTIDE hovered + CHEM tool: returns nullptr when R3 is absent
@@ -200,11 +240,12 @@ BOOST_AUTO_TEST_CASE(test_peptide_chem_returns_nullptr_when_no_ap3)
     TestMonomer monomer("ALA", rdkit_extensions::ChainType::PEPTIDE);
     auto* ap1 = monomer.makeAP(1);
     auto* ap2 = monomer.makeAP(2);
-    std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2};
+    auto* ap_hbond = monomer.makeNamedAP("pair");
+    std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2, ap_hbond};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::CHEM, items);
-    BOOST_TEST(result == nullptr);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::CHEM, "LIG", items);
+    BOOST_TEST(result == ap_hbond);
 }
 
 /// PEPTIDE hovered + unmatched tool type: returns nullptr
@@ -215,8 +256,8 @@ BOOST_AUTO_TEST_CASE(test_peptide_unmatched_tool_returns_nullptr)
     auto* ap2 = monomer.makeAP(2);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2};
 
-    auto* result = get_default_attachment_point(MonomerType::PEPTIDE,
-                                                MonomerType::NA_BASE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::PEPTIDE, "A", MonomerType::NA_BASE, "A", items);
     BOOST_TEST(result == nullptr);
 }
 
@@ -228,8 +269,8 @@ BOOST_AUTO_TEST_CASE(test_na_base_na_base_returns_pair)
     auto* ap_pair = monomer.makeNamedAP("pair");
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap_pair};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_BASE,
-                                                MonomerType::NA_BASE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_BASE, "A", MonomerType::NA_BASE, "A", items);
     BOOST_TEST(result == ap_pair);
 }
 
@@ -240,8 +281,8 @@ BOOST_AUTO_TEST_CASE(test_na_base_na_base_returns_nullptr_when_no_pair)
     auto* ap1 = monomer.makeAP(1);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_BASE,
-                                                MonomerType::NA_BASE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_BASE, "A", MonomerType::NA_BASE, "A", items);
     BOOST_TEST(result == nullptr);
 }
 
@@ -252,8 +293,8 @@ BOOST_AUTO_TEST_CASE(test_na_base_chem_returns_pair)
     auto* ap_pair = monomer.makeNamedAP("pair");
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap_pair};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_BASE,
-                                                MonomerType::CHEM, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_BASE, "A", MonomerType::CHEM, "LIG", items);
     BOOST_TEST(result == ap_pair);
 }
 
@@ -265,8 +306,8 @@ BOOST_AUTO_TEST_CASE(test_na_base_na_sugar_returns_ap1)
     auto* ap_pair = monomer.makeNamedAP("pair");
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap_pair, ap1};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_BASE,
-                                                MonomerType::NA_SUGAR, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_BASE, "A", MonomerType::NA_SUGAR, "R", items);
     BOOST_TEST(result == ap1);
 }
 
@@ -278,7 +319,7 @@ BOOST_AUTO_TEST_CASE(test_na_base_unmatched_tool_returns_nullptr)
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
     auto* result = get_default_attachment_point(
-        MonomerType::NA_BASE, MonomerType::NA_PHOSPHATE, items);
+        MonomerType::NA_BASE, "A", MonomerType::NA_PHOSPHATE, "P", items);
     BOOST_TEST(result == nullptr);
 }
 
@@ -291,8 +332,8 @@ BOOST_AUTO_TEST_CASE(test_na_sugar_na_base_returns_ap3)
     auto* ap3 = monomer.makeAP(3);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2, ap3};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_SUGAR,
-                                                MonomerType::NA_BASE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_SUGAR, "R", MonomerType::NA_BASE, "A", items);
     BOOST_TEST(result == ap3);
 }
 
@@ -305,7 +346,7 @@ BOOST_AUTO_TEST_CASE(test_na_sugar_na_phosphate_prefers_ap2)
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2};
 
     auto* result = get_default_attachment_point(
-        MonomerType::NA_SUGAR, MonomerType::NA_PHOSPHATE, items);
+        MonomerType::NA_SUGAR, "R", MonomerType::NA_PHOSPHATE, "P", items);
     BOOST_TEST(result == ap2);
 }
 
@@ -317,7 +358,7 @@ BOOST_AUTO_TEST_CASE(test_na_sugar_na_phosphate_falls_back_to_ap1)
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
     auto* result = get_default_attachment_point(
-        MonomerType::NA_SUGAR, MonomerType::NA_PHOSPHATE, items);
+        MonomerType::NA_SUGAR, "R", MonomerType::NA_PHOSPHATE, "P", items);
     BOOST_TEST(result == ap1);
 }
 
@@ -328,8 +369,8 @@ BOOST_AUTO_TEST_CASE(test_na_sugar_unmatched_tool_returns_nullptr)
     auto* ap1 = monomer.makeAP(1);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_SUGAR,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_SUGAR, "R", MonomerType::PEPTIDE, "A", items);
     BOOST_TEST(result == nullptr);
 }
 
@@ -341,8 +382,8 @@ BOOST_AUTO_TEST_CASE(test_na_phosphate_na_sugar_prefers_ap2)
     auto* ap2 = monomer.makeAP(2);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1, ap2};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_PHOSPHATE,
-                                                MonomerType::NA_SUGAR, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_PHOSPHATE, "P", MonomerType::NA_SUGAR, "R", items);
     BOOST_TEST(result == ap2);
 }
 
@@ -353,8 +394,8 @@ BOOST_AUTO_TEST_CASE(test_na_phosphate_na_sugar_falls_back_to_ap1)
     auto* ap1 = monomer.makeAP(1);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_PHOSPHATE,
-                                                MonomerType::NA_SUGAR, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_PHOSPHATE, "P", MonomerType::NA_SUGAR, "R", items);
     BOOST_TEST(result == ap1);
 }
 
@@ -365,8 +406,8 @@ BOOST_AUTO_TEST_CASE(test_na_phosphate_unmatched_tool_returns_nullptr)
     auto* ap1 = monomer.makeAP(1);
     std::vector<UnboundMonomericAttachmentPointItem*> items{ap1};
 
-    auto* result = get_default_attachment_point(MonomerType::NA_PHOSPHATE,
-                                                MonomerType::PEPTIDE, items);
+    auto* result = get_default_attachment_point(
+        MonomerType::NA_PHOSPHATE, "P", MonomerType::PEPTIDE, "A", items);
     BOOST_TEST(result == nullptr);
 }
 

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool.cpp
@@ -412,54 +412,62 @@ BOOST_AUTO_TEST_CASE(test_na_phosphate_unmatched_tool_returns_nullptr)
 }
 
 // clang-format off
-// Test data: (existing_monomer_type, existing_monomer_ap, new_monomer_type, expected_ap, description)
-const std::vector<std::tuple<MonomerType, std::string, MonomerType, std::string,
+// Test data: (existing_monomer_type, existing_monomer_ap, new_monomer_type, new_monomer_res_name, expected_ap, description)
+const std::vector<std::tuple<MonomerType, std::string, MonomerType, std::string, std::string,
                              std::string>>
     new_monomer_ap_test_data = {
         // CHEM always returns R1
-        {MonomerType::PEPTIDE, "R1", MonomerType::CHEM, "R1",
+        {MonomerType::PEPTIDE, "R1", MonomerType::CHEM, "LIG", "R1",
          "CHEM new monomer always returns R1"},
 
         // PEPTIDE onto PEPTIDE: R1 (N) -> R2 (C), R2 (C) -> R1 (N)
-        {MonomerType::PEPTIDE, "R1", MonomerType::PEPTIDE, "R2",
+        {MonomerType::PEPTIDE, "R1", MonomerType::PEPTIDE, "C", "R2",
          "PEPTIDE from PEPTIDE R1 returns R2"},
-        {MonomerType::PEPTIDE, "R2", MonomerType::PEPTIDE, "R1",
+        {MonomerType::PEPTIDE, "R2", MonomerType::PEPTIDE, "C", "R1",
          "PEPTIDE from PEPTIDE R2 returns R1"},
-        // PEPTIDE onto PEPTIDE: non-backbone AP falls through to sidechain
-        {MonomerType::PEPTIDE, "R3", MonomerType::PEPTIDE, "R3",
-         "PEPTIDE from PEPTIDE R3 returns R3 (sidechain)"},
+        // cysteine onto cysteine: form a disulfide
+        {MonomerType::PEPTIDE, "R3", MonomerType::PEPTIDE, "C", "R3",
+         "cysteine from cysteine R3 returns R3 (disulfide bond)"},
+        // cysteine onto non-cysteine: form a hydrogen bond
+        {MonomerType::PEPTIDE, "R3", MonomerType::PEPTIDE, "A", "pair",
+         "non-cysteine from cysteine R3 returns pair (hydrogen bond)"},
+        // non-cysteine onto cysteine: form a hydrogen bond
+        {MonomerType::PEPTIDE, "pair", MonomerType::PEPTIDE, "C", "pair",
+         "cysteine from non-cysteine pair returns pair (hydrogen bond)"},
         // PEPTIDE onto non-PEPTIDE: falls through to sidechain
-        {MonomerType::CHEM, "R1", MonomerType::PEPTIDE, "R3",
-         "PEPTIDE from CHEM returns R3 (sidechain)"},
+        {MonomerType::CHEM, "R1", MonomerType::PEPTIDE, "C", "pair",
+         "cysteine from CHEM returns pair"},
+        {MonomerType::CHEM, "R1", MonomerType::PEPTIDE, "A", "pair",
+         "non-cysteine PEPTIDE from CHEM returns pair"},
 
         // NA_BASE onto NA_SUGAR R3 (1') -> R1 (N1/9)
-        {MonomerType::NA_SUGAR, "R3", MonomerType::NA_BASE, "R1",
+        {MonomerType::NA_SUGAR, "R3", MonomerType::NA_BASE, "A", "R1",
          "NA_BASE from NA_SUGAR R3 returns R1"},
         // NA_BASE onto NA_SUGAR with non-matching AP -> pair
-        {MonomerType::NA_SUGAR, "R1", MonomerType::NA_BASE, "pair",
+        {MonomerType::NA_SUGAR, "R1", MonomerType::NA_BASE, "A", "pair",
          "NA_BASE from NA_SUGAR R1 returns pair"},
         // NA_BASE onto non-NA_SUGAR -> pair
-        {MonomerType::PEPTIDE, "R1", MonomerType::NA_BASE, "pair",
+        {MonomerType::PEPTIDE, "R1", MonomerType::NA_BASE, "A", "pair",
          "NA_BASE from PEPTIDE returns pair"},
 
         // NA_SUGAR onto NA_PHOSPHATE R1 (to_prev) -> R2 (3')
-        {MonomerType::NA_PHOSPHATE, "R1", MonomerType::NA_SUGAR, "R2",
+        {MonomerType::NA_PHOSPHATE, "R1", MonomerType::NA_SUGAR, "R", "R2",
          "NA_SUGAR from NA_PHOSPHATE R1 returns R2"},
         // NA_SUGAR onto NA_PHOSPHATE R2 (to_next) -> R1 (5')
-        {MonomerType::NA_PHOSPHATE, "R2", MonomerType::NA_SUGAR, "R1",
+        {MonomerType::NA_PHOSPHATE, "R2", MonomerType::NA_SUGAR, "R", "R1",
          "NA_SUGAR from NA_PHOSPHATE R2 returns R1"},
         // NA_SUGAR onto non-NA_PHOSPHATE -> R3 (1')
-        {MonomerType::NA_BASE, "R1", MonomerType::NA_SUGAR, "R3",
+        {MonomerType::NA_BASE, "R1", MonomerType::NA_SUGAR, "R", "R3",
          "NA_SUGAR from NA_BASE returns R3 (1')"},
 
         // NA_PHOSPHATE onto NA_SUGAR R2 (3') -> R1 (to_prev)
-        {MonomerType::NA_SUGAR, "R2", MonomerType::NA_PHOSPHATE, "R1",
+        {MonomerType::NA_SUGAR, "R2", MonomerType::NA_PHOSPHATE, "P", "R1",
          "NA_PHOSPHATE from NA_SUGAR R2 returns R1"},
         // NA_PHOSPHATE onto NA_SUGAR with non-matching AP -> R2 (to_next)
-        {MonomerType::NA_SUGAR, "R1", MonomerType::NA_PHOSPHATE, "R2",
+        {MonomerType::NA_SUGAR, "R1", MonomerType::NA_PHOSPHATE, "P", "R2",
          "NA_PHOSPHATE from NA_SUGAR R1 returns R2"},
         // NA_PHOSPHATE onto non-NA_SUGAR -> R2 (to_next)
-        {MonomerType::PEPTIDE, "R1", MonomerType::NA_PHOSPHATE, "R2",
+        {MonomerType::PEPTIDE, "R1", MonomerType::NA_PHOSPHATE, "P", "R2",
          "NA_PHOSPHATE from PEPTIDE returns R2"},
 };
 // clang-format on
@@ -467,10 +475,12 @@ const std::vector<std::tuple<MonomerType, std::string, MonomerType, std::string,
 BOOST_DATA_TEST_CASE(test_get_attachment_point_for_new_monomer,
                      bdata::make(new_monomer_ap_test_data),
                      existing_monomer_type, existing_monomer_ap,
-                     new_monomer_type, expected_ap, description)
+                     new_monomer_type, new_monomer_res_name, expected_ap,
+                     description)
 {
     auto result = get_attachment_point_for_new_monomer(
-        existing_monomer_type, existing_monomer_ap, new_monomer_type);
+        existing_monomer_type, existing_monomer_ap, new_monomer_type,
+        new_monomer_res_name);
     BOOST_CHECK_MESSAGE(result == expected_ap,
                         description << ": expected " << expected_ap << ", got "
                                     << result);

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
 }
 
 /**
- * Confirm that clicking on an unbounnd attachment point of an existing monomer
+ * Confirm that clicking on an unbound attachment point of an existing monomer
  * adds a new monomer via the clicked attachment point.
  */
 BOOST_AUTO_TEST_CASE(test_click_attachment_point)
@@ -82,12 +82,10 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{A}$$$$V2.0");
     auto monomer_pos = fix.getMonomerPos(0);
-    fix.setAminoAcidTool(AminoAcidTool::CYS);
-    // hover over the monomer to trigger AP label creation
-    fix.mouseMove(monomer_pos);
 
     // click on the N terminus attachment point
     fix.setAminoAcidTool(AminoAcidTool::CYS);
+    // hover over the monomer to trigger AP label creation
     fix.mouseMove(monomer_pos);
     auto n_ap_pos = fix.getAttachmentPointPos(0, "N");
     fix.mouseClick(n_ap_pos);
@@ -107,6 +105,63 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
     fix.mouseClick(x_ap_pos);
     fix.verifyHELM(
         "PEPTIDE1{C.A.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on an ALA H-bond attachment point with a CYS tool
+ * forms a hydrogen bond, not a disulfide
+ */
+BOOST_AUTO_TEST_CASE(test_click_ala_pair_with_cys)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    auto monomer_pos = fix.getMonomerPos(0);
+    // hover over the monomer to trigger AP label creation
+
+    fix.mouseMove(monomer_pos);
+    auto pair_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
+    fix.mouseClick(pair_ap_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on a CYS R3 attachment point with an ALA tool
+ * forms a hydrogen bond, not a disulfide
+ */
+BOOST_AUTO_TEST_CASE(test_click_cys_r3_with_ala)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    auto monomer_pos = fix.getMonomerPos(0);
+    // hover over the monomer to trigger AP label creation
+
+    fix.mouseMove(monomer_pos);
+    auto s_ap_pos = fix.getAttachmentPointPos(0, "S");
+    fix.mouseClick(s_ap_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+}
+
+/**
+ * Confirm that clicking on a CYS R3 attachment point with a CYS tool
+ * forms a disulfide
+ */
+BOOST_AUTO_TEST_CASE(test_click_cys_r3_with_cys)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    auto monomer_pos = fix.getMonomerPos(0);
+    // hover over the monomer to trigger AP label creation
+
+    fix.mouseMove(monomer_pos);
+    auto s_ap_pos = fix.getAttachmentPointPos(0, "S");
+    fix.mouseClick(s_ap_pos);
+    fix.verifyHELM(
+        "PEPTIDE1{C}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R3-1:R3$$$V2.0");
 }
 
 /**
@@ -385,7 +440,7 @@ BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
     // the drag should have added a new monomer with a side chain interaction
     // since we released over an invalid attachment point
     fix.verifyHELM("PEPTIDE1{C}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:R2-"
-                   "1:R2|PEPTIDE1,PEPTIDE3,1:R3-1:R3$$$V2.0");
+                   "1:R2|PEPTIDE1,PEPTIDE3,1:pair-1:pair$$$V2.0");
 }
 
 /**

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -57,8 +57,9 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_residue_mutates)
 }
 
 /**
- * Confirm that clicking on an existing monomer with a monomer tool of
- * a different monomer type has no effect.
+ * Confirm that clicking on an existing monomer with a monomer tool of a
+ * different monomer type adds an H-bond, or does nothing if there's already an
+ * H-bond.
  */
 BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
 {
@@ -67,7 +68,9 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
     auto pos = fix.getMonomerPos(0);
     fix.setNucleicAcidTool(NucleicAcidTool::P);
     fix.mouseClick(pos);
-    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{P}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+    fix.mouseClick(pos);
+    fix.verifyHELM("PEPTIDE1{A}|RNA1{P}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
 }
 
 /**
@@ -100,10 +103,10 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
     // click on the side chain attachment point
     fix.setAminoAcidTool(AminoAcidTool::TRP);
     fix.mouseMove(monomer_pos);
-    auto x_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
     fix.mouseClick(x_ap_pos);
     fix.verifyHELM(
-        "PEPTIDE1{C.A.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:R3-1:R3$$$V2.0");
+        "PEPTIDE1{C.A.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:pair-1:pair$$$V2.0");
 }
 
 /**
@@ -152,47 +155,47 @@ BOOST_AUTO_TEST_CASE(
 BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty_adds_connected_via_dragged_ap)
 {
     MonomerToolTestFixture fix;
-    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
 
     // Add initial monomer
-    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
 
     // hover over the monomer so that the attachment point graphics items are
     // created
-    auto ala_pos = fix.getMonomerPos(0);
-    fix.mouseMove(ala_pos);
+    auto cys_pos = fix.getMonomerPos(0);
+    fix.mouseMove(cys_pos);
 
     // Drag from N attachment point to empty space
     auto start_pos = fix.getAttachmentPointPos(0, "N");
     auto end_pos = start_pos + QPointF(-100, 0);
     fix.mouseDrag(start_pos, end_pos);
 
-    fix.verifyHELM("PEPTIDE1{C.A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
 
     // hover over the first monomer so that its attachment point graphics items
     // are created again
     fix.setAminoAcidTool(AminoAcidTool::PHE);
-    fix.mouseMove(ala_pos);
+    fix.mouseMove(cys_pos);
 
     // Drag from C attachment point to empty space
     start_pos = fix.getAttachmentPointPos(0, "C");
     end_pos = start_pos + QPointF(100, 100);
     fix.mouseDrag(start_pos, end_pos);
 
-    fix.verifyHELM("PEPTIDE1{C.A.F}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A.C.F}$$$$V2.0");
 
     // hover over the first monomer so that its attachment point graphics items
     // are created again
-    fix.setAminoAcidTool(AminoAcidTool::ALA);
-    fix.mouseMove(ala_pos);
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    fix.mouseMove(cys_pos);
 
     // Drag from C attachment point to empty space
-    start_pos = fix.getAttachmentPointPos(0, "X");
+    start_pos = fix.getAttachmentPointPos(0, "S");
     end_pos = start_pos + QPointF(-50, 100);
     fix.mouseDrag(start_pos, end_pos);
 
     fix.verifyHELM(
-        "PEPTIDE1{C.A.F}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,2:R3-1:R3$$$V2.0");
+        "PEPTIDE1{A.C.F}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,2:R3-1:R3$$$V2.0");
 }
 
 /**
@@ -318,18 +321,18 @@ BOOST_AUTO_TEST_CASE(test_drag_empty_to_ap_adds_connected_correct_aps)
 {
     MonomerToolTestFixture fix;
     fix.importMolText("PEPTIDE1{C}$$$$V2.0");
-    fix.setAminoAcidTool(AminoAcidTool::ALA);
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
     auto start_pos = QPointF(100, 100);
     auto monomer_pos = fix.getMonomerPos(0);
     fix.mouseMove(start_pos);
     fix.mousePress(start_pos);
     // first, drag to the existing monomer to make its attachment points appear
     fix.mouseMove(monomer_pos);
-    auto end_pos = fix.getAttachmentPointPos(0, "X");
+    auto end_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseMove(end_pos);
     fix.mouseRelease(end_pos);
     fix.verifyHELM(
-        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R3-1:R2$$$V2.0");
+        "PEPTIDE1{C}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R3-1:R2$$$V2.0");
 }
 
 /**
@@ -367,21 +370,21 @@ BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
 {
     MonomerToolTestFixture fix;
     fix.importMolText(
-        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+        "PEPTIDE1{C}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
     fix.setAminoAcidTool(AminoAcidTool::PHE);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
-    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseMove(start_ap_pos);
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
-    auto end_ap_pos = fix.getAttachmentPointPos(1, "X");
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "S");
     fix.mouseMove(end_ap_pos);
     fix.mouseRelease(end_ap_pos);
     // the drag should have added a new monomer with a side chain interaction
     // since we released over an invalid attachment point
-    fix.verifyHELM("PEPTIDE1{C}|PEPTIDE2{A}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:R2-"
+    fix.verifyHELM("PEPTIDE1{C}|PEPTIDE2{C}|PEPTIDE3{F}$PEPTIDE1,PEPTIDE2,1:R2-"
                    "1:R2|PEPTIDE1,PEPTIDE3,1:R3-1:R3$$$V2.0");
 }
 
@@ -523,7 +526,7 @@ BOOST_AUTO_TEST_CASE(test_undo_drag_end_monomer_no_crash)
 BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}|RNA1{A}$$$$V2.0");
     fix.setNucleicAcidTool(NucleicAcidTool::A);
     auto start_monomer_pos = fix.getMonomerPos(1);
     auto end_monomer_pos = fix.getMonomerPos(0);
@@ -533,7 +536,7 @@ BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
     fix.mouseRelease(end_monomer_pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
 }
 
 /**
@@ -544,17 +547,17 @@ BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
 BOOST_AUTO_TEST_CASE(test_drag_to_na_base_from_peptide)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}|RNA1{A}$$$$V2.0");
     fix.setNucleicAcidTool(NucleicAcidTool::A);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
-    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseMove(start_ap_pos);
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
     fix.mouseRelease(end_monomer_pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
 
     // click on the side chain attachment point
     fix.mouseMove(monomer_pos);
-    auto x_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
     fix.mouseClick(x_ap_pos);
     fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
 }
@@ -137,8 +137,8 @@ BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty)
     fix.mouseMove(end_pos);
     fix.mouseMove(ala_pos);
 
-    // Drag from C attachment point to empty space
-    start_pos = fix.getAttachmentPointPos(0, "X");
+    // Drag from pair attachment point to empty space
+    start_pos = fix.getAttachmentPointPos(0, "H-bond");
     end_pos = start_pos + QPointF(-50, 100);
     fix.mouseDrag(start_pos, end_pos);
 
@@ -250,21 +250,21 @@ BOOST_AUTO_TEST_CASE(test_drag_second_custom_connection)
 {
     MonomerToolTestFixture fix;
     fix.importMolText(
-        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+        "PEPTIDE1{C}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
     fix.setMonomericConnectionTool(
         MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
-    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseMove(start_ap_pos);
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
-    auto end_ap_pos = fix.getAttachmentPointPos(1, "X");
+    auto end_ap_pos = fix.getAttachmentPointPos(1, "S");
     fix.mouseMove(end_ap_pos);
     fix.mouseRelease(end_ap_pos);
     fix.verifyHELM(
-        "PEPTIDE1{C}|PEPTIDE2{A}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
+        "PEPTIDE1{C}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:R2-1:R2$$$V2.0");
 }
 
 /**
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(test_undo_drag_end_monomer_no_crash)
 BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}|RNA1{A}$$$$V2.0");
     fix.setMonomericConnectionTool(
         MonomericConnectionTool::COVALENT_OR_DISULFIDE);
     auto start_monomer_pos = fix.getMonomerPos(1);
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
     fix.mouseRelease(end_monomer_pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}|RNA1{A}$RNA1,PEPTIDE1,1:pair-1:pair$$$V2.0");
 }
 
 /**
@@ -429,17 +429,17 @@ BOOST_AUTO_TEST_CASE(test_drag_from_na_base_to_peptide)
 BOOST_AUTO_TEST_CASE(test_drag_to_na_base_from_peptide)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}|RNA1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}|RNA1{A}$$$$V2.0");
     fix.setNucleicAcidTool(NucleicAcidTool::A);
     auto start_monomer_pos = fix.getMonomerPos(0);
     auto end_monomer_pos = fix.getMonomerPos(1);
     fix.mouseMove(start_monomer_pos);
-    auto start_ap_pos = fix.getAttachmentPointPos(0, "X");
+    auto start_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseMove(start_ap_pos);
     fix.mousePress(start_ap_pos);
     fix.mouseMove(end_monomer_pos);
     fix.mouseRelease(end_monomer_pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}|RNA1{A}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
 }
 
 } // namespace sketcher


### PR DESCRIPTION
- Linked Case: SKETCH-2833

### Description

According to the HELM spec, connections between numbered attachment points are reserved for covalent or disulfide bonds.  This means that cysteine is the only natural amino acid that should normally make connections with its R3 attachment point.  This PR modifies the attachment points that show up when hovering over the other natural amino acid; they now have a "pair" AP (which is used for hydrogen bonds) instead of an R3.  I've also changed the display name for R3 from "X" to "S".

I also made an additional tweak here: when dragging from a "pair" AP to another monomer, we no longer draw attachment points on the other monomer since the drag can only form a hydrogen bond.  Previously, we would draw those attachment points, but hovering over any of them would always lead to the same hydrogen bond being drawn.  In other words, this change is purely cosmetic; it avoids drawing things that don't have any real functionality.

### Testing Done

Updated existing unit tests, added additional unit test coverage, and manually tested via the desktop app on Windows.