### PR TITLE
SKETCH-2853: Protecting against empty $CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ if(ENABLE_TESTING)
       ${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PREFIX_PATH}
                                 OUTPUT_NAME ${TEST_STEM})
     # Create memtest target and command
-    if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
       # create the valgrind test
       set(CURRENT_MEMTEST_COMMAND ${MEMTEST_COMMAND})
       if(EXISTS "${PREFIX_PATH}/${SUPPRESSION_FILE}")
@@ -516,7 +516,7 @@ if(ENABLE_TESTING)
       ${TEST_TARGET} PROPERTIES ENVIRONMENT
                                 "SKETCHER_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
     # Add label for memtest targets
-    if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
       set_property(TEST ${TEST_TARGET} PROPERTY LABELS memtest)
     endif()
   endforeach()


### PR DESCRIPTION
- Linked Case: SKETCH-2853

### Description

I wasn't able to reproduce the issue locally, but a user ran into a build error resulting from the way CMake handles empty variables inside `if` statements.  (See #409.)  If `$CMAKE_BUILD_TYPE` is empty, then CMake converts
```
if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
```
to
```
if( STREQUAL "Debug")
```
before evaluating the condition and then complains about an `if` statement with only two arguments.  Adding double quotes prevents this and is recommended by the CMake documentation.  With this change, `$CMAKE_BUILD_TYPE` should effectively default to "Release" if it's not specified.

### Testing Done

Confirmed that a local $SCHRODINGER build still runs correctly.  As a sanity check, I asked Codex to review the change and it agreed that it was helpful but that it wasn't going to have any effect on local builds (as expected).