### PR TITLE
SKETCH-2643: Resolve widgets on foreground Qt surfaces

### DIFF
--- a/src/app/playwright_test_bridge.cpp
+++ b/src/app/playwright_test_bridge.cpp
@@ -138,11 +138,43 @@ QString without_mnemonic(QString text)
 }
 
 /**
- * Find a visible child widget by objectName. Several widgets may share a name,
- * so this returns the first visible one, or nullptr if none is visible.
+ * Find the visible widget a user can currently reach by objectName.
+ *
+ * Dialogs and QWidgetActions embedded in menus can be separate top-level Qt
+ * surfaces rather than children of SketcherWidget. Prefer the active popup or
+ * modal, then other visible top-level surfaces, before the background sketcher
+ * tree so a same-named background control cannot hide the foreground one.
  */
 QWidget* find_visible_widget(SketcherWidget& sketcher, const QString& name)
 {
+    const auto find_visible_match = [&name](QWidget* root) -> QWidget* {
+        if (root == nullptr || !root->isVisible()) {
+            return nullptr;
+        }
+        if (root->objectName() == name) {
+            return root;
+        }
+        for (auto* child : root->findChildren<QWidget*>(name)) {
+            if (child->isVisible()) {
+                return child;
+            }
+        }
+        return nullptr;
+    };
+    if (auto* match = find_visible_match(QApplication::activePopupWidget())) {
+        return match;
+    }
+    if (auto* match = find_visible_match(QApplication::activeModalWidget())) {
+        return match;
+    }
+    for (auto* top_level : QApplication::topLevelWidgets()) {
+        if (top_level == &sketcher) {
+            continue;
+        }
+        if (auto* match = find_visible_match(top_level)) {
+            return match;
+        }
+    }
     for (auto* widget : sketcher.findChildren<QWidget*>(name)) {
         if (widget->isVisible()) {
             return widget;
@@ -278,6 +310,7 @@ std::string widget_rect(SketcherWidget& sketcher, const std::string& name,
     if (!visible_only) {
         result["visible"] = widget->isVisible();
     }
+    result["styleSheet"] = widget->styleSheet();
     // A label the application painted is chrome, so it is normalized the way
     // the user reads it; a value the user typed or chose is reported verbatim,
     // since a test that sets a field and reads it back has to see exactly what
@@ -462,7 +495,9 @@ std::string menu_rect(SketcherWidget& sketcher, const std::string& value)
  * contents of a line edit or spin box. Text the application painted is reported
  * the way it appears on screen, with any mnemonic ampersand and surrounding
  * whitespace removed, while a value the user typed or chose is reported
- * verbatim. A button additionally reports "checked" and "toolTip".
+ * verbatim. Every widget reports its Qt "styleSheet" so a test can verify a
+ * user-visible state conveyed by styling; a button additionally reports
+ * "checked" and "toolTip".
  *
  * A "menu:" selector only resolves while the menu is on screen, so open the
  * menu first. It does not reach a QToolButton's menu, which cannot be open and

--- a/test/wasm/e2e/e2e_helpers.js
+++ b/test/wasm/e2e/e2e_helpers.js
@@ -426,15 +426,32 @@ export async function clickPopupTool(page, name) {
   if (!owner) {
     throw new Error(`"${name}" is not visible and is not inside a popup`);
   }
+  // When the owner is embedded in a cascading QMenu, Qt does not create that
+  // submenu until its hover delay expires. Waiting before resolving the owner
+  // prevents a same-named sidebar button from winning the lookup meanwhile.
+  await page.waitForTimeout(500);
   const rect = await waitForClickable(page, `widget:${owner}`);
   const x = rect.x + rect.width / 2;
   const y = rect.y + rect.height / 2;
   await showMouseMarker(page, x, y);
   await page.mouse.move(x, y, { steps: 4 });
   await page.mouse.down();
-  await page.waitForTimeout(POPUP_HOLD_MS);
-  await page.mouse.up();
-  await click(page, `widget:${name}`);
+  try {
+    await page.waitForTimeout(POPUP_HOLD_MS);
+    const target = await waitForClickable(page, `widget:${name}`);
+    const targetX = target.x + target.width / 2;
+    const targetY = target.y + target.height / 2;
+    await showMouseMarker(page, targetX, targetY);
+    // A ToolButtonWithPopup closes its press-and-hold popup if the original
+    // press is released before the target is activated. Keep that press held
+    // while clicking the desired tool, matching a person's press-drag-click
+    // sequence and the interaction Squish performs.
+    await page.mouse.move(targetX, targetY, { steps: 4 });
+    await page.mouse.down();
+    await page.mouse.up();
+  } finally {
+    await page.mouse.up();
+  }
 }
 
 /**

--- a/test/wasm/e2e/playwright_bridge_top_level.test.js
+++ b/test/wasm/e2e/playwright_bridge_top_level.test.js
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import {
+  activateAction,
+  clickPopupTool,
+  getExportedSmiles,
+  loadStructure,
+  openContextMenu,
+  selectAll,
+  waitForSketcherReady,
+  widgetState,
+} from './e2e_helpers.js';
+
+const SOURCE = 'NC(N)=NC(=O)CC1=C(Cl)C=CC=C1Cl';
+
+test.describe('Playwright bridge top-level Qt surfaces', () => {
+  test('reports text and style from the foreground Paste in Text dialog', async ({ page }) => {
+    await waitForSketcherReady(page);
+    await loadStructure(page, SOURCE);
+    await activateAction(page, 'Paste in Text...');
+
+    const status = await widgetState(page, 'status_lbl');
+    expect(status.text).toBe('Specified structure will <b>replace</b> Sketcher content');
+    expect(status.styleSheet).toBe('color : #c87c00');
+  });
+
+  test('clicks a popup tool embedded in a context menu', async ({ page }) => {
+    await waitForSketcherReady(page);
+    await loadStructure(page, SOURCE);
+    await selectAll(page);
+    await openContextMenu(page, 'atom:0', 'Modify Atoms', 'Set Element');
+
+    await expect(page.evaluate(() => Module._sketcher_get_popup_owner('pd_btn'))).resolves.toBe(
+      'periodic_table_btn',
+    );
+    await clickPopupTool(page, 'pd_btn');
+    expect(await getExportedSmiles(page)).toContain('[Pd]');
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve visible widgets on the foreground Qt surface first: active popup,
  active modal, then other visible top-level widgets before the background
  Sketcher widget tree.
- Include a widget's Qt style sheet in generic widget-state results so tests can
  inspect user-visible validation styling.
- Preserve the press-and-hold mouse gesture while activating a tool inside a
  popup, matching the interaction a user performs.
- Add focused Playwright contracts for the Paste in Text dialog and a periodic
  table embedded in a context menu.

## Why

PR #413 provides the generic selector-to-geometry bridge needed by the
Playwright tests. Some dialogs and QWidgetAction contents are separate
top-level Qt surfaces rather than children of SketcherWidget. A same-named
background widget could therefore be resolved instead of the foreground
control, or the foreground control could be missed entirely.

This is a narrow follow-up to make those foreground interactions work through
the same generic bridge. It does not add specialized bridge functions or CMake
changes.

## Validation

- Focused bridge contracts: 2 passed
- Stacked validation with the converted suite: all 51 suite tests passed
- JavaScript syntax and git diff checks passed

This bridge follow-up is intended to land before the larger tests-only change,
so that the latter can remain test and test-configuration code.
