### PR TITLE
SKETCH-2850: Removing H-bond AP from non-cysteine peptide monomers

### DIFF
--- a/src/schrodinger/sketcher/rdkit/monomeric.cpp
+++ b/src/schrodinger/sketcher/rdkit/monomeric.cpp
@@ -554,16 +554,13 @@ get_unbound_attachment_points(const RDKit::Atom* monomer,
 
     // figure out how many numbered attachment points we expect
     auto monomer_type = get_monomer_type(monomer);
-    bool is_amino_acid_other_than_cysteine =
-        monomer_type == MonomerType::PEPTIDE &&
-        get_monomer_res_name(monomer) != CYS_RES_NAME;
     int num_numbered_aps = -1;
     if (NUMBERED_AP_NAMES_BY_MONOMER_TYPE.contains(monomer_type)) {
         num_numbered_aps =
             NUMBERED_AP_NAMES_BY_MONOMER_TYPE.at(monomer_type).size();
-        if (is_amino_acid_other_than_cysteine) {
-            // only cysteine can form disulfides, other amino acids will have a
-            // H-bond attachment point added below
+        if (monomer_type == MonomerType::PEPTIDE &&
+            get_monomer_res_name(monomer) != CYS_RES_NAME) {
+            // cysteine is the only peptide that can form disulfides
             num_numbered_aps -= 1;
         }
     } else if (monomer_type == MonomerType::NA_PHOSPHATE) {
@@ -597,9 +594,7 @@ get_unbound_attachment_points(const RDKit::Atom* monomer,
         }
 
         // figure out if we should add an unbound H-bond attachment point
-        bool expect_h_bond_ap = monomer_type == MonomerType::NA_BASE ||
-                                is_amino_acid_other_than_cysteine;
-        if (expect_h_bond_ap &&
+        if (monomer_type == MonomerType::NA_BASE &&
             !bound_aps_with_custom_names.contains(H_BOND_AP_MODEL_NAME)) {
             auto dir = calculate_direction_for_unbound_attachment_point(
                 ATTACHMENT_POINT_WITH_CUSTOM_NAME, H_BOND_AP_MODEL_NAME,

--- a/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_monomeric.cpp
@@ -65,8 +65,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom0);
         exp_available = {{"R1", "N", 1, Direction::W},
-                         {"R2", "C", 2, Direction::E},
-                         {"pair", "H-bond", -1, Direction::N}};
+                         {"R2", "C", 2, Direction::E}};
         BOOST_TEST(bound_aps.empty());
         BOOST_TEST(unbound_aps == exp_available);
     }
@@ -81,16 +80,14 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E}};
-        exp_available = {{"R1", "N", 1, Direction::W},
-                         {"pair", "H-bond", -1, Direction::N}};
+        exp_available = {{"R1", "N", 1, Direction::W}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W}};
-        exp_available = {{"R2", "C", 2, Direction::E},
-                         {"pair", "H-bond", -1, Direction::N}};
+        exp_available = {{"R2", "C", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }
@@ -122,9 +119,8 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W},
                      {"R2", "C", 2, atom2, false, Direction::E}};
-        exp_available = {{"pair", "H-bond", -1, Direction::N}};
         BOOST_TEST(bound_aps == exp_bound);
-        BOOST_TEST(unbound_aps == exp_available);
+        BOOST_TEST(unbound_aps.empty());
 
         std::tie(bound_aps, unbound_aps) =
             get_attachment_points_for_monomer(atom2);
@@ -303,8 +299,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom0);
         exp_bound = {{"R2", "C", 2, atom1, false, Direction::E},
                      {"R4", "R4", 4, atom1, true, Direction::E}};
-        exp_available = {{"R1", "N", 1, Direction::W},
-                         {"pair", "H-bond", -1, Direction::N}};
+        exp_available = {{"R1", "N", 1, Direction::W}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
 
@@ -312,8 +307,7 @@ BOOST_AUTO_TEST_CASE(test_get_attachment_points)
             get_attachment_points_for_monomer(atom1);
         exp_bound = {{"R1", "N", 1, atom0, false, Direction::W},
                      {"R4", "R4", 4, atom0, true, Direction::W}};
-        exp_available = {{"R2", "C", 2, Direction::E},
-                         {"pair", "H-bond", -1, Direction::N}};
+        exp_available = {{"R2", "C", 2, Direction::E}};
         BOOST_TEST(bound_aps == exp_bound);
         BOOST_TEST(unbound_aps == exp_available);
     }

--- a/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomer_scene_tool_integration_tests.cpp
@@ -58,8 +58,7 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_residue_mutates)
 
 /**
  * Confirm that clicking on an existing monomer with a monomer tool of a
- * different monomer type adds an H-bond, or does nothing if there's already an
- * H-bond.
+ * different monomer type does nothing.
  */
 BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
 {
@@ -68,9 +67,7 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
     auto pos = fix.getMonomerPos(0);
     fix.setNucleicAcidTool(NucleicAcidTool::P);
     fix.mouseClick(pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{P}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
-    fix.mouseClick(pos);
-    fix.verifyHELM("PEPTIDE1{A}|RNA1{P}$PEPTIDE1,RNA1,1:pair-1:pair$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
 }
 
 /**
@@ -80,50 +77,32 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer_different_monomer_type)
 BOOST_AUTO_TEST_CASE(test_click_attachment_point)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
     auto monomer_pos = fix.getMonomerPos(0);
 
     // click on the N terminus attachment point
-    fix.setAminoAcidTool(AminoAcidTool::CYS);
+    fix.setAminoAcidTool(AminoAcidTool::ALA);
     // hover over the monomer to trigger AP label creation
     fix.mouseMove(monomer_pos);
     auto n_ap_pos = fix.getAttachmentPointPos(0, "N");
     fix.mouseClick(n_ap_pos);
-    fix.verifyHELM("PEPTIDE1{C.A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A.C}$$$$V2.0");
 
     // click on the C terminus attachment point
     fix.setAminoAcidTool(AminoAcidTool::PHE);
     fix.mouseMove(monomer_pos);
     auto c_ap_pos = fix.getAttachmentPointPos(0, "C");
     fix.mouseClick(c_ap_pos);
-    fix.verifyHELM("PEPTIDE1{C.A.F}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{A.C.F}$$$$V2.0");
 
     // click on the side chain attachment point
     fix.setAminoAcidTool(AminoAcidTool::TRP);
     fix.mouseMove(monomer_pos);
-    auto x_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseClick(x_ap_pos);
+    // this will be added as a hydrogen bond since TRP can't form disulfides
     fix.verifyHELM(
-        "PEPTIDE1{C.A.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:pair-1:pair$$$V2.0");
-}
-
-/**
- * Confirm that clicking on an ALA H-bond attachment point with a CYS tool
- * forms a hydrogen bond, not a disulfide
- */
-BOOST_AUTO_TEST_CASE(test_click_ala_pair_with_cys)
-{
-    MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
-    fix.setAminoAcidTool(AminoAcidTool::CYS);
-    auto monomer_pos = fix.getMonomerPos(0);
-    // hover over the monomer to trigger AP label creation
-
-    fix.mouseMove(monomer_pos);
-    auto pair_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
-    fix.mouseClick(pair_ap_pos);
-    fix.verifyHELM(
-        "PEPTIDE1{A}|PEPTIDE2{C}$PEPTIDE1,PEPTIDE2,1:pair-1:pair$$$V2.0");
+        "PEPTIDE1{A.C.F}|PEPTIDE2{W}$PEPTIDE1,PEPTIDE2,2:pair-1:pair$$$V2.0");
 }
 
 /**

--- a/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
+++ b/test/schrodinger/sketcher/tool/test_draw_monomeric_connection_scene_tool_integration_tests.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_click_existing_monomer)
 BOOST_AUTO_TEST_CASE(test_click_attachment_point)
 {
     MonomerToolTestFixture fix;
-    fix.importMolText("PEPTIDE1{A}$$$$V2.0");
+    fix.importMolText("PEPTIDE1{C}$$$$V2.0");
     auto monomer_pos = fix.getMonomerPos(0);
     fix.setMonomericConnectionTool(
         MonomericConnectionTool::COVALENT_OR_DISULFIDE);
@@ -61,19 +61,19 @@ BOOST_AUTO_TEST_CASE(test_click_attachment_point)
     fix.mouseMove(monomer_pos);
     auto n_ap_pos = fix.getAttachmentPointPos(0, "N");
     fix.mouseClick(n_ap_pos);
-    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
 
     // click on the C terminus attachment point
     fix.mouseMove(monomer_pos);
     auto c_ap_pos = fix.getAttachmentPointPos(0, "C");
     fix.mouseClick(c_ap_pos);
-    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
 
     // click on the side chain attachment point
     fix.mouseMove(monomer_pos);
-    auto x_ap_pos = fix.getAttachmentPointPos(0, "H-bond");
+    auto x_ap_pos = fix.getAttachmentPointPos(0, "S");
     fix.mouseClick(x_ap_pos);
-    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
+    fix.verifyHELM("PEPTIDE1{C}$$$$V2.0");
 }
 
 /**
@@ -128,18 +128,6 @@ BOOST_AUTO_TEST_CASE(test_drag_ap_to_empty)
     // Drag from C attachment point to empty space
     start_pos = fix.getAttachmentPointPos(0, "C");
     end_pos = start_pos + QPointF(100, 100);
-    fix.mouseDrag(start_pos, end_pos);
-
-    fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");
-
-    // hover over the first monomer so that its attachment point graphics items
-    // are created again
-    fix.mouseMove(end_pos);
-    fix.mouseMove(ala_pos);
-
-    // Drag from pair attachment point to empty space
-    start_pos = fix.getAttachmentPointPos(0, "H-bond");
-    end_pos = start_pos + QPointF(-50, 100);
     fix.mouseDrag(start_pos, end_pos);
 
     fix.verifyHELM("PEPTIDE1{A}$$$$V2.0");


### PR DESCRIPTION
- Linked Case: SKETCH-2850

### Description

This is a quick change to remove the H-bond attachment point from non-cysteine peptides.  Users can still form hydrogen bonds to those monomers using the hydrogen bond tool, but the attachment point will no longer be visible when using the covalent/disulfide bond tool.

### Testing Done

Updated existing unit tests.  Tested manually in the Windows desktop app.
