### PR TITLE
SKETCH-2851: Hooking up Copy All As -> Image in top bar menu

### DIFF
--- a/include/schrodinger/sketcher/sketcher_widget.h
+++ b/include/schrodinger/sketcher/sketcher_widget.h
@@ -15,6 +15,7 @@
 
 class QGraphicsSvgItem;
 class QGraphicsSceneMouseEvent;
+class QImage;
 class QUndoStack;
 
 #ifdef __EMSCRIPTEN__
@@ -406,6 +407,7 @@ class SKETCHER_API SketcherWidget : public QWidget
     virtual std::string getClipboardContents() const;
     virtual void setClipboardContents(std::string text,
                                       std::string binary) const;
+    virtual void setClipboardImage(const QImage& image) const;
 
     /**
      * Perform the actual paste of clipboard text into the scene at the given

--- a/src/schrodinger/sketcher/sketcher_widget.cpp
+++ b/src/schrodinger/sketcher/sketcher_widget.cpp
@@ -627,6 +627,11 @@ void SketcherWidget::setClipboardContents(std::string text,
 #endif
 }
 
+void SketcherWidget::setClipboardImage(const QImage& image) const
+{
+    QApplication::clipboard()->setImage(image);
+}
+
 void SketcherWidget::cut(Format format)
 {
     copy(format, SceneSubset::SELECTION);
@@ -664,7 +669,7 @@ void SketcherWidget::copyAsImage()
     image_bytes = get_image_bytes(*m_scene, ImageFormat::PNG, opts);
     QImage image;
     image.loadFromData(image_bytes, "PNG");
-    QApplication::clipboard()->setImage(image);
+    setClipboardImage(image);
 }
 
 #ifdef __EMSCRIPTEN__
@@ -954,6 +959,8 @@ void SketcherWidget::connectTopBarSlots()
             &SketcherWidget::cut);
     connect(m_ui->top_bar_wdg, &SketcherTopBar::copyRequested, this,
             &SketcherWidget::copy);
+    connect(m_ui->top_bar_wdg, &SketcherTopBar::copyAsImageRequested, this,
+            &SketcherWidget::copyAsImage);
     connect(m_ui->top_bar_wdg, &SketcherTopBar::pasteRequested, this,
             &SketcherWidget::paste);
 

--- a/src/schrodinger/sketcher/widget/sketcher_top_bar.cpp
+++ b/src/schrodinger/sketcher/widget/sketcher_top_bar.cpp
@@ -95,6 +95,9 @@ void SketcherTopBar::initMenus()
     connect(m_more_actions_menu->m_cut_copy_manager,
             &CutCopyActionManager::copyRequested, this,
             &SketcherTopBar::copyRequested);
+    connect(m_more_actions_menu->m_cut_copy_manager,
+            &CutCopyActionManager::copyAsImageRequested, this,
+            &SketcherTopBar::copyAsImageRequested);
     connect(m_more_actions_menu->m_paste_act, &QAction::triggered, this,
             &SketcherTopBar::pasteRequested);
     connect(m_more_actions_menu->m_flip_horizontal_act, &QAction::triggered,

--- a/src/schrodinger/sketcher/widget/sketcher_top_bar.h
+++ b/src/schrodinger/sketcher/widget/sketcher_top_bar.h
@@ -64,6 +64,7 @@ class SKETCHER_API SketcherTopBar : public SketcherView
     void invertSelectionRequested();
     void cutRequested(rdkit_extensions::Format format);
     void copyRequested(rdkit_extensions::Format format, SceneSubset subset);
+    void copyAsImageRequested();
     void pasteRequested();
     void flipHorizontalRequested();
     void flipVerticalRequested();

--- a/test/schrodinger/sketcher/test_common.h
+++ b/test/schrodinger/sketcher/test_common.h
@@ -92,6 +92,7 @@ class TestSketcherWidget : public SketcherWidget
     // failures on buildbot, so we create our own clipboard
     mutable std::string m_clipboard_text;
     mutable std::string m_clipboard_binary;
+    mutable bool m_clipboard_image_set = false;
     std::string getClipboardContents() const override
     {
         return m_clipboard_binary.empty() ? m_clipboard_text
@@ -102,6 +103,10 @@ class TestSketcherWidget : public SketcherWidget
     {
         m_clipboard_text = text;
         m_clipboard_binary = binary;
+    }
+    void setClipboardImage(const QImage&) const override
+    {
+        m_clipboard_image_set = true;
     }
 };
 

--- a/test/schrodinger/sketcher/test_sketcher_widget.cpp
+++ b/test/schrodinger/sketcher/test_sketcher_widget.cpp
@@ -22,6 +22,7 @@
 #include "schrodinger/sketcher/menu/cut_copy_action_manager.h"
 #include "schrodinger/sketcher/menu/monomer_context_menu.h"
 #include "schrodinger/sketcher/menu/selection_context_menu.h"
+#include "schrodinger/sketcher/menu/sketcher_top_bar_menus.h"
 #include "schrodinger/sketcher/molviewer/monomer_utils.h"
 #include "schrodinger/sketcher/rdkit/monomeric.h"
 #include "schrodinger/sketcher/rdkit/coord_utils.h"
@@ -30,6 +31,7 @@
 #include "schrodinger/sketcher/molviewer/scene.h"
 #include "schrodinger/sketcher/sketcher_widget.h"
 #include "schrodinger/sketcher/ui/ui_sketcher_widget.h"
+#include "schrodinger/sketcher/widget/sketcher_top_bar.h"
 #include "schrodinger/test/checkexceptionmsg.h"
 #include "test_common.h"
 
@@ -66,6 +68,27 @@ struct TestWidgetFixture {
 };
 
 BOOST_GLOBAL_FIXTURE(TestWidgetFixture);
+
+BOOST_AUTO_TEST_CASE(test_copy_all_as_image_from_top_bar)
+{
+    TestSketcherWidget& sk = *TestWidgetFixture::get();
+    sk.addFromString("CC");
+    sk.m_clipboard_image_set = false;
+
+    QAction* image_action = nullptr;
+    auto* copy_as_menu = sk.m_ui->top_bar_wdg->m_more_actions_menu
+                             ->m_cut_copy_manager->m_copy_as_menu;
+    for (auto* action : copy_as_menu->actions()) {
+        if (action->text() == "Image") {
+            image_action = action;
+            break;
+        }
+    }
+    BOOST_TEST_REQUIRE(image_action != nullptr);
+
+    image_action->trigger();
+    BOOST_TEST(sk.m_clipboard_image_set);
+}
 
 static void send_key_press(TestSketcherWidget& sk, Qt::Key key,
                            const QString& text)


### PR DESCRIPTION
- Linked Case: SKETCH-2851

### Description

This was just a missing signal connection, so I let Codex one-shot the case.

### Testing Done

Added a new unit test that sanity checks that the menu action triggers a call to `SketcherWidget::setClipboardImage`.  I also ran the Windows desktop app from the command line and confirmed that the menu option works for both atomistic and monomeric structures.
