### PR TITLE
SHARED-12615: fix potential dereferencing elements in an empty container

### DIFF
--- a/src/schrodinger/rdkit_extensions/fasta/to_string.cpp
+++ b/src/schrodinger/rdkit_extensions/fasta/to_string.cpp
@@ -64,7 +64,8 @@ get_property(const RDKitObject* obj, const std::string& propname)
 [[nodiscard]] static bool is_biopolymer(std::string_view polymer_id)
 {
     // PEPTIDE[0-9]* or RNA[0-9]*
-    return polymer_id.front() == 'P' || polymer_id.front() == 'R';
+    return !polymer_id.empty() &&
+           (polymer_id.front() == 'P' || polymer_id.front() == 'R');
 }
 
 [[nodiscard]] static std::string

--- a/src/schrodinger/rdkit_extensions/helm/to_string.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/to_string.cpp
@@ -92,7 +92,8 @@ namespace
             fmt::format("({})", get_property<std::string>(atom, MONOMER_LIST));
     } else {
         const auto id = get_property<std::string>(atom, ATOM_LABEL);
-        const auto& is_blob = (get_polymer_id(atom).front() == 'B');
+        const auto polymer_id = get_polymer_id(atom);
+        const auto is_blob = !polymer_id.empty() && polymer_id.front() == 'B';
         monomer_id =
             ((id.size() == 1 || is_blob) ? id : fmt::format("[{}]", id));
     }


### PR DESCRIPTION
Linked Case: SHARED-12615

Description
These are bugs found by Codex when I asked it to check the code for potential bugs.

It fixes two instances where we could potentially dereference the first instance of an empty container. I'm not sure if this is actually possible (i.e. we have guards against this in upstream code, or it's just impossible due to context), but the checks are small, and it probably doesn't hurt to add them.