### PR TITLE
SKETCH-2643: Add a Playwright test bridge for the WASM sketcher

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -17,12 +17,9 @@
 #include <utility>
 #include <vector>
 
-#include <QAbstractButton>
 #include <QApplication>
 #include <QFile>
 #include <QIcon>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QString>
 #include <QStyleHints>
 
@@ -32,6 +29,7 @@
 #include "schrodinger/rdkit_extensions/monomer_database.h"
 #include "schrodinger/sketcher/image_generation.h"
 #include "schrodinger/sketcher/sketcher_widget.h"
+#include "sketcher_instance.h"
 
 using schrodinger::rdkit_extensions::Format;
 using schrodinger::sketcher::CarbonLabels;
@@ -163,56 +161,6 @@ void sketcher_reset_custom_monomers()
     db.resetMonomerDefinitions();
 }
 
-/**
- * Programmatically click a button by its Qt objectName.
- * Used by e2e tests to interact with popup buttons that can't be targeted
- * via browser events in the WASM environment.
- *
- * Throws std::runtime_error if no button with the given name is found,
- * which typically indicates the test needs to be updated.
- */
-void sketcher_click_button(const std::string& name)
-{
-    auto& sk = get_sketcher_instance();
-    auto* button = sk.findChild<QAbstractButton*>(QString::fromStdString(name));
-    if (!button) {
-        throw std::runtime_error(
-            "sketcher_click_button: no button found with objectName '" + name +
-            "'");
-    }
-    button->click();
-}
-
-/**
- * Return the position and size of any child widget found by its Qt
- * objectName. Returns a JSON object with {x, y, width, height}.
- * Coordinates are relative to the sketcher widget's top-left corner.
- * Returns "{}" if no widget with the given name is found.
- */
-std::string sketcher_get_widget_rect(const std::string& object_name)
-{
-    auto& sk = get_sketcher_instance();
-    const QString name = QString::fromStdString(object_name);
-    QWidget* widget = nullptr;
-    const auto candidates = sk.findChildren<QWidget*>(name);
-    for (auto* w : candidates) {
-        if (w->isVisible()) {
-            widget = w;
-            break;
-        }
-    }
-    if (!widget) {
-        return "{}";
-    }
-    const QPoint topLeft = widget->mapTo(&sk, QPoint(0, 0));
-    QJsonObject result;
-    result["x"] = topLeft.x();
-    result["y"] = topLeft.y();
-    result["width"] = widget->width();
-    result["height"] = widget->height();
-    return QJsonDocument(result).toJson(QJsonDocument::Compact).toStdString();
-}
-
 void sketcher_changed()
 {
 #ifdef __EMSCRIPTEN__
@@ -302,10 +250,8 @@ EMSCRIPTEN_BINDINGS(sketcher)
                          &sketcher_insert_custom_monomers);
     emscripten::function("sketcher_reset_custom_monomers",
                          &sketcher_reset_custom_monomers);
-    emscripten::function("_sketcher_get_widget_rect",
-                         &sketcher_get_widget_rect);
-    emscripten::function("_sketcher_click_button", &sketcher_click_button);
     // see sketcher_changed_callback above
+    // the e2e test bindings are registered in playwright_test_bridge.cpp
 }
 #endif
 

--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -48,6 +48,7 @@
 #include <QGraphicsView>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QList>
 #include <QMenu>
 #include <QPoint>
 #include <QRect>
@@ -142,6 +143,10 @@ QWidget* find_visible_widget(SketcherWidget& sketcher, const QString& name)
  * held, so a test that wants such a tool has to know which button to hold.
  * Deriving that from the widget tree keeps tests from carrying a hand-written
  * map of every tool to its owning button.
+ *
+ * Should the same objectName appear in more than one popup, this returns the
+ * first owner found; name the widget unambiguously rather than relying on
+ * which one that is.
  */
 std::string popup_owner(SketcherWidget& sketcher, const std::string& name)
 {
@@ -223,7 +228,7 @@ QGraphicsItem* find_visible_item(const QGraphicsView& view, const bool is_atom,
  * "widget" only matches a visible widget, since that is what a test can click.
  * "state" matches whether or not the widget is showing and reports "visible",
  * which is how a test asserts that a shortcut selected a tool that lives in a
- * closed popup. A button also reports "checked" and "text".
+ * closed popup. A button also reports "checked", "text", and "toolTip".
  */
 std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
                         const bool visible_only)
@@ -280,6 +285,29 @@ std::string item_rect(SketcherWidget& sketcher, const bool is_atom,
 }
 
 /**
+ * Find the action matching name_or_text, or nullptr if there is none.
+ *
+ * Most menu actions are created without an objectName, so tests usually name a
+ * row by the text the user sees. An objectName match still wins over a text
+ * match anywhere in the list, so that a test naming a specific action can't be
+ * captured by an unrelated one whose label happens to collide.
+ */
+QAction* find_action(const QList<QAction*>& actions, const QString& name)
+{
+    const QString wanted = without_mnemonic(name);
+    QAction* by_text = nullptr;
+    for (auto* action : actions) {
+        if (action->objectName() == name) {
+            return action;
+        }
+        if (by_text == nullptr && without_mnemonic(action->text()) == wanted) {
+            by_text = action;
+        }
+    }
+    return by_text;
+}
+
+/**
  * Resolve a row of one open QMenu, or "" if this menu has no matching row.
  *
  * Reading action geometry is only safe once the popup is actually visible; Qt
@@ -293,20 +321,16 @@ std::string action_rect_in_menu(const QMenu& menu,
     if (!menu.isVisible()) {
         return {};
     }
-    const QString wanted = without_mnemonic(name);
-    for (auto* action : menu.actions()) {
-        if (action->objectName() != name &&
-            without_mnemonic(action->text()) != wanted) {
-            continue;
-        }
-        const QRect rect = menu.actionGeometry(action);
-        if (rect.isEmpty()) {
-            continue;
-        }
-        return rect_to_json(map_to_sketcher(menu, sketcher, rect.topLeft()),
-                            rect.size(), action->isEnabled());
+    auto* action = find_action(menu.actions(), name);
+    if (action == nullptr) {
+        return {};
     }
-    return {};
+    const QRect rect = menu.actionGeometry(action);
+    if (rect.isEmpty()) {
+        return {};
+    }
+    return rect_to_json(map_to_sketcher(menu, sketcher, rect.topLeft()),
+                        rect.size(), action->isEnabled());
 }
 
 /**
@@ -339,26 +363,19 @@ std::string menu_rect(SketcherWidget& sketcher, const std::string& value)
 
 /**
  * Trigger the QAction matching name_or_text, or return false if there is none.
- *
- * Actions are matched on objectName first and then on display text, since most
- * menu actions are created without an objectName.
  */
 bool try_activate_action(SketcherWidget& sketcher, const QString& name)
 {
-    const QString wanted = without_mnemonic(name);
-    for (auto* action : sketcher.findChildren<QAction*>()) {
-        if (action->objectName() != name &&
-            without_mnemonic(action->text()) != wanted) {
-            continue;
-        }
-        if (!action->isEnabled()) {
-            throw std::runtime_error("playwright test bridge: action '" +
-                                     name.toStdString() + "' is disabled");
-        }
-        action->trigger();
-        return true;
+    auto* action = find_action(sketcher.findChildren<QAction*>(), name);
+    if (action == nullptr) {
+        return false;
     }
-    return false;
+    if (!action->isEnabled()) {
+        throw std::runtime_error("playwright test bridge: action '" +
+                                 name.toStdString() + "' is disabled");
+    }
+    action->trigger();
+    return true;
 }
 
 } // namespace
@@ -405,10 +422,11 @@ bool try_activate_action(SketcherWidget& sketcher, const QString& name)
  * order the structure was built in, not the canonical order a format like
  * SMILES may renumber to on export.
  *
- * Returns "{}" when nothing visible matches, since there is no coordinate a
- * test could click. "enabled" reports whether Qt would accept a click there;
- * Playwright applies that check automatically to real DOM elements but has no
- * way to do so for something painted into a canvas.
+ * Returns "{}" when nothing matches: for every selector but "state:" that means
+ * nothing visible matches, since there is no coordinate a test could click.
+ * "enabled" reports whether Qt would accept a click there; Playwright applies
+ * that check automatically to real DOM elements but has no way to do so for
+ * something painted into a canvas.
  *
  * Throws std::runtime_error for a malformed selector or an unrecognized kind,
  * which indicates the test needs to be updated.

--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -1,0 +1,491 @@
+/* -------------------------------------------------------------------------
+ * Playwright-only test bridge for the WebAssembly Sketcher application.
+ *
+ * Qt/WASM paints the entire application into a single canvas element, so
+ * Playwright cannot see individual widgets or scene items in the DOM. The
+ * bridge exists to close exactly that gap and no more: sketcher_get_rect()
+ * resolves a selector to canvas coordinates, and the test then drives the
+ * application with real Playwright mouse and keyboard events. Anything a test
+ * can do with coordinates plus Playwright belongs in the JavaScript helpers,
+ * not here.
+ *
+ * A Qt::Popup widget is painted into its own canvas element, but that element
+ * is positioned over the page, so a rect mapped through global coordinates is
+ * still a clickable page coordinate. Such a widget is reached with a real mouse
+ * event like anything else.
+ *
+ * A context menu behaves the same way: the sketcher shows one with
+ * QMenu::show() rather than exec(), so it does not run a nested event loop and
+ * its rows are located with a "menu:" selector and clicked for real.
+ *
+ * A QToolButton's menu is the one exception, and sketcher_activate_action()
+ * exists for it alone: Qt does run a nested event loop while such a menu is
+ * open, which under Asyncify suspends the WebAssembly stack and stops any call
+ * into the module from completing until the menu closes. See that function.
+ *
+ * Everything here is self-contained: the functions are registered with
+ * JavaScript by the EMSCRIPTEN_BINDINGS block at the bottom, so no other
+ * translation unit refers to them. Production UI code neither calls nor depends
+ * on this interface. The bound names are underscore-prefixed to mark them
+ * test-only.
+ *
+ * Copyright Schrodinger LLC, All Rights Reserved.
+ --------------------------------------------------------------------------- */
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/bind.h>
+#endif
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <QAbstractButton>
+#include <QAction>
+#include <QApplication>
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMenu>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QWidget>
+
+#include <rdkit/GraphMol/Atom.h>
+#include <rdkit/GraphMol/Bond.h>
+
+#include "schrodinger/sketcher/molviewer/abstract_atom_or_monomer_item.h"
+#include "schrodinger/sketcher/molviewer/abstract_bond_or_connector_item.h"
+#include "schrodinger/sketcher/sketcher_widget.h"
+#include "schrodinger/sketcher/widget/tool_button_with_popup.h"
+#include "sketcher_instance.h"
+
+using schrodinger::sketcher::AbstractAtomOrMonomerItem;
+using schrodinger::sketcher::AbstractBondOrConnectorItem;
+using schrodinger::sketcher::SketcherWidget;
+using schrodinger::sketcher::ToolButtonWithPopup;
+
+namespace
+{
+
+std::string to_json(const QJsonObject& object)
+{
+    return QJsonDocument(object).toJson(QJsonDocument::Compact).toStdString();
+}
+
+QJsonObject rect_json(const QPoint& top_left, const QSize& size,
+                      const bool enabled)
+{
+    QJsonObject result;
+    result["x"] = top_left.x();
+    result["y"] = top_left.y();
+    result["width"] = size.width();
+    result["height"] = size.height();
+    result["enabled"] = enabled;
+    return result;
+}
+
+std::string rect_to_json(const QPoint& top_left, const QSize& size,
+                         const bool enabled)
+{
+    return to_json(rect_json(top_left, size, enabled));
+}
+
+/**
+ * Split a selector such as "widget:na_u_btn" or "atom:2" into its kind and
+ * value. Throws if there is no ':' separator, which indicates a test bug.
+ */
+std::pair<std::string, std::string> split_selector(const std::string& selector)
+{
+    const auto separator = selector.find(':');
+    if (separator == std::string::npos) {
+        throw std::runtime_error(
+            "playwright test bridge: malformed selector '" + selector +
+            "' (expected \"<kind>:<value>\")");
+    }
+    return {selector.substr(0, separator), selector.substr(separator + 1)};
+}
+
+/**
+ * QAction text may contain an ampersand marking its mnemonic (e.g. "Modify
+ * &All"), but tests refer to actions by the name the user sees.
+ */
+QString without_mnemonic(QString text)
+{
+    text.remove('&');
+    return text.simplified();
+}
+
+/**
+ * Find a visible child widget by objectName. Several widgets may share a name,
+ * so this returns the first visible one, or nullptr if none is visible.
+ */
+QWidget* find_visible_widget(SketcherWidget& sketcher, const QString& name)
+{
+    for (auto* widget : sketcher.findChildren<QWidget*>(name)) {
+        if (widget->isVisible()) {
+            return widget;
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * Find the button whose popup contains the named widget, or "" if the widget
+ * isn't in a popup at all.
+ *
+ * Many tools live in a popup that only appears while its button is pressed and
+ * held, so a test that wants such a tool has to know which button to hold.
+ * Deriving that from the widget tree keeps tests from carrying a hand-written
+ * map of every tool to its owning button.
+ */
+std::string popup_owner(SketcherWidget& sketcher, const std::string& name)
+{
+    const auto wanted = QString::fromStdString(name);
+    for (auto* button : sketcher.findChildren<ToolButtonWithPopup*>()) {
+        auto* popup = button->getPopupWidget();
+        if (popup != nullptr &&
+            (popup->objectName() == wanted ||
+             popup->findChild<QWidget*>(wanted) != nullptr)) {
+            return button->objectName().toStdString();
+        }
+    }
+    return {};
+}
+
+/**
+ * Map a point from some widget's coordinates into the sketcher's.
+ *
+ * This deliberately goes through global coordinates rather than using
+ * QWidget::mapTo(). A Qt::Popup (or a dialog) is a separate top-level window,
+ * and mapTo() only walks the widget hierarchy — for a window it accumulates
+ * screen coordinates partway through and returns nonsense. Going via global
+ * coordinates is correct for both cases and matches what Qt itself does for
+ * independent top-level widgets.
+ */
+QPoint map_to_sketcher(const QWidget& widget, const SketcherWidget& sketcher,
+                       const QPoint& point)
+{
+    return sketcher.mapFromGlobal(widget.mapToGlobal(point));
+}
+
+QGraphicsView& require_view(SketcherWidget& sketcher)
+{
+    auto* view = sketcher.findChild<QGraphicsView*>("view");
+    if (view == nullptr) {
+        throw std::runtime_error(
+            "playwright test bridge: no QGraphicsView named 'view'");
+    }
+    return *view;
+}
+
+/**
+ * Find the visible Scene item for the atom or bond at the given model index, or
+ * nullptr if there isn't one.
+ *
+ * The casts are dynamic_casts to the abstract base classes rather than
+ * qgraphicsitem_casts to AtomItem/BondItem, because qgraphicsitem_cast matches
+ * type() exactly and so would skip monomers and monomer connectors: those are
+ * siblings of AtomItem and BondItem, not subclasses.
+ */
+QGraphicsItem* find_visible_item(const QGraphicsView& view, const bool is_atom,
+                                 const int index)
+{
+    for (auto* item : view.scene()->items()) {
+        if (!item->isVisible()) {
+            continue;
+        }
+        if (is_atom) {
+            auto* atom_item = dynamic_cast<AbstractAtomOrMonomerItem*>(item);
+            if (atom_item != nullptr &&
+                static_cast<int>(atom_item->getAtom()->getIdx()) == index) {
+                return atom_item;
+            }
+        } else {
+            auto* bond_item = dynamic_cast<AbstractBondOrConnectorItem*>(item);
+            if (bond_item != nullptr &&
+                static_cast<int>(bond_item->getBond()->getIdx()) == index) {
+                return bond_item;
+            }
+        }
+    }
+    return nullptr;
+}
+
+/**
+ * Resolve a "widget:<objectName>" or "state:<objectName>" selector, or "{}" if
+ * nothing matches.
+ *
+ * "widget" only matches a visible widget, since that is what a test can click.
+ * "state" matches whether or not the widget is showing and reports "visible",
+ * which is how a test asserts that a shortcut selected a tool that lives in a
+ * closed popup. A button also reports "checked" and "text".
+ */
+std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
+                        const bool visible_only)
+{
+    const auto object_name = QString::fromStdString(name);
+    auto* widget = find_visible_widget(sketcher, object_name);
+    if (widget == nullptr) {
+        if (visible_only) {
+            return "{}";
+        }
+        widget = sketcher.findChild<QWidget*>(object_name);
+        if (widget == nullptr) {
+            return "{}";
+        }
+    }
+    auto result = rect_json(map_to_sketcher(*widget, sketcher, QPoint(0, 0)),
+                            widget->size(), widget->isEnabled());
+    if (!visible_only) {
+        result["visible"] = widget->isVisible();
+    }
+    if (auto* button = qobject_cast<QAbstractButton*>(widget)) {
+        result["checked"] = button->isChecked();
+        result["text"] = without_mnemonic(button->text());
+        result["toolTip"] = button->toolTip();
+    }
+    return to_json(result);
+}
+
+/**
+ * Resolve an "atom:<index>" or "bond:<index>" selector, or "{}" if no visible
+ * item matches. Scene items are QGraphicsItems rather than QWidgets, so they
+ * can't be found by objectName; their bounding rect is mapped through the View
+ * transform instead.
+ */
+std::string item_rect(SketcherWidget& sketcher, const bool is_atom,
+                      const std::string& value)
+{
+    bool is_number = false;
+    const int index = QString::fromStdString(value).toInt(&is_number);
+    if (!is_number) {
+        throw std::runtime_error("playwright test bridge: '" + value +
+                                 "' is not a valid item index");
+    }
+    auto& view = require_view(sketcher);
+    auto* item = find_visible_item(view, is_atom, index);
+    if (item == nullptr) {
+        return "{}";
+    }
+    const QRect viewport_rect =
+        view.mapFromScene(item->sceneBoundingRect()).boundingRect();
+    return rect_to_json(
+        map_to_sketcher(*view.viewport(), sketcher, viewport_rect.topLeft()),
+        viewport_rect.size(), item->isEnabled());
+}
+
+/**
+ * Resolve a row of one open QMenu, or "" if this menu has no matching row.
+ *
+ * Reading action geometry is only safe once the popup is actually visible; Qt
+ * has not laid the rows out before that, and on WASM touching a menu's
+ * internals mid-show aborts the runtime.
+ */
+std::string action_rect_in_menu(const QMenu& menu,
+                                const SketcherWidget& sketcher,
+                                const QString& name)
+{
+    if (!menu.isVisible()) {
+        return {};
+    }
+    const QString wanted = without_mnemonic(name);
+    for (auto* action : menu.actions()) {
+        if (action->objectName() != name &&
+            without_mnemonic(action->text()) != wanted) {
+            continue;
+        }
+        const QRect rect = menu.actionGeometry(action);
+        if (rect.isEmpty()) {
+            continue;
+        }
+        return rect_to_json(map_to_sketcher(menu, sketcher, rect.topLeft()),
+                            rect.size(), action->isEnabled());
+    }
+    return {};
+}
+
+/**
+ * Resolve a "menu:<objectName or text>" selector against whichever menus are
+ * open, or "{}" if none of them has a matching row.
+ *
+ * The active popup is tried first. With a submenu open Qt reports the deepest
+ * one, which is both the menu a human pointer event would reach next and the
+ * disambiguation this needs, since the same label can appear at more than one
+ * level of a nested menu.
+ */
+std::string menu_rect(SketcherWidget& sketcher, const std::string& value)
+{
+    const auto name = QString::fromStdString(value);
+    if (auto* active =
+            qobject_cast<QMenu*>(QApplication::activePopupWidget())) {
+        if (const auto result = action_rect_in_menu(*active, sketcher, name);
+            !result.empty()) {
+            return result;
+        }
+    }
+    for (auto* menu : sketcher.findChildren<QMenu*>()) {
+        if (const auto result = action_rect_in_menu(*menu, sketcher, name);
+            !result.empty()) {
+            return result;
+        }
+    }
+    return "{}";
+}
+
+/**
+ * Trigger the QAction matching name_or_text, or return false if there is none.
+ *
+ * Actions are matched on objectName first and then on display text, since most
+ * menu actions are created without an objectName.
+ */
+bool try_activate_action(SketcherWidget& sketcher, const QString& name)
+{
+    const QString wanted = without_mnemonic(name);
+    for (auto* action : sketcher.findChildren<QAction*>()) {
+        if (action->objectName() != name &&
+            without_mnemonic(action->text()) != wanted) {
+            continue;
+        }
+        if (!action->isEnabled()) {
+            throw std::runtime_error("playwright test bridge: action '" +
+                                     name.toStdString() + "' is disabled");
+        }
+        action->trigger();
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+// The functions below deliberately have external linkage even though nothing
+// else refers to them: the EMSCRIPTEN_BINDINGS block is compiled out on desktop
+// builds, and file-local functions would then trip -Wunused-function under
+// -Werror. Compiling them everywhere means the non-WASM CI jobs still catch
+// errors here.
+
+/**
+ * Resolve an object selector to its position and size on the canvas, as
+ * {"x":…, "y":…, "width":…, "height":…, "enabled":…}. Coordinates are relative
+ * to the sketcher widget's top-left corner, which is also the top-left of the
+ * WASM canvas, so tests can use them directly as page coordinates.
+ *
+ * Supported selectors:
+ *
+ *   "widget:<objectName>"  a visible QWidget, by its Qt objectName
+ *   "state:<objectName>"   the same, but matching a hidden widget too
+ *   "atom:<index>"         an atom of the current molecule, by model index
+ *   "bond:<index>"         a bond of the current molecule, by model index
+ *   "menu:<name or text>"  a row of an open context menu, by objectName or text
+ *
+ * Use "widget:" to find something to click, since only a visible widget can be
+ * clicked. Use "state:" to ask whether a control is checked or enabled when it
+ * may be out of sight, such as a tool inside a closed popup; it adds "visible"
+ * to the result. A button of either kind also reports "checked", "text", and
+ * "toolTip".
+ *
+ * A "menu:" selector only resolves while the menu is on screen, so open the
+ * menu first. It does not reach a QToolButton's menu, which cannot be open and
+ * queried at the same time; use sketcher_activate_action() for those rows.
+ *
+ * Monomers are addressed as "atom" and monomer connectors as "bond", since the
+ * model stores them as RDKit atoms and bonds. Every atom has a non-empty
+ * bounding rect even when its label isn't painted (an unlabeled carbon, say),
+ * because the rect is built from the predictive highlighting path, so the
+ * returned rect is always a usable click target.
+ *
+ * Model indices are indices into the molecule returned by
+ * SketcherWidget::getRDKitMolecule(). That molecule is a plain copy of the one
+ * the scene items are built from, so the indices agree; note that this is the
+ * order the structure was built in, not the canonical order a format like
+ * SMILES may renumber to on export.
+ *
+ * Returns "{}" when nothing visible matches, since there is no coordinate a
+ * test could click. "enabled" reports whether Qt would accept a click there;
+ * Playwright applies that check automatically to real DOM elements but has no
+ * way to do so for something painted into a canvas.
+ *
+ * Throws std::runtime_error for a malformed selector or an unrecognized kind,
+ * which indicates the test needs to be updated.
+ */
+std::string sketcher_get_rect(const std::string& selector)
+{
+    const auto [kind, value] = split_selector(selector);
+    auto& sketcher = get_sketcher_instance();
+    if (kind == "widget" || kind == "state") {
+        return widget_rect(sketcher, value, kind == "widget");
+    }
+    if (kind == "atom" || kind == "bond") {
+        return item_rect(sketcher, kind == "atom", value);
+    }
+    if (kind == "menu") {
+        return menu_rect(sketcher, value);
+    }
+    throw std::runtime_error(
+        "playwright test bridge: unrecognized selector kind '" + kind +
+        "' (expected 'widget', 'state', 'atom', 'bond', or 'menu')");
+}
+
+/**
+ * Trigger a menu action by objectName or visible text, without opening the menu
+ * it belongs to. Mnemonic ampersands are ignored when comparing text.
+ *
+ * This exists because a menu row cannot be clicked the way every other control
+ * can. The menu belongs to a QToolButton, and Qt runs a nested event loop for
+ * as long as that menu is open. Qt/WASM is built with Asyncify, so that nested
+ * loop leaves the WebAssembly stack suspended, and no further call into the
+ * module completes until the menu closes — sketcher_get_rect() included. A test
+ * therefore cannot ask where a menu row is while the menu is showing, which
+ * leaves triggering the action directly as the only way to reach it.
+ *
+ * Note what this gives up: the menu never opens, so nothing here covers the
+ * menu's own layout or hit-testing, only the action's effect. Controls outside
+ * a menu — including those in Qt::Popup widgets, which do not run a nested
+ * event loop — should still be clicked with real mouse events.
+ *
+ * Throws std::runtime_error if nothing matches, or if the match is disabled.
+ * Triggering skips the enabled check a real mouse event goes through, so
+ * refusing here keeps a test from passing against a row the user could not have
+ * activated.
+ */
+void sketcher_activate_action(const std::string& name_or_text)
+{
+    auto& sketcher = get_sketcher_instance();
+    if (!try_activate_action(sketcher, QString::fromStdString(name_or_text))) {
+        throw std::runtime_error(
+            "playwright test bridge: no action found matching '" +
+            name_or_text + "'");
+    }
+}
+
+/**
+ * Return the objectName of the button whose popup holds the named widget, or an
+ * empty string if it isn't in a popup.
+ *
+ * A test uses this to find the button it has to press and hold before a tool
+ * becomes visible and clickable.
+ */
+std::string sketcher_get_popup_owner(const std::string& name)
+{
+    return popup_owner(get_sketcher_instance(), name);
+}
+
+#ifdef __EMSCRIPTEN__
+// A second bindings block alongside the one in main.cpp; embind allows any
+// number of them as long as each has a distinct name. This object file is
+// linked directly into the executable rather than through a static library, so
+// the registrations always run.
+EMSCRIPTEN_BINDINGS(sketcher_playwright_test_bridge)
+{
+    emscripten::function("_sketcher_get_rect", &sketcher_get_rect);
+    emscripten::function("_sketcher_activate_action",
+                         &sketcher_activate_action);
+    emscripten::function("_sketcher_get_popup_owner",
+                         &sketcher_get_popup_owner);
+}
+#endif

--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -256,16 +256,15 @@ QGraphicsItem* find_visible_item(const QGraphicsView& view,
  * @param name the objectName to look for
  * @param visible_only if true, only a widget that is currently showing counts
  * as a match; if false, a hidden widget matches too and the result carries an
- * extra "visible" entry
+ * extra "visible" entry. Either way a visible widget is preferred when several
+ * share the objectName, as documented on sketcher_get_rect(); only when none is
+ * visible does a false visible_only fall back to a hidden one.
  * @return the JSON object described by sketcher_get_rect(), or "{}" if no
  * widget matches
  */
 std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
                         const bool visible_only)
 {
-    // Several widgets can share an objectName, so a visible one wins: it is the
-    // only match a test could click, and it is the one a test means when a
-    // duplicate happens to be showing.
     const auto object_name = QString::fromStdString(name);
     auto* widget = find_visible_widget(sketcher, object_name);
     if (widget == nullptr && !visible_only) {
@@ -450,6 +449,13 @@ std::string menu_rect(SketcherWidget& sketcher, const std::string& value)
  * clicked. Use "state:" to ask whether a control is checked or enabled when it
  * may be out of sight, such as a tool inside a closed popup; it adds "visible"
  * to the result.
+ *
+ * Several widgets may share an objectName, and a visible one is deliberately
+ * preferred: it is the only match "widget:" can return, and it is the one a
+ * "state:" query means when a duplicate happens to be showing. "state:" falls
+ * back to the first widget in the tree only when none of them is visible, so a
+ * test that has to distinguish two same-named widgets should name them
+ * unambiguously rather than rely on which one it gets.
  *
  * A widget of either kind whose text the user can read also reports it as
  * "text": a button's or label's text, a combo box's current item, or the

--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -19,8 +19,8 @@
  * its rows are located with a "menu:" selector and clicked for real.
  *
  * A QToolButton's menu is the one exception, and sketcher_activate_action()
- * exists for it alone: Qt does run a nested event loop while such a menu is
- * open, which under Asyncify suspends the WebAssembly stack and stops any call
+ * exists for it alone: Qt runs a nested event loop while such a menu is open,
+ * which under Asyncify suspends the WebAssembly stack and stops any call
  * into the module from completing until the menu closes. See that function.
  *
  * Everything here is self-contained: the functions are registered with
@@ -65,17 +65,29 @@
 
 #include "schrodinger/sketcher/molviewer/abstract_atom_or_monomer_item.h"
 #include "schrodinger/sketcher/molviewer/abstract_bond_or_connector_item.h"
+#include "schrodinger/sketcher/molviewer/constants.h"
+#include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/sketcher_widget.h"
 #include "schrodinger/sketcher/widget/tool_button_with_popup.h"
 #include "sketcher_instance.h"
 
 using schrodinger::sketcher::AbstractAtomOrMonomerItem;
 using schrodinger::sketcher::AbstractBondOrConnectorItem;
+using schrodinger::sketcher::InteractiveItemFlagType;
+using schrodinger::sketcher::Scene;
 using schrodinger::sketcher::SketcherWidget;
 using schrodinger::sketcher::ToolButtonWithPopup;
+namespace InteractiveItemFlag = schrodinger::sketcher::InteractiveItemFlag;
 
 namespace
 {
+
+/**
+ * Whether a selector addresses an atom or a bond. Monomers are addressed as
+ * atoms and monomer connectors as bonds, since the model stores them as RDKit
+ * atoms and bonds.
+ */
+enum class AtomOrBond { ATOM, BOND };
 
 std::string to_json(const QJsonObject& object)
 {
@@ -192,71 +204,85 @@ QGraphicsView& require_view(SketcherWidget& sketcher)
     return *view;
 }
 
+Scene& require_scene(const QGraphicsView& view)
+{
+    auto* scene = qobject_cast<Scene*>(view.scene());
+    if (scene == nullptr) {
+        throw std::runtime_error(
+            "playwright test bridge: the view holds no sketcher Scene");
+    }
+    return *scene;
+}
+
 /**
  * Find the visible Scene item for the atom or bond at the given model index, or
  * nullptr if there isn't one.
  *
- * The casts are dynamic_casts to the abstract base classes rather than
- * qgraphicsitem_casts to AtomItem/BondItem, because qgraphicsitem_cast matches
- * type() exactly and so would skip monomers and monomer connectors: those are
- * siblings of AtomItem and BondItem, not subclasses.
+ * Asking the Scene for its interactive items of the requested kind keeps
+ * transient graphics — a predictive highlight shown on hover, say — from being
+ * mistaken for the atom or bond itself. Every item the Scene returns for these
+ * two flags derives from the corresponding abstract base, so the cast always
+ * succeeds.
  */
-QGraphicsItem* find_visible_item(const QGraphicsView& view, const bool is_atom,
-                                 const int index)
+QGraphicsItem* find_visible_item(const QGraphicsView& view,
+                                 const AtomOrBond kind, const int index)
 {
-    for (auto* item : view.scene()->items()) {
+    const auto is_atom = kind == AtomOrBond::ATOM;
+    const InteractiveItemFlagType flags =
+        is_atom ? InteractiveItemFlag::ATOM_OR_MONOMER
+                : InteractiveItemFlag::BOND_OR_CONNECTOR;
+    for (auto* item : require_scene(view).getInteractiveItems(flags)) {
         if (!item->isVisible()) {
             continue;
         }
-        if (is_atom) {
-            auto* atom_item = dynamic_cast<AbstractAtomOrMonomerItem*>(item);
-            if (atom_item != nullptr &&
-                static_cast<int>(atom_item->getAtom()->getIdx()) == index) {
-                return atom_item;
-            }
-        } else {
-            auto* bond_item = dynamic_cast<AbstractBondOrConnectorItem*>(item);
-            if (bond_item != nullptr &&
-                static_cast<int>(bond_item->getBond()->getIdx()) == index) {
-                return bond_item;
-            }
+        const auto item_index =
+            is_atom ? static_cast<AbstractAtomOrMonomerItem*>(item)
+                          ->getAtom()
+                          ->getIdx()
+                    : static_cast<AbstractBondOrConnectorItem*>(item)
+                          ->getBond()
+                          ->getIdx();
+        if (static_cast<int>(item_index) == index) {
+            return item;
         }
     }
     return nullptr;
 }
 
 /**
- * Resolve a "widget:<objectName>" or "state:<objectName>" selector, or "{}" if
- * nothing matches.
+ * Find a child widget by objectName and report its geometry and state as JSON.
  *
- * "widget" only matches a visible widget, since that is what a test can click.
- * "state" matches whether or not the widget is showing and reports "visible",
- * which is how a test asserts that a shortcut selected a tool that lives in a
- * closed popup. A widget whose text the user can read reports it as "text", and
- * a button also reports "checked" and "toolTip".
+ * @param sketcher the widget tree to search
+ * @param name the objectName to look for
+ * @param visible_only if true, only a widget that is currently showing counts
+ * as a match; if false, a hidden widget matches too and the result carries an
+ * extra "visible" entry
+ * @return the JSON object described by sketcher_get_rect(), or "{}" if no
+ * widget matches
  */
 std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
                         const bool visible_only)
 {
+    // Several widgets can share an objectName, so a visible one wins: it is the
+    // only match a test could click, and it is the one a test means when a
+    // duplicate happens to be showing.
     const auto object_name = QString::fromStdString(name);
     auto* widget = find_visible_widget(sketcher, object_name);
-    if (widget == nullptr) {
-        if (visible_only) {
-            return "{}";
-        }
+    if (widget == nullptr && !visible_only) {
         widget = sketcher.findChild<QWidget*>(object_name);
-        if (widget == nullptr) {
-            return "{}";
-        }
+    }
+    if (widget == nullptr) {
+        return "{}";
     }
     auto result = rect_json(map_to_sketcher(*widget, sketcher, QPoint(0, 0)),
                             widget->size(), widget->isEnabled());
     if (!visible_only) {
         result["visible"] = widget->isVisible();
     }
-    // A caption is chrome, so it is normalized the way the user reads it; a
-    // value the user typed or chose is reported verbatim, since a test that
-    // sets a field and reads it back has to see exactly what it wrote.
+    // A label the application painted is chrome, so it is normalized the way
+    // the user reads it; a value the user typed or chose is reported verbatim,
+    // since a test that sets a field and reads it back has to see exactly what
+    // it wrote.
     if (auto* button = qobject_cast<QAbstractButton*>(widget)) {
         result["checked"] = button->isChecked();
         result["text"] = without_mnemonic(button->text());
@@ -274,22 +300,31 @@ std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
 }
 
 /**
- * Resolve an "atom:<index>" or "bond:<index>" selector, or "{}" if no visible
- * item matches. Scene items are QGraphicsItems rather than QWidgets, so they
- * can't be found by objectName; their bounding rect is mapped through the View
- * transform instead.
+ * Find the Scene item for an atom or bond and report its geometry as JSON.
+ *
+ * Scene items are QGraphicsItems rather than QWidgets, so they can't be found
+ * by objectName; their bounding rect is mapped through the View transform
+ * instead.
+ *
+ * @param sketcher the sketcher whose Scene to search
+ * @param kind whether to look for an atom or a bond
+ * @param index the item's model index, as the decimal string taken from the
+ * selector
+ * @return the JSON object described by sketcher_get_rect(), or "{}" if no
+ * visible item matches
+ * @throw std::runtime_error if index isn't an integer
  */
-std::string item_rect(SketcherWidget& sketcher, const bool is_atom,
-                      const std::string& value)
+std::string item_rect(SketcherWidget& sketcher, const AtomOrBond kind,
+                      const std::string& index_string)
 {
     bool is_number = false;
-    const int index = QString::fromStdString(value).toInt(&is_number);
+    const int index = QString::fromStdString(index_string).toInt(&is_number);
     if (!is_number) {
-        throw std::runtime_error("playwright test bridge: '" + value +
+        throw std::runtime_error("playwright test bridge: '" + index_string +
                                  "' is not a valid item index");
     }
     auto& view = require_view(sketcher);
-    auto* item = find_visible_item(view, is_atom, index);
+    auto* item = find_visible_item(view, kind, index);
     if (item == nullptr) {
         return "{}";
     }
@@ -301,19 +336,21 @@ std::string item_rect(SketcherWidget& sketcher, const bool is_atom,
 }
 
 /**
- * Find the action matching name_or_text, or nullptr if there is none.
+ * Find the action matching name_or_text in the list of actions, or nullptr if
+ * there is none.
  *
  * Most menu actions are created without an objectName, so tests usually name a
  * row by the text the user sees. An objectName match still wins over a text
  * match anywhere in the list, so that a test naming a specific action can't be
  * captured by an unrelated one whose label happens to collide.
  */
-QAction* find_action(const QList<QAction*>& actions, const QString& name)
+QAction* find_action(const QList<QAction*>& actions,
+                     const QString& name_or_text)
 {
-    const QString wanted = without_mnemonic(name);
+    const QString wanted = without_mnemonic(name_or_text);
     QAction* by_text = nullptr;
     for (auto* action : actions) {
-        if (action->objectName() == name) {
+        if (action->objectName() == name_or_text) {
             return action;
         }
         if (by_text == nullptr && without_mnemonic(action->text()) == wanted) {
@@ -324,20 +361,28 @@ QAction* find_action(const QList<QAction*>& actions, const QString& name)
 }
 
 /**
- * Resolve a row of one open QMenu, or "" if this menu has no matching row.
+ * Resolve a row of one open QMenu.
  *
  * Reading action geometry is only safe once the popup is actually visible; Qt
  * has not laid the rows out before that, and on WASM touching a menu's
  * internals mid-show aborts the runtime.
+ *
+ * @param menu the menu to search
+ * @param sketcher the widget the returned coordinates are relative to
+ * @param name_or_text the row's objectName or its visible text
+ * @return the JSON object described by sketcher_get_rect(), or an empty string
+ * — not the "{}" that the bound functions return — if this menu is closed or
+ * has no such row, so that menu_rect() can tell "no match here" from a match
+ * and go on to the next menu
  */
 std::string action_rect_in_menu(const QMenu& menu,
                                 const SketcherWidget& sketcher,
-                                const QString& name)
+                                const QString& name_or_text)
 {
     if (!menu.isVisible()) {
         return {};
     }
-    auto* action = find_action(menu.actions(), name);
+    auto* action = find_action(menu.actions(), name_or_text);
     if (action == nullptr) {
         return {};
     }
@@ -360,38 +405,23 @@ std::string action_rect_in_menu(const QMenu& menu,
  */
 std::string menu_rect(SketcherWidget& sketcher, const std::string& value)
 {
-    const auto name = QString::fromStdString(value);
+    const auto name_or_text = QString::fromStdString(value);
     if (auto* active =
             qobject_cast<QMenu*>(QApplication::activePopupWidget())) {
-        if (const auto result = action_rect_in_menu(*active, sketcher, name);
+        if (const auto result =
+                action_rect_in_menu(*active, sketcher, name_or_text);
             !result.empty()) {
             return result;
         }
     }
     for (auto* menu : sketcher.findChildren<QMenu*>()) {
-        if (const auto result = action_rect_in_menu(*menu, sketcher, name);
+        if (const auto result =
+                action_rect_in_menu(*menu, sketcher, name_or_text);
             !result.empty()) {
             return result;
         }
     }
     return "{}";
-}
-
-/**
- * Trigger the QAction matching name_or_text, or return false if there is none.
- */
-bool try_activate_action(SketcherWidget& sketcher, const QString& name)
-{
-    auto* action = find_action(sketcher.findChildren<QAction*>(), name);
-    if (action == nullptr) {
-        return false;
-    }
-    if (!action->isEnabled()) {
-        throw std::runtime_error("playwright test bridge: action '" +
-                                 name.toStdString() + "' is disabled");
-    }
-    action->trigger();
-    return true;
 }
 
 } // namespace
@@ -422,11 +452,11 @@ bool try_activate_action(SketcherWidget& sketcher, const QString& name)
  * to the result.
  *
  * A widget of either kind whose text the user can read also reports it as
- * "text": a button's or label's caption, a combo box's current item, or the
- * contents of a line edit or spin box. A caption is reported the way it is
- * painted, with any mnemonic ampersand and surrounding whitespace removed,
- * while a value the user typed or chose is reported verbatim. A button
- * additionally reports "checked" and "toolTip".
+ * "text": a button's or label's text, a combo box's current item, or the
+ * contents of a line edit or spin box. Text the application painted is reported
+ * the way it appears on screen, with any mnemonic ampersand and surrounding
+ * whitespace removed, while a value the user typed or chose is reported
+ * verbatim. A button additionally reports "checked" and "toolTip".
  *
  * A "menu:" selector only resolves while the menu is on screen, so open the
  * menu first. It does not reach a QToolButton's menu, which cannot be open and
@@ -461,7 +491,9 @@ std::string sketcher_get_rect(const std::string& selector)
         return widget_rect(sketcher, value, kind == "widget");
     }
     if (kind == "atom" || kind == "bond") {
-        return item_rect(sketcher, kind == "atom", value);
+        return item_rect(sketcher,
+                         kind == "atom" ? AtomOrBond::ATOM : AtomOrBond::BOND,
+                         value);
     }
     if (kind == "menu") {
         return menu_rect(sketcher, value);
@@ -496,11 +528,18 @@ std::string sketcher_get_rect(const std::string& selector)
 void sketcher_activate_action(const std::string& name_or_text)
 {
     auto& sketcher = get_sketcher_instance();
-    if (!try_activate_action(sketcher, QString::fromStdString(name_or_text))) {
+    auto* action = find_action(sketcher.findChildren<QAction*>(),
+                               QString::fromStdString(name_or_text));
+    if (action == nullptr) {
         throw std::runtime_error(
             "playwright test bridge: no action found matching '" +
             name_or_text + "'");
     }
+    if (!action->isEnabled()) {
+        throw std::runtime_error("playwright test bridge: action '" +
+                                 name_or_text + "' is disabled");
+    }
+    action->trigger();
 }
 
 /**

--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -41,13 +41,17 @@
 #include <utility>
 
 #include <QAbstractButton>
+#include <QAbstractSpinBox>
 #include <QAction>
 #include <QApplication>
+#include <QComboBox>
 #include <QGraphicsItem>
 #include <QGraphicsScene>
 #include <QGraphicsView>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLabel>
+#include <QLineEdit>
 #include <QList>
 #include <QMenu>
 #include <QPoint>
@@ -228,7 +232,8 @@ QGraphicsItem* find_visible_item(const QGraphicsView& view, const bool is_atom,
  * "widget" only matches a visible widget, since that is what a test can click.
  * "state" matches whether or not the widget is showing and reports "visible",
  * which is how a test asserts that a shortcut selected a tool that lives in a
- * closed popup. A button also reports "checked", "text", and "toolTip".
+ * closed popup. A widget whose text the user can read reports it as "text", and
+ * a button also reports "checked" and "toolTip".
  */
 std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
                         const bool visible_only)
@@ -249,10 +254,21 @@ std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
     if (!visible_only) {
         result["visible"] = widget->isVisible();
     }
+    // A caption is chrome, so it is normalized the way the user reads it; a
+    // value the user typed or chose is reported verbatim, since a test that
+    // sets a field and reads it back has to see exactly what it wrote.
     if (auto* button = qobject_cast<QAbstractButton*>(widget)) {
         result["checked"] = button->isChecked();
         result["text"] = without_mnemonic(button->text());
         result["toolTip"] = button->toolTip();
+    } else if (auto* label = qobject_cast<QLabel*>(widget)) {
+        result["text"] = without_mnemonic(label->text());
+    } else if (auto* combo_box = qobject_cast<QComboBox*>(widget)) {
+        result["text"] = combo_box->currentText();
+    } else if (auto* line_edit = qobject_cast<QLineEdit*>(widget)) {
+        result["text"] = line_edit->text();
+    } else if (auto* spin_box = qobject_cast<QAbstractSpinBox*>(widget)) {
+        result["text"] = spin_box->text();
     }
     return to_json(result);
 }
@@ -403,8 +419,14 @@ bool try_activate_action(SketcherWidget& sketcher, const QString& name)
  * Use "widget:" to find something to click, since only a visible widget can be
  * clicked. Use "state:" to ask whether a control is checked or enabled when it
  * may be out of sight, such as a tool inside a closed popup; it adds "visible"
- * to the result. A button of either kind also reports "checked", "text", and
- * "toolTip".
+ * to the result.
+ *
+ * A widget of either kind whose text the user can read also reports it as
+ * "text": a button's or label's caption, a combo box's current item, or the
+ * contents of a line edit or spin box. A caption is reported the way it is
+ * painted, with any mnemonic ampersand and surrounding whitespace removed,
+ * while a value the user typed or chose is reported verbatim. A button
+ * additionally reports "checked" and "toolTip".
  *
  * A "menu:" selector only resolves while the menu is on screen, so open the
  * menu first. It does not reach a QToolButton's menu, which cannot be open and

--- a/src/app/sketcher_instance.h
+++ b/src/app/sketcher_instance.h
@@ -1,0 +1,20 @@
+/* -------------------------------------------------------------------------
+ * Access to the application's single SketcherWidget.
+ *
+ * Defined in main.cpp; declared here so that other translation units in the
+ * app can reach the instance without duplicating the declaration.
+ *
+ * Copyright Schrodinger LLC, All Rights Reserved.
+ --------------------------------------------------------------------------- */
+
+#pragma once
+
+namespace schrodinger
+{
+namespace sketcher
+{
+class SketcherWidget;
+} // namespace sketcher
+} // namespace schrodinger
+
+schrodinger::sketcher::SketcherWidget& get_sketcher_instance();

--- a/src/app/sketcher_instance.h
+++ b/src/app/sketcher_instance.h
@@ -3,8 +3,6 @@
  *
  * Defined in main.cpp; declared here so that other translation units in the
  * app can reach the instance without duplicating the declaration.
- *
- * Copyright Schrodinger LLC, All Rights Reserved.
  --------------------------------------------------------------------------- */
 
 #pragma once

--- a/src/schrodinger/sketcher/widget/tool_button_with_popup.h
+++ b/src/schrodinger/sketcher/widget/tool_button_with_popup.h
@@ -124,9 +124,6 @@ class SKETCHER_API ToolButtonWithPopup : public QToolButton
 
   private:
     QTimer* m_popup_timer = nullptr;
-    // The Playwright tests hold a button down for POPUP_HOLD_MS (see
-    // test/wasm/e2e/e2e_helpers.js) to open its popup, so raise that value to
-    // stay clear of this one if this default grows.
     float m_popup_delay = 250;
     bool m_show_popup_indicator = true;
     bool m_show_popup_indicator_on_hover = false;

--- a/src/schrodinger/sketcher/widget/tool_button_with_popup.h
+++ b/src/schrodinger/sketcher/widget/tool_button_with_popup.h
@@ -124,6 +124,9 @@ class SKETCHER_API ToolButtonWithPopup : public QToolButton
 
   private:
     QTimer* m_popup_timer = nullptr;
+    // The Playwright tests hold a button down for POPUP_HOLD_MS (see
+    // test/wasm/e2e/e2e_helpers.js) to open its popup, so raise that value to
+    // stay clear of this one if this default grows.
     float m_popup_delay = 250;
     bool m_show_popup_indicator = true;
     bool m_show_popup_indicator_on_hover = false;

--- a/test/wasm/e2e/analog.test.js
+++ b/test/wasm/e2e/analog.test.js
@@ -5,7 +5,6 @@ import {
   getExportedHelm,
   selectAll,
   clickWidget,
-  clickPopupButton,
 } from './e2e_helpers.js';
 
 test.beforeEach(async ({ page }) => {
@@ -35,9 +34,10 @@ test.describe('Amino Acid Analog Tests', () => {
     // Click alanine to activate it (checks the button)
     await clickWidget(page, 'ala_btn');
 
-    // Select the dA analog via the C++ API (popup buttons can't be
-    // targeted by Playwright in WASM — see clickPopupButton helper).
-    await clickPopupButton(page, 'analog_dA_btn');
+    // The analog buttons live in a Qt::Popup, which is its own top-level
+    // window. The bridge maps its rect through global coordinates, so this is
+    // an ordinary click.
+    await clickWidget(page, 'analog_dA_btn');
 
     // Place the analog on canvas
     const center = await getDrawingAreaCenter(page);

--- a/test/wasm/e2e/e2e_helpers.js
+++ b/test/wasm/e2e/e2e_helpers.js
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 /**
  * Navigate to the sketcher page and wait for the WASM module to be fully
  * loaded and the canvas to be visible.
@@ -30,21 +32,97 @@ export async function getCanvasCenter(page) {
 }
 
 /**
- * Return the {x, y, width, height} rect of any child widget by its Qt
- * objectName. Uses a single generic C++ function so no new WASM bindings
- * are needed when new widgets are introduced.
+ * Call one of the bridge's exported functions and return its result.
+ *
  * @param {import('@playwright/test').Page} page
- * @param {string} objectName - Qt objectName of the widget
+ * @param {string} name - the bound function, e.g. "_sketcher_get_rect"
+ * @param {string} arg
  */
-export async function getWidgetRect(page, objectName) {
-  const rect = await page.evaluate(
-    (name) => JSON.parse(Module._sketcher_get_widget_rect(name)),
-    objectName,
+async function callBridge(page, name, arg) {
+  return page.evaluate(
+    async ({ fn, value }) => {
+      try {
+        // Qt/WASM is built with Asyncify, so a bridge call that unwinds the
+        // stack hands back a promise rather than its value; await covers both.
+        return await Module[fn](value);
+      } catch (e) {
+        // A C++ exception reaches JS as an opaque emscripten value, so decode
+        // it to keep the reason in the test failure. A WASM trap arrives as an
+        // ordinary JS Error instead, and handing one of those to
+        // getExceptionMessage() makes it read unrelated memory and take the
+        // whole renderer down, so only decode what is actually opaque.
+        if (e instanceof Error) {
+          throw e;
+        }
+        let detail;
+        try {
+          detail = Module.getExceptionMessage(e).join(': ');
+        } catch {
+          detail = String(e);
+        }
+        throw new Error(detail);
+      }
+    },
+    { fn: name, value: arg },
   );
-  if (!rect || rect.width === undefined) {
-    throw new Error(`Widget "${objectName}" not found`);
+}
+
+/**
+ * Resolve an object selector to {x, y, width, height, enabled} in page
+ * coordinates, or null if nothing visible matches.
+ *
+ * This is the only way tests can locate anything inside the sketcher: Qt paints
+ * the whole application into one canvas, so there are no DOM elements to query.
+ * Once you have a rect, drive the application with ordinary Playwright mouse
+ * and keyboard events.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - "widget:<objectName>", "atom:<index>", or
+ *   "bond:<index>"; indices are 0-based indices into the molecule
+ */
+async function getRect(page, selector) {
+  const rect = JSON.parse(await callBridge(page, '_sketcher_get_rect', selector));
+  return rect && rect.width !== undefined ? rect : null;
+}
+
+/**
+ * Return {x, y, width, height, enabled} for a selector, failing if nothing
+ * visible matches.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - see getRect
+ */
+export async function requireRect(page, selector) {
+  const rect = await getRect(page, selector);
+  if (rect === null) {
+    throw new Error(`Nothing visible matches "${selector}"`);
   }
   return rect;
+}
+
+/**
+ * Return a widget's state, failing if no widget has that objectName.
+ *
+ * A button reports "enabled", "checked", "text", and "visible", which is how a
+ * test asserts that a shortcut selected the tool it should have. This matches a
+ * hidden widget too, since a tool inside a closed popup is still the tool the
+ * shortcut is meant to have chosen.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name - a Qt objectName
+ */
+export async function widgetState(page, name) {
+  return requireRect(page, `state:${name}`);
+}
+
+/**
+ * Whether a widget is currently on screen, and so can be clicked.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name - a Qt objectName
+ */
+export async function isWidgetVisible(page, name) {
+  return (await getRect(page, `widget:${name}`)) !== null;
 }
 
 /**
@@ -52,22 +130,48 @@ export async function getWidgetRect(page, objectName) {
  * @param {import('@playwright/test').Page} page
  */
 export async function getDrawingAreaCenter(page) {
-  const rect = await getWidgetRect(page, 'view');
+  const rect = await requireRect(page, 'widget:view');
   return { x: Math.round(rect.x + rect.width / 2), y: Math.round(rect.y + rect.height / 2) };
+}
+
+/**
+ * Add a structure to the canvas, bypassing the import UI.
+ *
+ * This adds rather than replaces, so clear the canvas first if the test wants
+ * the structure on its own.
+ *
+ * This is fixture setup, not an assertion of the Import flow; a test that
+ * covers importing should drive the dialog instead.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} text - a structure in any format the sketcher auto-detects
+ */
+export async function loadStructure(page, text) {
+  await page.evaluate((value) => Module.sketcher_import_text(value), text);
+}
+
+/**
+ * Return the current molecule in the named export format.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} format - a key of Module.Format, e.g. "MDL_MOLV3000"
+ */
+async function getExportedText(page, format) {
+  return page.evaluate((name) => Module.sketcher_export_text(Module.Format[name]), format);
 }
 
 /**
  * Return the current molecule as a SMILES string.
  */
 export async function getExportedSmiles(page) {
-  return page.evaluate(() => Module.sketcher_export_text(Module.Format.SMILES));
+  return getExportedText(page, 'SMILES');
 }
 
 /**
  * Return the current molecule as a HELM string.
  */
 export async function getExportedHelm(page) {
-  return page.evaluate(() => Module.sketcher_export_text(Module.Format.HELM));
+  return getExportedText(page, 'HELM');
 }
 
 /**
@@ -86,26 +190,388 @@ export async function isSketcherEmpty(page) {
 }
 
 /**
- * Click a toolbar button by its Qt objectName (e.g. "c_btn").
- * Uses the generic getWidgetRect to find the button's position.
+ * Return the system clipboard's text/plain content.
  *
- * @param {import('@playwright/test').Page} page
- * @param {string} name - Qt objectName of the button
+ * On WASM the sketcher bypasses QClipboard and talks to navigator.clipboard
+ * directly, so the page can read and write what Copy and Paste see. The
+ * clipboard permissions this needs are granted in playwright.config.js.
  */
-export async function clickWidget(page, name) {
-  const rect = await getWidgetRect(page, name);
-  await page.mouse.click(rect.x + rect.width / 2, rect.y + rect.height / 2);
+export async function getClipboardText(page) {
+  return page.evaluate(() => navigator.clipboard.readText());
 }
 
 /**
- * Programmatically click a popup button by its Qt objectName.
- * Qt::Popup windows in WASM create a separate canvas whose event listeners
- * can't be targeted by Playwright, so we call into C++ directly.
+ * Put text on the system clipboard as text/plain.
+ */
+export async function setClipboardText(page, text) {
+  await page.evaluate((value) => navigator.clipboard.writeText(value), text);
+}
+
+/**
+ * Show a test-only cursor marker at a page coordinate.
+ *
+ * Playwright's trace viewer can't show where a click landed inside a canvas,
+ * so this draws the pointer position when PLAYWRIGHT_SHOW_MOUSE=1. It is off
+ * by default and is only an aid for writing and debugging tests.
+ */
+async function showMouseMarker(page, x, y) {
+  if (process.env.PLAYWRIGHT_SHOW_MOUSE !== '1') {
+    return;
+  }
+  await page.evaluate(
+    ({ left, top }) => {
+      let marker = document.getElementById('playwright-mouse-marker');
+      if (!marker) {
+        marker = document.createElement('div');
+        marker.id = 'playwright-mouse-marker';
+        Object.assign(marker.style, {
+          background: 'rgba(255, 45, 45, 0.28)',
+          border: '2px solid #ff2d2d',
+          borderRadius: '50%',
+          boxSizing: 'border-box',
+          height: '18px',
+          left: '0',
+          pointerEvents: 'none',
+          position: 'fixed',
+          top: '0',
+          transform: 'translate(-50%, -50%)',
+          width: '18px',
+          zIndex: '2147483647',
+        });
+        document.body.append(marker);
+      }
+      marker.style.display = 'block';
+      marker.style.left = `${left}px`;
+      marker.style.top = `${top}px`;
+    },
+    { left: x, top: y },
+  );
+}
+
+/**
+ * Hide the optional cursor marker, so that it stays out of a screenshot.
+ */
+export async function hideMouseMarker(page) {
+  if (process.env.PLAYWRIGHT_SHOW_MOUSE !== '1') {
+    return;
+  }
+  await page.evaluate(() => {
+    const marker = document.getElementById('playwright-mouse-marker');
+    if (marker) {
+      marker.style.display = 'none';
+    }
+  });
+}
+
+/**
+ * Press and release a mouse button at a page coordinate, optionally with
+ * keyboard modifiers held down.
+ *
+ * Playwright's page.mouse.click() takes no modifiers, and Qt wants to see the
+ * pointer arrive before the press, so this moves first and holds the modifiers
+ * around the whole gesture.
  *
  * @param {import('@playwright/test').Page} page
- * @param {string} name - Qt objectName of the popup button
- * @throws if no button with the given name is found
+ * @param {number} x
+ * @param {number} y
+ * @param {object} [options]
+ * @param {'left'|'right'|'middle'} [options.button]
+ * @param {string[]} [options.modifiers] - e.g. ['Shift']
  */
-export async function clickPopupButton(page, name) {
-  await page.evaluate((n) => Module._sketcher_click_button(n), name);
+export async function mouseClick(page, x, y, { button = 'left', modifiers = [] } = {}) {
+  await showMouseMarker(page, x, y);
+  for (const modifier of modifiers) {
+    await page.keyboard.down(modifier);
+  }
+  try {
+    await page.mouse.move(x, y, { steps: 4 });
+    await page.mouse.down({ button });
+    await page.mouse.up({ button });
+  } finally {
+    for (const modifier of [...modifiers].reverse()) {
+      await page.keyboard.up(modifier);
+    }
+  }
+}
+
+/**
+ * Drag from one page coordinate to another with intermediate moves, so that Qt
+ * sees a real drag rather than a teleport.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {{x: number, y: number}} start
+ * @param {{x: number, y: number}} end
+ * @param {object} [options]
+ * @param {'left'|'right'|'middle'} [options.button]
+ * @param {string[]} [options.modifiers]
+ * @param {number} [options.steps]
+ */
+export async function mouseDrag(
+  page,
+  start,
+  end,
+  { button = 'left', modifiers = [], steps = 12 } = {},
+) {
+  await showMouseMarker(page, start.x, start.y);
+  for (const modifier of modifiers) {
+    await page.keyboard.down(modifier);
+  }
+  try {
+    await page.mouse.move(start.x, start.y, { steps: 4 });
+    await page.mouse.down({ button });
+    for (let step = 1; step <= steps; step += 1) {
+      const progress = step / steps;
+      await page.mouse.move(
+        start.x + (end.x - start.x) * progress,
+        start.y + (end.y - start.y) * progress,
+      );
+    }
+    await page.mouse.up({ button });
+  } finally {
+    for (const modifier of [...modifiers].reverse()) {
+      await page.keyboard.up(modifier);
+    }
+  }
+  await showMouseMarker(page, end.x, end.y);
+}
+
+/**
+ * Wait for a selector to resolve to a visible, enabled rect and return it.
+ *
+ * Qt updates visibility and enabled state in response to model changes that may
+ * not have landed yet, and a menu popup is laid out an event-loop turn after
+ * the click that opens it. Failing on disabled is deliberate: a real user
+ * couldn't have clicked it, and a test that clicks a disabled control then
+ * asserts nothing happened would pass either way. To assert unavailability,
+ * poll `(await requireRect(page, selector)).enabled` instead.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - see getRect
+ */
+async function waitForClickable(page, selector) {
+  let rect;
+  await expect
+    .poll(
+      async () => {
+        rect = await getRect(page, selector);
+        if (rect === null) {
+          return 'not visible';
+        }
+        return rect.enabled ? 'clickable' : 'disabled';
+      },
+      { timeout: 5000, message: `"${selector}"` },
+    )
+    .toBe('clickable');
+  return rect;
+}
+
+/**
+ * Click whatever a selector resolves to, with a real mouse event so that Qt's
+ * own hit-testing runs.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - see getRect
+ * @param {object} [options] - see mouseClick
+ */
+async function click(page, selector, options) {
+  const rect = await waitForClickable(page, selector);
+  await mouseClick(page, rect.x + rect.width / 2, rect.y + rect.height / 2, options);
+}
+
+/**
+ * Click a widget by its Qt objectName (e.g. "c_btn").
+ *
+ * This works for a widget inside a Qt::Popup as well as one in the main window,
+ * because the bridge maps rects through global coordinates.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name - Qt objectName of the widget
+ * @param {object} [options] - see mouseClick
+ */
+export async function clickWidget(page, name, options) {
+  await click(page, `widget:${name}`, options);
+}
+
+// ToolButtonWithPopup opens its popup 250 ms after the press, and a release
+// before then cancels it, so hold well past that.
+const POPUP_HOLD_MS = 600;
+
+/**
+ * Click a tool that lives in a button's press-and-hold popup.
+ *
+ * The bridge is asked which button owns the popup so that tests don't have to
+ * carry a map of every tool to the button hiding it. The popup is a plain
+ * widget rather than a QMenu, so it doesn't run a nested event loop and its
+ * contents can be located and clicked normally once it's open.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name - Qt objectName of the tool inside the popup
+ */
+export async function clickPopupTool(page, name) {
+  const owner = await callBridge(page, '_sketcher_get_popup_owner', name);
+  if (!owner) {
+    throw new Error(`"${name}" is not visible and is not inside a popup`);
+  }
+  const rect = await waitForClickable(page, `widget:${owner}`);
+  const x = rect.x + rect.width / 2;
+  const y = rect.y + rect.height / 2;
+  await showMouseMarker(page, x, y);
+  await page.mouse.move(x, y, { steps: 4 });
+  await page.mouse.down();
+  await page.waitForTimeout(POPUP_HOLD_MS);
+  await page.mouse.up();
+  await click(page, `widget:${name}`);
+}
+
+/**
+ * Click an atom or bond by its index in the molecule.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {'atom'|'bond'} kind - monomers are addressed as 'atom' and monomer
+ *   connectors as 'bond'
+ * @param {number} index - 0-based index into the molecule's atoms or bonds
+ * @param {object} [options] - see mouseClick
+ */
+export async function clickItem(page, kind, index, options) {
+  await click(page, `${kind}:${index}`, options);
+}
+
+/**
+ * Move the pointer over whatever a selector resolves to.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - see getRect
+ */
+async function hover(page, selector) {
+  const rect = await waitForClickable(page, selector);
+  const x = rect.x + rect.width / 2;
+  const y = rect.y + rect.height / 2;
+  await showMouseMarker(page, x, y);
+  await page.mouse.move(x, y, { steps: 4 });
+}
+
+/**
+ * Open a context menu by right-clicking whatever a selector resolves to, then
+ * walk a path of rows: every row but the last is hovered to open its submenu,
+ * and the last is clicked.
+ *
+ * Unlike the More Actions menu, a context menu can be driven for real. The
+ * sketcher shows one with QMenu::show() rather than exec(), so it doesn't run
+ * the nested event loop that would otherwise suspend the WASM module — see
+ * activateAction.
+ *
+ * The whole gesture is retried, because Qt/WASM can take a frame to put the
+ * popup up and a half-open menu resolves no rows. Reopening replays the same
+ * user actions rather than falling back to triggering the action directly, so a
+ * genuinely unreachable row still fails.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - what to right-click, see getRect
+ * @param {...string} path - row labels, outermost first
+ */
+export async function contextMenuAction(page, selector, ...path) {
+  if (path.length === 0) {
+    throw new Error('contextMenuAction needs at least one row to click');
+  }
+  const rect = await waitForClickable(page, selector);
+  let lastError;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await mouseClick(page, rect.x + rect.width / 2, rect.y + rect.height / 2, {
+      button: 'right',
+    });
+    try {
+      for (const label of path.slice(0, -1)) {
+        await hover(page, `menu:${label}`);
+      }
+      await click(page, `menu:${path.at(-1)}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      await page.keyboard.press('Escape');
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Open a context menu and leave it showing, having hovered down to the last row
+ * of the path. Use this to screenshot a menu rather than act on it.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector - what to right-click, see getRect
+ * @param {...string} path - row labels to hover, outermost first
+ */
+export async function openContextMenu(page, selector, ...path) {
+  const rect = await waitForClickable(page, selector);
+  let lastError;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await mouseClick(page, rect.x + rect.width / 2, rect.y + rect.height / 2, {
+      button: 'right',
+    });
+    try {
+      for (const label of path) {
+        await hover(page, `menu:${label}`);
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+      await page.keyboard.press('Escape');
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Trigger a menu action by objectName or visible text, without opening its
+ * menu.
+ *
+ * This is the one control that can't be clicked for real. Qt runs a nested
+ * event loop while a QToolButton's menu is open, and because Qt/WASM is built
+ * with Asyncify that leaves the WebAssembly stack suspended — no call into the
+ * module returns until the menu closes, so a test can't even ask where a row
+ * is. Everything else, popup widgets included, gets a real mouse event.
+ *
+ * Throws if no action matches or the match is disabled.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} nameOrText - objectName, or the row's visible text
+ */
+export async function activateAction(page, nameOrText) {
+  await callBridge(page, '_sketcher_activate_action', nameOrText);
+}
+
+/**
+ * Click a visible text control and replace its value through keyboard input.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name - Qt objectName of the text control
+ * @param {string} text
+ */
+export async function setWidgetText(page, name, text) {
+  await clickWidget(page, name);
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(String(text), { delay: 10 });
+}
+
+/**
+ * Place a single atom of the given element in the middle of the drawing area,
+ * selecting the element with its keyboard shortcut.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} element - an element symbol with a shortcut, e.g. "N"
+ */
+export async function drawElement(page, element) {
+  const center = await getDrawingAreaCenter(page);
+  await focusCanvas(page);
+  await page.keyboard.press(element);
+  await mouseClick(page, center.x, center.y);
+}
+
+/**
+ * Draw one bond with the active bond tool, starting from the middle of the
+ * drawing area.
+ */
+export async function drawBond(page) {
+  const center = await getDrawingAreaCenter(page);
+  await mouseDrag(page, center, { x: center.x + 100, y: center.y });
 }

--- a/test/wasm/e2e/e2e_helpers.js
+++ b/test/wasm/e2e/e2e_helpers.js
@@ -77,8 +77,14 @@ async function callBridge(page, name, arg) {
  * and keyboard events.
  *
  * @param {import('@playwright/test').Page} page
- * @param {string} selector - "widget:<objectName>", "atom:<index>", or
- *   "bond:<index>"; indices are 0-based indices into the molecule
+ * @param {string} selector - one of:
+ *   "widget:<objectName>"  a visible widget, by its Qt objectName
+ *   "state:<objectName>"   the same, but matching a hidden widget too, and
+ *                          adding "visible" to the result
+ *   "atom:<index>"         an atom, by 0-based index into the molecule
+ *   "bond:<index>"         a bond, by 0-based index into the molecule
+ *   "menu:<name or text>"  a row of an already-open context menu
+ *   A button also reports "checked", "text", and "toolTip".
  */
 async function getRect(page, selector) {
   const rect = JSON.parse(await callBridge(page, '_sketcher_get_rect', selector));
@@ -103,10 +109,10 @@ export async function requireRect(page, selector) {
 /**
  * Return a widget's state, failing if no widget has that objectName.
  *
- * A button reports "enabled", "checked", "text", and "visible", which is how a
- * test asserts that a shortcut selected the tool it should have. This matches a
- * hidden widget too, since a tool inside a closed popup is still the tool the
- * shortcut is meant to have chosen.
+ * A button reports "enabled", "visible", "checked", "text", and "toolTip",
+ * which is how a test asserts that a shortcut selected the tool it should have.
+ * This matches a hidden widget too, since a tool inside a closed popup is still
+ * the tool the shortcut is meant to have chosen.
  *
  * @param {import('@playwright/test').Page} page
  * @param {string} name - a Qt objectName
@@ -392,8 +398,8 @@ export async function clickWidget(page, name, options) {
   await click(page, `widget:${name}`, options);
 }
 
-// ToolButtonWithPopup opens its popup 250 ms after the press, and a release
-// before then cancels it, so hold well past that.
+// ToolButtonWithPopup::m_popup_delay is 250 ms, and releasing before it elapses
+// cancels the popup, so hold well past it. Raise this if that default changes.
 const POPUP_HOLD_MS = 600;
 
 /**

--- a/test/wasm/e2e/e2e_helpers.js
+++ b/test/wasm/e2e/e2e_helpers.js
@@ -84,7 +84,9 @@ async function callBridge(page, name, arg) {
  *   "atom:<index>"         an atom, by 0-based index into the molecule
  *   "bond:<index>"         a bond, by 0-based index into the molecule
  *   "menu:<name or text>"  a row of an already-open context menu
- *   A button also reports "checked", "text", and "toolTip".
+ *   A widget whose text the user can read also reports "text" — a caption, a
+ *   combo box's current item, or a line edit's or spin box's contents — and a
+ *   button also reports "checked" and "toolTip".
  */
 async function getRect(page, selector) {
   const rect = JSON.parse(await callBridge(page, '_sketcher_get_rect', selector));
@@ -109,10 +111,11 @@ export async function requireRect(page, selector) {
 /**
  * Return a widget's state, failing if no widget has that objectName.
  *
- * Every widget reports "enabled" and "visible"; a button adds "checked",
- * "text", and "toolTip", which is how a test asserts that a shortcut selected
- * the tool it should have. This matches a hidden widget too, since a tool inside
- * a closed popup is still the tool the shortcut is meant to have chosen.
+ * Every widget reports "enabled" and "visible", and one the user can read text
+ * from adds "text"; a button adds "checked" and "toolTip", which is how a test
+ * asserts that a shortcut selected the tool it should have. This matches a
+ * hidden widget too, since a tool inside a closed popup is still the tool the
+ * shortcut is meant to have chosen.
  *
  * @param {import('@playwright/test').Page} page
  * @param {string} name - a Qt objectName

--- a/test/wasm/e2e/e2e_helpers.js
+++ b/test/wasm/e2e/e2e_helpers.js
@@ -109,10 +109,10 @@ export async function requireRect(page, selector) {
 /**
  * Return a widget's state, failing if no widget has that objectName.
  *
- * A button reports "enabled", "visible", "checked", "text", and "toolTip",
- * which is how a test asserts that a shortcut selected the tool it should have.
- * This matches a hidden widget too, since a tool inside a closed popup is still
- * the tool the shortcut is meant to have chosen.
+ * Every widget reports "enabled" and "visible"; a button adds "checked",
+ * "text", and "toolTip", which is how a test asserts that a shortcut selected
+ * the tool it should have. This matches a hidden widget too, since a tool inside
+ * a closed popup is still the tool the shortcut is meant to have chosen.
  *
  * @param {import('@playwright/test').Page} page
  * @param {string} name - a Qt objectName
@@ -256,6 +256,11 @@ async function showMouseMarker(page, x, y) {
 
 /**
  * Hide the optional cursor marker, so that it stays out of a screenshot.
+ *
+ * The mouse helpers deliberately leave the marker showing once a gesture ends,
+ * so that a trace frame captured after the click still says where the pointer
+ * went; hiding it there would erase the only record of it. Call this from a test
+ * that is about to take a visual snapshot.
  */
 export async function hideMouseMarker(page) {
   if (process.env.PLAYWRIGHT_SHOW_MOUSE !== '1') {
@@ -444,6 +449,10 @@ export async function clickItem(page, kind, index, options) {
 
 /**
  * Move the pointer over whatever a selector resolves to.
+ *
+ * Every selector kind reports "enabled", not just a button, so this waits for an
+ * enabled target the way click() does — its callers hover a menu row to open the
+ * submenu underneath it, and a disabled row has none to open.
  *
  * @param {import('@playwright/test').Page} page
  * @param {string} selector - see getRect

--- a/test/wasm/e2e/monomer_mutation.test.js
+++ b/test/wasm/e2e/monomer_mutation.test.js
@@ -5,6 +5,7 @@ import {
   getExportedHelm,
   selectAll,
   clickWidget,
+  requireRect,
 } from './e2e_helpers.js';
 
 test.beforeEach(async ({ page }) => {
@@ -47,7 +48,7 @@ test.describe('Monomer Mutation', () => {
     expect(helm).not.toContain('R(C)');
   });
 
-  test('clicking disabled incompatible monomer button does not mutate', async ({ page }) => {
+  test('incompatible monomer button is disabled for a peptide selection', async ({ page }) => {
     await clickWidget(page, 'monomeric_btn');
     await clickWidget(page, 'amino_monomer_btn');
 
@@ -61,10 +62,14 @@ test.describe('Monomer Mutation', () => {
     // Switch to nucleic acid page — peptide selection should persist
     await clickWidget(page, 'nucleic_monomer_btn');
 
-    // Click a nucleic acid base button (should be disabled for peptide selection)
-    await clickWidget(page, 'na_u_btn');
+    // A nucleic acid base can't be applied to a peptide selection, so the
+    // button must be disabled. Assert that directly rather than clicking it and
+    // checking the molecule is unchanged, which would also pass if the button
+    // were enabled but the mutation silently did nothing.
+    await expect
+      .poll(async () => (await requireRect(page, 'widget:na_u_btn')).enabled, { timeout: 5000 })
+      .toBe(false);
 
-    // Verify no mutation occurred
     const helm = await getExportedHelm(page);
     expect(helm).toContain('PEPTIDE1{A.G.L}');
   });

--- a/test/wasm/playwright.config.js
+++ b/test/wasm/playwright.config.js
@@ -13,6 +13,9 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     viewport: { width: 1280, height: 720 },
     actionTimeout: 10000,
+    // On WASM the sketcher bypasses QClipboard and talks to
+    // navigator.clipboard directly, so clipboard tests need these granted.
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
   retries: process.env.CI ? 1 : 0,
   snapshotPathTemplate: '{testDir}/{testFileDir}/__snapshots__/{testFileName}/{arg}{ext}',


### PR DESCRIPTION
- Linked Case: SKETCH-2643

### Description

I took Sean's PR, whined at claude a bunch, fed it Juzer comments, and ended up with this -- a small surface area of emscripten exposed functions that are able to collect coordinates of parts of the sketcher, or activate parts of the sketcher explicitly. I believe this should cover all of Sean's needs for atom/bond/menu/etc interaction. Below is claude's writeup of the changes:

Qt/WASM paints the whole app into one canvas, so Playwright has no DOM to target. Today's e2e tests work around that with two ad-hoc functions in `main.cpp` that only reach visible toolbar buttons; porting the rest of the Squish suite needs atoms, bonds, context menu rows, and the tools that only exist inside press-and-hold popups.

Instead of a binding per object kind, the bridge does the one thing Playwright can't do itself: resolve a selector (`widget:fit_btn`, `atom:2`, `bond:0`, `menu:Flip`) to page coordinates, along with enough state to tell whether Qt would accept a click. Tests take it from there with real mouse and keyboard events, so Qt's hit-testing stays in the loop and new selector kinds cost no new bindings. Two cases need more than geometry: a `QToolButton` menu runs a nested event loop that suspends the WASM stack under Asyncify, so its rows are activated rather than clicked, and a tool hidden in a popup needs its owning button pressed and held first — the bridge derives that owner from the widget tree rather than making tests carry a hand-written map of all seventeen.

This PR is infrastructure only. The ported Squish suites and their snapshots are held back for a follow-up branch so this one stays reviewable, which does mean most of the helper layer lands ahead of its callers — the existing e2e tests exercise the widget selector and nothing else. Worth flagging for review: like the two functions it replaces, the bridge is compiled unconditionally, so these bindings ship in the released WASM as they do today. They are underscore-prefixed, no production code path calls them, and the whole file compiles away outside Emscripten, but gating it behind a build flag would be a reasonable follow-up if we'd rather it not ship at all.

### Testing Done

CI. Locally, the ported bond context menu suite — held back for the follow-up branch — ran green against this bridge, exercising the `menu:`, `atom:`, and `bond:` selectors along with menu row activation. That run predates the review-comment commits that followed it, whose changes are covered by compilation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

