### PR TITLE
SKETCH-2852: Fixing crash during click-and-drag with monomer tool

### DIFF
--- a/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/abstract_draw_monomer_or_monomeric_connection_scene_tool.cpp
@@ -743,6 +743,9 @@ void AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragMove(
             labelAttachmentPointsOnDragEndMonomer(
                 hovered_monomer_item->getAtom(), hovered_monomer_item);
         }
+        // update drag_end_info now that we've updated the attachment point
+        // labels
+        drag_end_info = getDragEndInfo(event->scenePos()).first;
     }
 
     if (drag_end_info != m_drag_end_info) {

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -391,6 +391,41 @@ BOOST_AUTO_TEST_CASE(test_drag_empty_to_ap_adds_connected_correct_aps)
 }
 
 /**
+ * Regression test for SKETCH-2852. When a drag moved from one monomer to
+ * another, the drag-end information could retain a pointer to an attachment
+ * point item that was deleted while updating the attachment point labels for
+ * the newly hovered monomer.
+ */
+BOOST_AUTO_TEST_CASE(test_drag_across_monomers_does_not_use_deleted_ap_item)
+{
+    MonomerToolTestFixture fix;
+    fix.importMolText("PEPTIDE1{C.C.C}$$$$V2.0");
+    fix.setAminoAcidTool(AminoAcidTool::CYS);
+
+    auto first_cys_pos = fix.getMonomerPos(0);
+    auto middle_cys_pos = fix.getMonomerPos(1);
+    auto empty_pos = first_cys_pos + QPointF(0, -200);
+    fix.mouseMove(empty_pos);
+    fix.mousePress(empty_pos);
+
+    for (int i = 0; i < 5; ++i) {
+        // Moving over the first cysteine creates its N and S attachment point
+        // items. Moving directly from its N attachment point to the middle
+        // cysteine replaces those items with the middle cysteine's S item. We
+        // repeat these movements multiple times since the bug was intermittent;
+        // the loop increases the likelihood of triggering the exception should
+        // a regression occur.
+        fix.mouseMove(first_cys_pos, Qt::LeftButton);
+        auto first_cys_n_ap_pos = fix.getAttachmentPointPos(0, "N");
+        fix.mouseMove(first_cys_n_ap_pos, Qt::LeftButton);
+        fix.mouseMove(middle_cys_pos, Qt::LeftButton);
+    }
+
+    fix.mouseRelease(middle_cys_pos);
+    BOOST_TEST(fix.m_mol_model->getMol()->getNumAtoms() == 4);
+}
+
+/**
  * Make sure that dragging between two existing monomer won't create a second
  * standard backbone connection between them (since monomer_mol can't store more
  * than one standard backbone connection between the same pair of monomers)


### PR DESCRIPTION
- Linked Case: SKETCH-2852

### Description

This crash happens when a drag mouse movement moves directly from one monomer to an adjacent one without any intervening mouse moves into empty space.  In that scenario `AbstractDrawMonomerOrMonomericConnectionSceneTool::onLeftButtonDragMove` would:

1. record the drag end info containing a pointer to an attachment point on the previously hovered monomer
2. update the attachment points by deleting the attachment points from the previously hovered monomer and drawing attachment points on the newly hovered monomer
3. draw a hint structure using the drag end info recorded in step 1, which contains a pointer to an attachment point that we deleted in step 2
4. this eventually leads to attempting to pull an attachment point name out of invalid memory

Codex easily tracked down the cause of the crash, although it came up with a fix that involved an almost-completely-unrelated surprisingly-sizable refactoring in addition to the actual one-line fix.  I just implemented the one-line fix.

### Testing Done

The recipe in the Jira case uses alanine's H-bond attachment points, but those are going to be removed soon as part of SKETCH-2850, so I didn't want to use that recipe for a unit test.  Codex came up with a new recipe to trigger the crash.  This recipe is much harder to trigger in the actual GUI since it involves moving the mouse a fair distance in a single step, but it works perfectly for the unit test.  I confirmed that the unit test fails without the fix and passes with it.  I also manually confirmed that the Jira recipe no longer crashes with the fix.
