### PR TITLE
SKETCH-2845: Preventing Qt from trying to auto-apply dark mode color scheme on desktop builds

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -311,13 +311,6 @@ EMSCRIPTEN_BINDINGS(sketcher)
 
 void apply_stylesheet(QApplication& app)
 {
-    // In Qt 6.8 and newer, Qt will try to automatically apply a dark mode color
-    // scheme if the system and/or browser is set to dark mode. The result looks
-    // terrible, so switch back to light mode.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
-    QApplication::styleHints()->setColorScheme(Qt::ColorScheme::Light);
-#endif
-
     QFile styleFile(":resources/schrodinger_livedesign.qss");
     bool success = styleFile.open(QFile::ReadOnly);
     if (!success) {
@@ -338,6 +331,13 @@ int main(int argc, char** argv)
     Q_INIT_RESOURCE(sketcher);
 #endif
     QApplication::setWindowIcon(QIcon(":icons/sketcher-logo.svg"));
+
+    // In Qt 6.8 and newer, Qt will try to automatically apply a dark mode color
+    // scheme if the system and/or web browser is set to dark mode. The result
+    // looks terrible, so switch back to light mode.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    QApplication::styleHints()->setColorScheme(Qt::ColorScheme::Light);
+#endif
 
 #ifdef __EMSCRIPTEN__
     // Only apply this stylesheet for the WASM build


### PR DESCRIPTION
- Linked Case: SKETCH-2845

### Description

Now that the core suite has upgraded to Qt 6.8, I’m seeing the same behavior from SKETCH-2651 (which was WASM-only) on `$SCHRODINGER` builds of the desktop app.  The result looks considerably less terrible than the result from SKETCH-2651, but I’d hesitate to call it “good.”  This commit just moves the SKETCH-2651 fix out of its `#ifdef __EMSCRIPTEN__` block so that the fix applies to desktop builds as well.

Ethan, since Chris is out this week and this is a fairly trivial change, I'm planning to override the requirement for his approval after you approve this PR.  Let me know if you think it's worth waiting for Chris to take a look at this after R&R before merging.

### Testing Done

Tested on a Windows desktop `$SCHRODINGER` build.  Here's the screen shot before this fix:
<img width="1288" height="829" alt="image" src="https://github.com/user-attachments/assets/398b715f-2cd2-479d-b64c-18b679877018" />

and here's the screen shot after this fix:
<img width="1278" height="829" alt="image" src="https://github.com/user-attachments/assets/bb7800e3-a334-4ab9-96ee-0637ea791331" />

