### PR TITLE
SKETCH-2844: Fixing X and N monomer wildcard button styling

### DIFF
--- a/src/schrodinger/sketcher/sketcher_css_style.h
+++ b/src/schrodinger/sketcher/sketcher_css_style.h
@@ -71,7 +71,7 @@ const QString ATOM_ELEMENT_OR_MONOMER_COMPACT_STYLE{
 /// style for an unknown monomer (e.g. amino acid X or nucleotide N)
 const QString UNKNOWN_MONOMER_STYLE{
     "QToolButton { font-size: 14px; font-weight: bold; font-style: italic; "
-    "color: #333333; }"
+    "color: #606060; }"
     "QToolButton:disabled { color: #E4E4E4; }"};
 
 const QString ATOM_QUERY_STYLE{

--- a/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
+++ b/src/schrodinger/sketcher/ui/monomer_tool_widget.ui
@@ -182,10 +182,10 @@
        <item row="7" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -260,10 +260,10 @@
        <item row="3" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -364,7 +364,7 @@
         </widget>
        </item>
        <item row="4" column="2">
-        <widget class="schrodinger::sketcher::ModularToolButton" name="na_n_btn">
+        <widget class="QToolButton" name="na_n_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -428,7 +428,7 @@
        <item row="10" column="0">
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -553,7 +553,7 @@
        <item row="7" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1094,7 +1094,7 @@
         </widget>
        </item>
        <item row="6" column="2">
-        <widget class="schrodinger::sketcher::ModularToolButton" name="unk_btn">
+        <widget class="QToolButton" name="unk_btn">
          <property name="minimumSize">
           <size>
            <width>32</width>
@@ -1224,7 +1224,7 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -1233,7 +1233,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1284,7 +1284,7 @@
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1335,7 +1335,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1350,7 +1350,7 @@
    <item>
     <spacer name="verticalSpacer_5">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
+++ b/src/schrodinger/sketcher/widget/monomer_tool_widget.cpp
@@ -117,6 +117,14 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
 
     for (auto& entry : m_button_amino_acid_bimap.left) {
         auto* button = entry.first;
+        auto aa_tool = entry.second;
+        auto symbol = AMINO_ACID_TOOL_TO_RES_NAME.at(aa_tool);
+        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
+        if (aa_tool == AminoAcidTool::UNK) {
+            // the UNK button doesn't get a popup and isn't a ModularToolButton
+            button->setToolTip(QString::fromStdString(name));
+            continue;
+        }
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
         Q_ASSERT_X(modular_btn, "MonomerToolWidget",
                    "Expected ModularToolButton");
@@ -124,9 +132,6 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
         // reveal on buttons that actually get an analog popup attached.
         modular_btn->showPopupIndicator(false);
 
-        auto aa_tool = entry.second;
-        auto symbol = AMINO_ACID_TOOL_TO_RES_NAME.at(aa_tool);
-        const auto& name = AMINO_ACID_TOOL_TO_FULL_NAME.at(aa_tool);
         auto it = analogs_by_aa.find(symbol);
         if (it == analogs_by_aa.end() || it->second.empty()) {
             button->setToolTip(QString::fromStdString(name));
@@ -170,6 +175,12 @@ MonomerToolWidget::MonomerToolWidget(QWidget* parent) :
             continue; // sugar/phosphate/full-nucleotide buttons
         }
         const auto& [symbol, name] = *std_name;
+        if (na_tool == NucleicAcidTool::N) {
+            // the N button doesn't get a popup and isn't a ModularToolButton
+            button->setToolTip(QString::fromStdString(name));
+            continue;
+        }
+
         auto* modular_btn = qobject_cast<ModularToolButton*>(button);
         // Hide the wedge by default for every per-base NA button; only
         // enable hover reveal on buttons that actually get an analog popup
@@ -246,8 +257,9 @@ void MonomerToolWidget::updateWidgetsEnabled()
 
     // Enable individual nucleic acid component buttons only if that
     // component type is in the selection (or there's no monomer selection)
-    std::array base_btns{ui->na_a_btn, ui->na_c_btn, ui->na_g_btn,
-                         ui->na_u_btn, ui->na_t_btn, ui->na_n_btn};
+    auto base_btns =
+        std::to_array<QToolButton*>({ui->na_a_btn, ui->na_c_btn, ui->na_g_btn,
+                                     ui->na_u_btn, ui->na_t_btn, ui->na_n_btn});
     for (auto* btn : base_btns) {
         btn->setEnabled(!has_monomer_selection || has_na_base);
     }

--- a/test/schrodinger/sketcher/widget/test_monomer_tool_widget.cpp
+++ b/test/schrodinger/sketcher/widget/test_monomer_tool_widget.cpp
@@ -1,0 +1,38 @@
+#define BOOST_TEST_MODULE test_monomer_tool_widget
+#include <boost/test/unit_test.hpp>
+
+#include <QAbstractButton>
+
+#include "../test_common.h"
+#include "schrodinger/sketcher/widget/monomer_tool_widget.h"
+
+BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
+
+namespace schrodinger
+{
+namespace sketcher
+{
+
+/**
+ * Verify that unknown monomer buttons use the unknown monomer styling. If these
+ * buttons are converted to ModularToolButtons, then the ModularToolButton
+ * styling will inadvertently overwrite the UNKNOWN_MONOMER_STYLE.
+ */
+BOOST_AUTO_TEST_CASE(unknown_monomer_button_styles)
+{
+    MonomerToolWidget widget;
+
+    for (const auto* button_name : {"unk_btn", "na_n_btn"}) {
+        const auto* button = widget.findChild<QAbstractButton*>(button_name);
+        BOOST_REQUIRE(button != nullptr);
+        const auto style_sheet = button->styleSheet();
+        BOOST_TEST_CONTEXT(button->objectName().toStdString())
+        {
+            BOOST_TEST(style_sheet.contains(QStringLiteral("italic")));
+            BOOST_TEST(style_sheet.contains(QStringLiteral("#606060")));
+        }
+    }
+}
+
+} // namespace sketcher
+} // namespace schrodinger


### PR DESCRIPTION
- Linked Case: SKETCH-2844

### Description

In SKETCH-2729, the monomer tool buttons were converted to `ModularToolButton`s so that they could have popup palettes.  Unfortunately, `ModularToolButton` uses style sheets to control the button's appearance, which means that as a side effect of that change, `UNKNOWN_MONOMER_STYLE` was no longer getting applied to the X and N buttons.

There's a separate case to remove the palettes from the X and N buttons (SKETCH-2829), so I just implemented that here, which allows `UNKNOWN_MONOMER_STYLE` to be properly applied.  That case also calls for removing the palettes from the R and dR buttons until there's something to put in them.  I haven't done anything to those buttons, though, so I was planning on leaving that case open.

Note that most of the changes to `monomer_tool_widget.ui` (i.e. everything other than the two `ModularToolButton` to `QToolButton` changes) are a result of using the Qt 6.8 version of Designer instead of the Qt 6.5 version.  The new version apparently uses scoped names for enums, which seems reasonable.

### Testing Done

I confirmed that the buttons now appear italicized and gray in the Windows desktop app.  I also added a unit test that checks the style sheet to make sure it contains the expected formatting and confirmed that the new test fails without these changes.
