### PR TITLE
expand the number of cases tackled with snaking layouts

### DIFF
--- a/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
+++ b/src/schrodinger/rdkit_extensions/helm/monomer_coordgen.cpp
@@ -544,6 +544,74 @@ struct TurnConstraint {
 };
 
 /**
+ * Computes a turn centered between the monomers connected by a custom bond.
+ * The turn size is chosen from the number of intervening monomers so that the
+ * two connected monomers occupy corresponding positions on adjacent strands.
+ */
+static TurnInfo compute_centered_turn(const TurnConstraint& constraint)
+{
+    const auto distance = constraint.max_pos - constraint.min_pos;
+
+    unsigned int turn_size;
+    if (distance < 4) {
+        turn_size = 0; // An instant turn is sufficient for a short interval.
+    } else if (distance % 2 == 1) {
+        turn_size = 2; // Two turn monomers balance an odd-length interval.
+    } else {
+        turn_size = 1; // One turn monomer balances an even-length interval.
+    }
+
+    const auto turn_pos =
+        constraint.min_pos + 1 +
+        (constraint.max_pos - turn_size - constraint.min_pos) / 2;
+    return {turn_pos, turn_size};
+}
+
+/**
+ * Returns true when each custom bond can be closed around a different turn.
+ *
+ * A custom bond whose endpoints contain exactly one turn connects adjacent
+ * strands. Requiring this for every bond allows interlocking intervals to use
+ * consecutive pairs of strands without crossing. We also require at least one
+ * monomer between adjacent turns so that each intermediate strand is non-empty.
+ *
+ * The constraints must be ordered by their first monomer, as returned by
+ * extract_custom_bonds().
+ */
+static bool
+can_use_independent_turns(const std::vector<TurnConstraint>& constraints)
+{
+    std::vector<TurnInfo> turns;
+    std::transform(constraints.begin(), constraints.end(),
+                   std::back_inserter(turns), compute_centered_turn);
+
+    // lay_out_chain_with_turns() requires ordered, non-overlapping turns and a
+    // non-empty chain segment between each pair.
+    for (size_t idx = 1; idx < turns.size(); ++idx) {
+        const auto& previous = turns[idx - 1];
+        if (previous.position + previous.size >= turns[idx].position) {
+            return false;
+        }
+    }
+
+    // If a bond interval contains zero turns, its endpoints stay on the same
+    // strand. If it contains multiple turns, they end up more than one strand
+    // apart. Neither case can be closed by this layout without a crossing or a
+    // stretched bond.
+    for (const auto& constraint : constraints) {
+        const auto num_turns_in_constraint =
+            std::count_if(turns.begin(), turns.end(), [&](const auto& turn) {
+                return turn.position > constraint.min_pos &&
+                       turn.position < constraint.max_pos;
+            });
+        if (num_turns_in_constraint != 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Extracts the CUSTOM_BONDs from `polymer` and returns them as a list of
  * CustomBondInfo, sorted by starting position.
  */
@@ -701,8 +769,19 @@ compute_turn_positions_for_chain(const RDKit::ROMol& polymer)
         constraints.push_back({bond.monomer_i, bond.monomer_j});
     }
 
-    // If the regions "pinched" by two bonds are one inside the other (i1 < i2 <
-    // j2 < j1), they  they share a turn between i2 and j2
+    // Interlocking custom bonds do not necessarily cross. If each bond can be
+    // assigned its own turn, the bonds connect consecutive pairs of strands.
+    // For example, bonds 0-6 and 5-11 use separate turns with monomers 5 and 6
+    // together on the middle strand.
+    if (can_use_independent_turns(constraints)) {
+        return constraints;
+    }
+
+    // The remaining supported arrangement has nested bond intervals (i1 < i2
+    // < j2 < j1). Nested bonds connect the same pair of strands and therefore
+    // share a turn in the intersection of their constraints. Any other
+    // arrangement that reached this point cannot use either independent or
+    // shared centered turns.
     for (size_t idx1 = 0; idx1 < custom_bonds.size(); ++idx1) {
         for (size_t idx2 = idx1 + 1; idx2 < custom_bonds.size(); ++idx2) {
             auto& bond1 = custom_bonds[idx1];
@@ -713,13 +792,12 @@ compute_turn_positions_for_chain(const RDKit::ROMol& polymer)
                 bond2.monomer_i < bond2.monomer_j &&
                 bond2.monomer_j < bond1.monomer_j) {
 
-                //  bond2 is completely contained within bond1 - they will
-                //  connect the same pair of consecutive rows The turn must be
-                //  between i2 and j1
+                // bond2 is completely contained within bond1, so both bonds
+                // connect the same pair of consecutive strands.
                 constraints.push_back({bond2.monomer_i, bond2.monomer_j});
             } else {
-                // bond regions overlap. This means that the two bonds would
-                // cross, and the layout is not possible
+                // The available centered turns cannot place these bonds on
+                // adjacent strands without a crossing or stretched bond.
                 return {};
             }
         }
@@ -1342,24 +1420,7 @@ static bool maybe_lay_out_cyclic_polymer_as_snaking_chain(
     }
     std::vector<TurnInfo> turn_positions;
     for (const auto& turn : turns) {
-        // Calculate distance from the constraint range
-        unsigned int distance = turn.max_pos - turn.min_pos;
-
-        // Determine turn size based on distance, so that the CUSTOM_BOND is
-        // laid out vertically
-        unsigned int turn_size;
-        if (distance < 4) {
-            turn_size = 0; // Very small distance: instant turn
-        } else if (distance % 2 == 1) {
-            turn_size = 2; // Odd distance
-        } else {
-            turn_size = 1; // Even distance
-        }
-
-        unsigned int turn_pos =
-            (turn.min_pos + 1 + (turn.max_pos - turn_size - turn.min_pos) / 2);
-
-        turn_positions.push_back({turn_pos, turn_size});
+        turn_positions.push_back(compute_centered_turn(turn));
     }
 
     // Extract custom bonds to identify protected regions

--- a/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
+++ b/test/schrodinger/rdkit_extensions/test_monomer_coordgen.cpp
@@ -244,6 +244,23 @@ BOOST_DATA_TEST_CASE(
           {0.75, 2.308263},
           {1.963525, 1.426585}}},
 
+        // Interlocking disulfides can use two turns: C1 is on the top strand,
+        // C6-C7 are together on the middle strand, and C12 is on the bottom.
+        {"PEPTIDE1{C.K.F.K.L.C.C.T.Y.A.G.C}$PEPTIDE1,PEPTIDE1,1:R3-7:R3|"
+         "PEPTIDE1,PEPTIDE1,6:R3-12:R3$$$",
+         {{0, 0},
+          {1.5, 0},
+          {3, 0},
+          {3.75, -1.299038},
+          {3, -2.598076},
+          {1.5, -2.598076},
+          {0, -2.598076},
+          {-1.5, -2.598076},
+          {-2.25, -3.897114},
+          {-1.5, -5.196152},
+          {0, -5.196152},
+          {1.5, -5.196152}}},
+
         {"PEPTIDE1{G.C.C.S.L.P.R.C.A.L.N.C}$PEPTIDE1,PEPTIDE1,2:R3-8:R3|"
          "PEPTIDE1,PEPTIDE1,3:R3-12:R3$$$",
          {{0, 0},


### PR DESCRIPTION
This was mainly CODEX, I reviewed the code and congratulated it for a job well done

- Linked Case: CRDGEN-423

### Description

snaking layouts used to exclude custom bonds that connected interlocking regions (like 1-7 and 6-12). Now we allow this if they fall in separate strands, so a number of cases that would fall back on coordgen no longer do. Here's the structure of the case, in all its glory

<img width="282" height="294" alt="Screenshot 2026-09-12 at 17 19 04" src="https://github.com/user-attachments/assets/c196584d-5f82-4c81-82b5-af95a80e2fa0" />


### Testing Done

added a regression test.
regenerated the full table and hand-checked that no weirdness is happening