### PR TITLE
SKETCH-2643: linking the Sketcher executable against RDKit::Depictor to fix local build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,8 +346,12 @@ if(EMSCRIPTEN)
 endif()
 target_link_libraries(
   ${APP_TARGET}
-  PRIVATE Boost::boost Boost::filesystem Qt6::Widgets RDKit::Depictor
-          ${RDKIT_EXTENSIONS_TARGET} ${SKETCHER_TARGET}
+  PRIVATE Boost::boost
+          Boost::filesystem
+          Qt6::Widgets
+          RDKit::Depictor
+          ${RDKIT_EXTENSIONS_TARGET}
+          ${SKETCHER_TARGET}
           ${EXTRA_SKETCHER_APP_LINK_FLAGS})
 
 # Utility: smiles_to_helm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ if(EMSCRIPTEN)
 endif()
 target_link_libraries(
   ${APP_TARGET}
-  PRIVATE Boost::boost Boost::filesystem Qt6::Widgets
+  PRIVATE Boost::boost Boost::filesystem Qt6::Widgets RDKit::Depictor
           ${RDKIT_EXTENSIONS_TARGET} ${SKETCHER_TARGET}
           ${EXTRA_SKETCHER_APP_LINK_FLAGS})
 


### PR DESCRIPTION
- Linked Case: SKETCH-2643

### Description

When I run a local $SCHRODINGER build of Sketcher, I get an error complaining about:
```
LNK2019: unresolved external symbol "__declspec(dllimport) double RDDepict::BOND_LEN" 
```

The issue is that playwright_test_bridge.cpp causes the Sketcher executable (i.e. CMake's `APP_TARGET`) to access RDKit's `BUILD_LEN` directly.  Previously, only the Sketcher library (i.e. CMake's `SKETCHER_TARGET`) accessed `BUILD_LEN`.  This PR just links `APP_TARGET` against the RDKit target that defines `BUILD_LEN`, which fixes the issue.

### Testing Done

Local builds now succeed.
