### PR TITLE
Fixing uncommon intermittent memtest failure

### DIFF
--- a/test/valgrind_Qt_runner_suppressions.Linux-x86_64
+++ b/test/valgrind_Qt_runner_suppressions.Linux-x86_64
@@ -564,3 +564,18 @@
    ...
    fun:*QApplicationRequiredFixture*
 }
+{
+   Qt raster paint thread pool TLS - false positive
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.34
+   fun:_ZN7QThread5startENS_8PriorityE
+   fun:_ZN18QThreadPoolPrivate11startThreadEP9QRunnable
+   fun:_ZN11QThreadPool5startEP9QRunnablei
+   fun:_ZL19blend_color_genericiPK11QT_FT_Span_Pv
+}


### PR DESCRIPTION
### Description

On a recent PR (#418), I got a memtest failure that seemed to have nothing to do with the code that I changed.  Codex confirmed that the failure was a false positive stemming from QGraphicsScene's sometimes multi-threaded painting behavior.  Re-running the memtests allowed them to pass so I could push the PR, but I figured I'd add a suppression so no one else runs into this.

### Testing Done

This PR will run a memtest.
