### PR TITLE
SKETCH-2839: Fixing monomer connection tool icons

### DIFF
--- a/src/schrodinger/sketcher/icons/monomeric_connection.svg
+++ b/src/schrodinger/sketcher/icons/monomeric_connection.svg
@@ -1,29 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<svg
-   version="1.1"
-   id="Layer_1"
-   x="0px"
-   y="0px"
-   viewBox="0 0 30 32"
-   style="enable-background:new 0 0 30 32;"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-<style
-   type="text/css"
-   id="style1">
-	.st0{fill:#666666;}
-</style>
-<g
-   id="g1">
-	<rect
-   x="4.290565"
-   y="14.508935"
-   transform="rotate(-0.03205834)"
-   class="st0"
-   width="21.399361"
-   height="2.9999104"
-   id="rect1"
-   style="stroke-width:0.99997" />
-</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 3">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #666;
+      }
+    </style>
+  </defs>
+  <g id="g1">
+    <rect id="rect1" class="cls-1" x="4" y="0" width="22" height="3"/>
+  </g>
 </svg>

--- a/src/schrodinger/sketcher/icons/monomeric_hbond.svg
+++ b/src/schrodinger/sketcher/icons/monomeric_hbond.svg
@@ -1,20 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   version="1.1"
-   id="Layer_1"
-   x="0px"
-   y="0px"
-   viewBox="0 0 30 32"
-   style="enable-background:new 0 0 30 32;"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <style
-     type="text/css"
-     id="style1">
-	.st0{fill:#666666;}
-</style>
-  <path
-     style="fill:#666666;fill-opacity:1;stroke:#666666;stroke-width:3.21968;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:5.47345612,4.02460009;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
-     d="M 2.752991,15.991204 H 27.29127"
-     id="path1" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 3">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #666;
+        stroke: #666;
+        stroke-dasharray: 4 2;
+        stroke-linejoin: bevel;
+        stroke-width: 3px;
+      }
+    </style>
+  </defs>
+  <path id="path1" class="cls-1" d="M4,1.5h22"/>
 </svg>

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -1231,6 +1231,19 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QToolButton" name="covalent_or_disulfide_btn">
        <property name="minimumSize">
         <size>
@@ -1254,6 +1267,12 @@
         <iconset resource="../sketcher.qrc">
          <normaloff>:/icons/monomeric_connection.svg</normaloff>:/icons/monomeric_connection.svg</iconset>
        </property>
+       <property name="iconSize">
+        <size>
+         <width>30</width>
+         <height>32</height>
+        </size>
+       </property>
        <property name="checkable">
         <bool>true</bool>
        </property>
@@ -1261,6 +1280,19 @@
         <string notr="true">monomeric_connection_group</string>
        </attribute>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <widget class="QToolButton" name="hbond_btn">
@@ -1285,6 +1317,12 @@
        <property name="icon">
         <iconset resource="../sketcher.qrc">
          <normaloff>:/icons/monomeric_hbond.svg</normaloff>:/icons/monomeric_hbond.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>30</width>
+         <height>32</height>
+        </size>
        </property>
        <property name="checkable">
         <bool>true</bool>


### PR DESCRIPTION
- Linked Case: SKETCH-2839

### Description

The main issue here was that the monomer_tool_widget.ui file had set the icons of the monomeric connection tools be displayed at 16x16 pixels instead of the 30x32 pixels that all of the other buttons use.  As a result, the icons were shrunk down to fit, resulting in very thin lines.  This PR fixes the UI file and replaces the icons with ones that Laura tweaked a bit.  I've also centered the two connection buttons (at Laura's request).  Here's what the side bar looks like now:

<img width="156" height="826" alt="image" src="https://github.com/user-attachments/assets/8b9a4a0a-30bc-4153-9845-ee12f9c3daf6" />

That screen shot got Laura's seal of approval on the Jira case, so these buttons should be good to go.

(Ignore the fact that GitHub says that the new versions of the icons are 300px by 30px.  GitHub is getting oddly creative with the conversion from SVG pixels to rasterized pixels, but Qt doesn't take the same liberties.)

### Testing Done

Confirmed that the buttons look correct on the Windows desktop version of the app.
